### PR TITLE
chore(infra): CI 워크플로우에 main PR 트리거 추가

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -2,7 +2,7 @@ name: Backend CI - ppiyaki
 
 on:
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "develop", "main" ]
     types: [ opened, synchronize, reopened ]
     paths:
       - '**/*.java'


### PR DESCRIPTION
## AS-IS
- `backend-ci.yml`이 `pull_request → develop`에서만 동작.
- `develop → main` 릴리즈 머지 PR에서는 게이트(checkstyle/spotless/test/bootJar)가 다시 실행되지 않음.

## TO-BE
- `on.pull_request.branches`에 `main` 추가.
- 릴리즈 PR에서도 동일 게이트가 재실행되어 회귀를 차단.

## 관련 이슈
- closes #4

## 리뷰어 참고 포인트
- `.github/workflows/`는 보호 영역. 변경은 1줄(`branches: [ "develop", "main" ]`)뿐.
- 트리거 경로(`**/*.java`, `**/build.gradle*`)는 그대로. 문서/설정만 변경한 PR은 skip 유지(이슈 #5 결정).

## 라벨 부여 확인
- [x] `type:chore`
- [x] `scope:infra`
- [x] `ai-generated`
- [x] `needs-human-review` (`.github/workflows/` 보호 영역 변경)

---

## AI 작업 여부
- [x] AI 보조/생성 사용 (Claude Opus 4.6)

## 품질 게이트 체크
- [x] yml 1줄 변경, 문법 영향 없음
- [x] 회귀 가능 구간: develop PR 동작은 동일, main PR에 신규 트리거만 추가
- [x] 롤백: 1줄 revert

## 보안/민감정보 체크
- [x] 시크릿 변경 없음

## AI 작업 기록
- 사용한 프롬프트/지시 요약: "CI 워크플로우에 main PR 트리거 추가" (이슈 #4)
- AI가 직접 수정한 파일: `.github/workflows/backend-ci.yml`
- 사람이 수동 검증할 항목: main PR이 실제로 트리거되는지 머지 후 다음 릴리즈 PR에서 확인