### PR TITLE
test(user): 카카오 로그인 E2E 테스트 및 인프라 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'io.rest-assured:rest-assured'
+    testImplementation 'org.wiremock:wiremock-standalone:3.13.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-security'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/docs/features/kakao-login.md
+++ b/docs/features/kakao-login.md
@@ -9,6 +9,9 @@ related_prs: []
 last_reviewed: 2026-04-09
 ---
 
+> **프론트엔드 팀 전달 사항은 §5-4 참조**
+---
+
 # 카카오 로그인
 
 ## 1) 개요 (What / Why)
@@ -18,9 +21,25 @@ last_reviewed: 2026-04-09
 - 이 기능이 없으면 Medicine/Prescription 등 소유자 기반 기능이 실사용자 흐름으로 검증되지 않는다.
 
 ## 2) 사용자 시나리오
-1. **신규 보호자 가입**: 사용자가 앱 첫 실행 시 "카카오로 시작하기"를 누르면, 카카오 인증 후 우리 서버가 JWT를 발급하고 `users` + `oauth_identities`를 생성한다.
-2. **기존 사용자 재로그인**: 기존 카카오 계정으로 다시 로그인 시, `oauth_identities`에서 매칭되는 user를 찾아 JWT만 재발급한다.
-3. **로컬 계정이 있는 사용자의 카카오 연결(선택)**: 이번 범위에서는 **제외**. 별도 feature로 분리.
+
+### SC-1: 신규 사용자 카카오 가입 + 온보딩
+1. 사용자가 앱에서 "카카오로 시작하기"를 탭한다.
+2. 카카오 SDK가 인가코드를 발급한다.
+3. 앱이 인가코드를 백엔드 `POST /api/v1/auth/kakao`에 전달한다.
+4. 백엔드가 카카오 서버와 토큰 교환 → 사용자 정보 조회 → 신규 유저 자동 생성(`users` + `oauth_identities`) → JWT 발급.
+5. 응답에 `isOnboarded=false` 포함 → 앱이 온보딩 화면(닉네임/역할 입력)으로 이동.
+6. 온보딩 완료 후 메인 화면 진입. (온보딩 API 자체는 별도 feature)
+
+### SC-2: 기존 사용자 카카오 로그인
+1. 사용자가 "카카오로 시작하기" 탭 → 인가코드 → 백엔드 전달.
+2. 백엔드가 기존 `oauth_identities` 매칭 → JWT 발급.
+3. `isOnboarded=true` → 앱이 메인 화면으로 이동.
+
+### SC-3: 토큰 만료 시 갱신
+1. access token 만료 → 앱이 refresh token으로 `POST /api/v1/auth/refresh` 호출.
+2. 새 access token + refresh token 발급(rotation).
+
+> 로컬 계정이 있는 사용자의 카카오 연결(선택)은 이번 범위에서 **제외**. 별도 feature로 분리.
 
 ## 3) 요구사항
 
@@ -31,7 +50,8 @@ last_reviewed: 2026-04-09
 - [ ] `oauth_identities`에 `(provider=KAKAO, provider_user_id)` 조회
   - 존재: 해당 `user_id`로 JWT 발급
   - 미존재: 신규 `users` 생성(nickname은 카카오 닉네임, 기타는 null) 후 `oauth_identities` 생성
-- [ ] JWT 응답 형식: `{ accessToken, refreshToken, userId, role }`
+- [ ] JWT 응답 형식: `{ accessToken, refreshToken, isOnboarded }`
+- [ ] 온보딩 미완료 판별: `users.role IS NULL` → `isOnboarded=false`
 - [ ] Refresh 엔드포인트로 access token 재발급
 - [ ] 로그아웃 엔드포인트(서버에서 refresh 토큰 무효화)
 
@@ -67,7 +87,7 @@ last_reviewed: 2026-04-09
 ### 5-2) API 엔드포인트
 | Method | Path | 설명 | 인증 | Req | Res |
 |---|---|---|---|---|---|
-| POST | /api/v1/auth/kakao | Authorization Code → 서버 JWT | 없음 | `{ code, redirectUri }` | `{ accessToken, refreshToken, userId, role }` |
+| POST | /api/v1/auth/kakao | Authorization Code → 서버 JWT | 없음 | `{ code, redirectUri }` | `{ accessToken, refreshToken, isOnboarded }` |
 | POST | /api/v1/auth/refresh | Refresh token 재발급 | 없음 | `{ refreshToken }` | `{ accessToken, refreshToken }` |
 | POST | /api/v1/auth/logout | 로그아웃 (refresh 무효화) | 필수 | `{ refreshToken }` | 204 |
 | GET | /api/v1/users/me | 현재 로그인 유저 정보 | 필수 | - | UserResponse |
@@ -80,30 +100,62 @@ last_reviewed: 2026-04-09
 - `infra/auth/KakaoOAuthClient` 어댑터 분리
 - 설정: `application-local.yml`/`application.yml` 또는 환경변수로 `kakao.client-id`, `kakao.client-secret`, `kakao.redirect-uri`
 
-### 5-4) 데이터 흐름
+### 5-4) 데이터 흐름 (프론트엔드 팀 공유용)
+
 ```
-Client
-  │  1) 카카오 로그인 SDK → authorization code
-  ▼
-Server /api/v1/auth/kakao (code)
-  │  2) POST kauth.kakao.com/oauth/token
-  ▼
-Kakao Auth
-  │  3) access_token
-  ▼
-Server
-  │  4) GET kapi.kakao.com/v2/user/me
-  ▼
-Kakao API
-  │  5) { id, properties.nickname, ... }
-  ▼
-Server
-  │  6) oauth_identities 조회 → user 매칭 or 생성
-  │  7) JWT(access+refresh) 발급
-  ▼
-Client
-  │  { accessToken, refreshToken, userId, role }
+┌──────┐       ┌──────────┐       ┌──────────┐       ┌──────────┐
+│  App │       │ 카카오SDK  │       │ Backend  │       │카카오 서버│
+└──┬───┘       └────┬─────┘       └────┬─────┘       └────┬─────┘
+   │  1. 로그인 탭   │                  │                   │
+   │───────────────>│                  │                   │
+   │                │  2. 카카오 인증   │                   │
+   │                │─────────────────────────────────────>│
+   │                │  3. 인가코드 반환  │                   │
+   │                │<─────────────────────────────────────│
+   │ 4. 인가코드     │                  │                   │
+   │<───────────────│                  │                   │
+   │                                   │                   │
+   │  5. POST /api/v1/auth/kakao       │                   │
+   │     { code, redirectUri }         │                   │
+   │──────────────────────────────────>│                   │
+   │                                   │ 6. 토큰 교환       │
+   │                                   │  POST /oauth/token│
+   │                                   │─────────────────>│
+   │                                   │  access_token     │
+   │                                   │<─────────────────│
+   │                                   │ 7. 사용자 정보     │
+   │                                   │  GET /v2/user/me  │
+   │                                   │─────────────────>│
+   │                                   │  kakao_user_id    │
+   │                                   │<─────────────────│
+   │                                   │                   │
+   │                                   │ 8. DB 조회/생성    │
+   │                                   │  oauth_identities │
+   │                                   │  → User 매칭/생성  │
+   │                                   │                   │
+   │                                   │ 9. JWT 발급       │
+   │                                   │  access + refresh │
+   │                                   │                   │
+   │  10. 응답                          │                   │
+   │  { accessToken, refreshToken,     │                   │
+   │    isOnboarded }                  │                   │
+   │<──────────────────────────────────│                   │
+   │                                   │                   │
+   │  [isOnboarded=false]              │                   │
+   │  → 온보딩 화면 (닉네임/역할 입력)  │                   │
+   │  [isOnboarded=true]               │                   │
+   │  → 메인 화면                      │                   │
 ```
+
+#### 프론트엔드 요약
+| 항목 | 내용 |
+|---|---|
+| 앱이 할 일 | 카카오 SDK로 **인가코드(authorization code)** 만 받아서 백엔드에 전달. access token 교환은 백엔드가 처리. |
+| 로그인 요청 | `POST /api/v1/auth/kakao` body: `{ "code": "인가코드", "redirectUri": "카카오에 등록한 redirect URI" }` |
+| 응답 분기 | `isOnboarded=false` → 온보딩 화면, `isOnboarded=true` → 메인 화면 |
+| 인증 헤더 | 이후 API 호출 시 `Authorization: Bearer {accessToken}` |
+| 토큰 갱신 | 401 응답 시 `POST /api/v1/auth/refresh` body: `{ "refreshToken": "..." }` → 새 토큰 쌍 수신 |
+| 로그아웃 | `POST /api/v1/auth/logout` (인증 필수) body: `{ "refreshToken": "..." }` → 204 |
 
 ### 5-5) DB 마이그레이션
 - `oauth_identities` 테이블은 #19에서 이미 생성됨. 추가 마이그레이션 불필요.
@@ -124,12 +176,19 @@ Client
 
 | # | 질문 | 선택지 | 담당/기한 |
 |---|---|---|---|
-| Q1 | refresh token 저장 위치 | (a) DB 테이블 `refresh_tokens` (b) Redis | @goohong / 구현 전 |
-| Q2 | JWT 시크릿 관리 | (a) GitHub Secrets + env (b) NCP 시크릿 매니저 | @goohong / 구현 전 |
-| Q3 | 카카오 신규 가입 시 default role | (a) CAREGIVER 고정 (b) 미결정(null) 후 온보딩에서 선택 | @goohong (프론트 협의) |
-| Q4 | logout 시 access token 블랙리스트 | (a) 없음(refresh만 무효화) (b) 단기 블랙리스트 | @goohong / 구현 전 |
+| ~~Q1~~ | ~~refresh token 저장 위치~~ | ~~(a) DB 테이블~~ | **결정됨** → §9 참조 |
+| ~~Q2~~ | ~~JWT 시크릿 관리~~ | ~~(a) GitHub Secrets + env~~ | **결정됨** → §9 참조 |
+| ~~Q3~~ | ~~카카오 신규 가입 시 default role~~ | ~~(b) null 후 온보딩에서 선택~~ | **결정됨** → §9 참조 |
+| ~~Q4~~ | ~~logout 시 access token 블랙리스트~~ | ~~(a) 없음(refresh만 무효화)~~ | **결정됨** → §9 참조 |
 | Q5 | 에러 응답 포맷 | `docs/features/` 다른 spec과 공유할 공통 ErrorCode | 프론트팀 합의 필요 |
 
 ## 9) 결정 로그
 - 2026-04-09: 초안 작성 (status=draft). 카카오 외 IdP, 로컬 계정 연결은 out-of-scope.
 - 2026-04-09: Refresh/Logout 포함 범위 확정. 역할 선택 UI는 온보딩 feature로 분리.
+- 2026-04-09: OAuth 플로우는 **하이브리드** 채택 — 앱이 카카오 SDK로 인가코드 획득, 백엔드가 토큰 교환. 순수 서버 redirect는 모바일 앱에 부적합.
+- 2026-04-09: Q3 결정 — 신규 가입 시 role=NULL. 온보딩에서 닉네임/역할 입력. `users.role IS NULL`로 온보딩 미완료 판별 (`isOnboarded` 응답 필드).
+- 2026-04-09: 기존 `OAuthIdentity`/`OAuthProvider(KAKAO)` 엔티티 재사용 확정.
+- 2026-04-09: 프론트엔드 연동 플로우 다이어그램 추가 (§5-4).
+- 2026-04-09: Q1 결정 — refresh token은 DB 테이블(`refresh_tokens`)에 저장.
+- 2026-04-09: Q2 결정 — JWT 시크릿은 GitHub Secrets + 환경변수로 관리.
+- 2026-04-09: Q4 결정 — logout 시 access token 블랙리스트 없음. refresh만 무효화. access token은 만료(30분)까지 유효.

--- a/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.ppiyaki.common.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+
+    public JwtAuthenticationFilter(final JwtProvider jwtProvider) {
+        this.jwtProvider = Objects.requireNonNull(jwtProvider, "jwtProvider must not be null");
+    }
+
+    @Override
+    protected void doFilterInternal(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final FilterChain filterChain
+    ) throws ServletException, IOException {
+        final String token = extractToken(request);
+
+        if (token != null && jwtProvider.isValid(token)) {
+            final Long userId = jwtProvider.extractUserId(token);
+            final UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId,
+                    null, List.of());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(final HttpServletRequest request) {
+        final String header = request.getHeader(AUTHORIZATION_HEADER);
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ppiyaki/common/auth/JwtProperties.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtProperties.java
@@ -1,0 +1,11 @@
+package com.ppiyaki.common.auth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        long accessTokenExpiry,
+        long refreshTokenExpiry
+) {
+}

--- a/src/main/java/com/ppiyaki/common/auth/JwtProvider.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtProvider.java
@@ -1,0 +1,72 @@
+package com.ppiyaki.common.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Objects;
+import javax.crypto.SecretKey;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpiry;
+    private final long refreshTokenExpiry;
+
+    public JwtProvider(final JwtProperties jwtProperties) {
+        Objects.requireNonNull(jwtProperties, "jwtProperties must not be null");
+        Objects.requireNonNull(jwtProperties.secret(), "jwt secret must not be null");
+        this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpiry = jwtProperties.accessTokenExpiry();
+        this.refreshTokenExpiry = jwtProperties.refreshTokenExpiry();
+    }
+
+    public String createAccessToken(final Long userId) {
+        Objects.requireNonNull(userId, "userId must not be null");
+        return createToken(userId, accessTokenExpiry);
+    }
+
+    public String createRefreshToken(final Long userId) {
+        Objects.requireNonNull(userId, "userId must not be null");
+        return createToken(userId, refreshTokenExpiry);
+    }
+
+    public Long extractUserId(final String token) {
+        Objects.requireNonNull(token, "token must not be null");
+        final Claims claims = parseClaims(token);
+        return claims.get("userId", Long.class);
+    }
+
+    public boolean isValid(final String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (final JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private String createToken(final Long userId, final long expiryMillis) {
+        final Date now = new Date();
+        final Date expiry = new Date(now.getTime() + expiryMillis);
+
+        return Jwts.builder()
+                .claim("userId", userId)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    private Claims parseClaims(final String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/ppiyaki/common/auth/KakaoOAuthClient.java
+++ b/src/main/java/com/ppiyaki/common/auth/KakaoOAuthClient.java
@@ -1,0 +1,71 @@
+package com.ppiyaki.common.auth;
+
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Component
+@EnableConfigurationProperties(KakaoOAuthProperties.class)
+public class KakaoOAuthClient {
+
+    private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final KakaoOAuthProperties properties;
+    private final RestClient restClient;
+
+    public KakaoOAuthClient(final KakaoOAuthProperties properties, final RestClient.Builder restClientBuilder) {
+        this.properties = Objects.requireNonNull(properties, "properties must not be null");
+        this.restClient = restClientBuilder.build();
+    }
+
+    public String fetchAccessToken(final String code, final String redirectUri) {
+        Objects.requireNonNull(code, "code must not be null");
+        Objects.requireNonNull(redirectUri, "redirectUri must not be null");
+
+        final MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", properties.clientId());
+        body.add("client_secret", properties.clientSecret());
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        @SuppressWarnings("unchecked") final Map<String, Object> response = restClient.post()
+                .uri(TOKEN_URL)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .body(Map.class);
+
+        return (String) response.get("access_token");
+    }
+
+    @SuppressWarnings("unchecked")
+    public KakaoUserInfo fetchUserInfo(final String accessToken) {
+        Objects.requireNonNull(accessToken, "accessToken must not be null");
+
+        final Map<String, Object> response = restClient.get()
+                .uri(USER_INFO_URL)
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .body(Map.class);
+
+        final Long kakaoId = ((Number) response.get("id")).longValue();
+        final Map<String, Object> kakaoAccount = (Map<String, Object>) response.get("kakao_account");
+        final Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        final String nickname = (String) profile.get("nickname");
+
+        return new KakaoUserInfo(kakaoId, nickname);
+    }
+
+    public record KakaoUserInfo(
+            Long id,
+            String nickname
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/common/auth/KakaoOAuthClient.java
+++ b/src/main/java/com/ppiyaki/common/auth/KakaoOAuthClient.java
@@ -13,9 +13,6 @@ import org.springframework.web.client.RestClient;
 @EnableConfigurationProperties(KakaoOAuthProperties.class)
 public class KakaoOAuthClient {
 
-    private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
-    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
-
     private final KakaoOAuthProperties properties;
     private final RestClient restClient;
 
@@ -36,7 +33,7 @@ public class KakaoOAuthClient {
         body.add("code", code);
 
         @SuppressWarnings("unchecked") final Map<String, Object> response = restClient.post()
-                .uri(TOKEN_URL)
+                .uri(properties.tokenUri())
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(body)
                 .retrieve()
@@ -50,7 +47,7 @@ public class KakaoOAuthClient {
         Objects.requireNonNull(accessToken, "accessToken must not be null");
 
         final Map<String, Object> response = restClient.get()
-                .uri(USER_INFO_URL)
+                .uri(properties.userInfoUri())
                 .header("Authorization", "Bearer " + accessToken)
                 .retrieve()
                 .body(Map.class);

--- a/src/main/java/com/ppiyaki/common/auth/KakaoOAuthProperties.java
+++ b/src/main/java/com/ppiyaki/common/auth/KakaoOAuthProperties.java
@@ -5,6 +5,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "kakao")
 public record KakaoOAuthProperties(
         String clientId,
-        String clientSecret
+        String clientSecret,
+        String tokenUri,
+        String userInfoUri
 ) {
 }

--- a/src/main/java/com/ppiyaki/common/auth/KakaoOAuthProperties.java
+++ b/src/main/java/com/ppiyaki/common/auth/KakaoOAuthProperties.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.common.auth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kakao")
+public record KakaoOAuthProperties(
+        String clientId,
+        String clientSecret
+) {
+}

--- a/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
+++ b/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
@@ -4,11 +4,13 @@ import java.util.Objects;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -35,6 +37,9 @@ public class SecurityConfig {
                                 "/actuator/health"
                         ).permitAll()
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
+++ b/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
@@ -1,0 +1,42 @@
+package com.ppiyaki.common.auth;
+
+import java.util.Objects;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableConfigurationProperties(JwtProperties.class)
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(final JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = Objects.requireNonNull(
+                jwtAuthenticationFilter, "jwtAuthenticationFilter must not be null");
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(final HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/**",
+                                "/h2-console/**",
+                                "/actuator/health"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/com/ppiyaki/user/RefreshToken.java
+++ b/src/main/java/com/ppiyaki/user/RefreshToken.java
@@ -32,7 +32,7 @@ public class RefreshToken extends BaseTimeEntity {
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
 
-    RefreshToken(
+    public RefreshToken(
             final Long userId,
             final String token,
             final LocalDateTime expiresAt

--- a/src/main/java/com/ppiyaki/user/RefreshToken.java
+++ b/src/main/java/com/ppiyaki/user/RefreshToken.java
@@ -1,0 +1,53 @@
+package com.ppiyaki.user;
+
+import com.ppiyaki.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "refresh_tokens")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "token", nullable = false, unique = true)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    RefreshToken(
+            final Long userId,
+            final String token,
+            final LocalDateTime expiresAt
+    ) {
+        this.userId = Objects.requireNonNull(userId, "userId must not be null");
+        this.token = Objects.requireNonNull(token, "token must not be null");
+        this.expiresAt = Objects.requireNonNull(expiresAt, "expiresAt must not be null");
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public void rotate(final String newToken, final LocalDateTime newExpiresAt) {
+        this.token = Objects.requireNonNull(newToken, "newToken must not be null");
+        this.expiresAt = Objects.requireNonNull(newExpiresAt, "newExpiresAt must not be null");
+    }
+}

--- a/src/main/java/com/ppiyaki/user/controller/AuthController.java
+++ b/src/main/java/com/ppiyaki/user/controller/AuthController.java
@@ -1,17 +1,24 @@
 package com.ppiyaki.user.controller;
 
+import com.ppiyaki.user.User;
 import com.ppiyaki.user.controller.dto.KakaoLoginRequest;
 import com.ppiyaki.user.controller.dto.LoginResponse;
+import com.ppiyaki.user.controller.dto.LogoutRequest;
+import com.ppiyaki.user.controller.dto.RefreshRequest;
+import com.ppiyaki.user.controller.dto.TokenResponse;
+import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.service.AuthService;
 import java.util.Objects;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1")
 public class AuthController {
 
     private final AuthService authService;
@@ -20,9 +27,28 @@ public class AuthController {
         this.authService = Objects.requireNonNull(authService, "authService must not be null");
     }
 
-    @PostMapping("/kakao")
+    @PostMapping("/auth/kakao")
     public ResponseEntity<LoginResponse> loginWithKakao(@RequestBody final KakaoLoginRequest kakaoLoginRequest) {
         final LoginResponse loginResponse = authService.loginWithKakao(kakaoLoginRequest);
         return ResponseEntity.ok(loginResponse);
+    }
+
+    @PostMapping("/auth/refresh")
+    public ResponseEntity<TokenResponse> refresh(@RequestBody final RefreshRequest refreshRequest) {
+        final TokenResponse tokenResponse = authService.refresh(refreshRequest.refreshToken());
+        return ResponseEntity.ok(tokenResponse);
+    }
+
+    @PostMapping("/auth/logout")
+    public ResponseEntity<Void> logout(@RequestBody final LogoutRequest logoutRequest) {
+        authService.logout(logoutRequest.refreshToken());
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/users/me")
+    public ResponseEntity<UserMeResponse> me(@AuthenticationPrincipal final Long userId) {
+        final User user = authService.findUserById(userId);
+        final UserMeResponse userMeResponse = UserMeResponse.from(user);
+        return ResponseEntity.ok(userMeResponse);
     }
 }

--- a/src/main/java/com/ppiyaki/user/controller/AuthController.java
+++ b/src/main/java/com/ppiyaki/user/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.ppiyaki.user.controller;
+
+import com.ppiyaki.user.controller.dto.KakaoLoginRequest;
+import com.ppiyaki.user.controller.dto.LoginResponse;
+import com.ppiyaki.user.service.AuthService;
+import java.util.Objects;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(final AuthService authService) {
+        this.authService = Objects.requireNonNull(authService, "authService must not be null");
+    }
+
+    @PostMapping("/kakao")
+    public ResponseEntity<LoginResponse> loginWithKakao(@RequestBody final KakaoLoginRequest kakaoLoginRequest) {
+        final LoginResponse loginResponse = authService.loginWithKakao(kakaoLoginRequest);
+        return ResponseEntity.ok(loginResponse);
+    }
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/KakaoLoginRequest.java
@@ -1,0 +1,9 @@
+package com.ppiyaki.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoLoginRequest(
+        @NotBlank String code,
+        @NotBlank String redirectUri
+) {
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/LoginResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/LoginResponse.java
@@ -1,0 +1,8 @@
+package com.ppiyaki.user.controller.dto;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken,
+        boolean isOnboarded
+) {
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/LogoutRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/LogoutRequest.java
@@ -1,0 +1,8 @@
+package com.ppiyaki.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequest(
+        @NotBlank String refreshToken
+) {
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/RefreshRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/RefreshRequest.java
@@ -1,0 +1,8 @@
+package com.ppiyaki.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+        @NotBlank String refreshToken
+) {
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/TokenResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/TokenResponse.java
@@ -1,0 +1,7 @@
+package com.ppiyaki.user.controller.dto;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/UserMeResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/UserMeResponse.java
@@ -1,0 +1,17 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.ppiyaki.user.User;
+
+public record UserMeResponse(
+        Long id,
+        String nickname,
+        String role,
+        boolean isOnboarded
+) {
+
+    public static UserMeResponse from(final User user) {
+        final String roleName = user.getRole() != null ? user.getRole().name() : null;
+        final boolean onboarded = user.getRole() != null;
+        return new UserMeResponse(user.getId(), user.getNickname(), roleName, onboarded);
+    }
+}

--- a/src/main/java/com/ppiyaki/user/repository/OAuthIdentityRepository.java
+++ b/src/main/java/com/ppiyaki/user/repository/OAuthIdentityRepository.java
@@ -1,0 +1,11 @@
+package com.ppiyaki.user.repository;
+
+import com.ppiyaki.user.OAuthIdentity;
+import com.ppiyaki.user.OAuthProvider;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OAuthIdentityRepository extends JpaRepository<OAuthIdentity, Long> {
+
+    Optional<OAuthIdentity> findByProviderAndProviderUserId(OAuthProvider provider, String providerUserId);
+}

--- a/src/main/java/com/ppiyaki/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/ppiyaki/user/repository/RefreshTokenRepository.java
@@ -8,5 +8,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByToken(String token);
 
+    Optional<RefreshToken> findByUserId(Long userId);
+
     void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/ppiyaki/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/ppiyaki/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.ppiyaki.user.repository;
+
+import com.ppiyaki.user.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/ppiyaki/user/repository/UserRepository.java
+++ b/src/main/java/com/ppiyaki/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.ppiyaki.user.repository;
+
+import com.ppiyaki.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -1,0 +1,88 @@
+package com.ppiyaki.user.service;
+
+import com.ppiyaki.common.auth.JwtProperties;
+import com.ppiyaki.common.auth.JwtProvider;
+import com.ppiyaki.common.auth.KakaoOAuthClient;
+import com.ppiyaki.common.auth.KakaoOAuthClient.KakaoUserInfo;
+import com.ppiyaki.user.OAuthIdentity;
+import com.ppiyaki.user.OAuthProvider;
+import com.ppiyaki.user.RefreshToken;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.controller.dto.KakaoLoginRequest;
+import com.ppiyaki.user.controller.dto.LoginResponse;
+import com.ppiyaki.user.repository.OAuthIdentityRepository;
+import com.ppiyaki.user.repository.RefreshTokenRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuthService {
+
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final JwtProvider jwtProvider;
+    private final JwtProperties jwtProperties;
+    private final UserRepository userRepository;
+    private final OAuthIdentityRepository oAuthIdentityRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public AuthService(
+            final KakaoOAuthClient kakaoOAuthClient,
+            final JwtProvider jwtProvider,
+            final JwtProperties jwtProperties,
+            final UserRepository userRepository,
+            final OAuthIdentityRepository oAuthIdentityRepository,
+            final RefreshTokenRepository refreshTokenRepository
+    ) {
+        this.kakaoOAuthClient = Objects.requireNonNull(kakaoOAuthClient, "kakaoOAuthClient must not be null");
+        this.jwtProvider = Objects.requireNonNull(jwtProvider, "jwtProvider must not be null");
+        this.jwtProperties = Objects.requireNonNull(jwtProperties, "jwtProperties must not be null");
+        this.userRepository = Objects.requireNonNull(userRepository, "userRepository must not be null");
+        this.oAuthIdentityRepository = Objects.requireNonNull(oAuthIdentityRepository,
+                "oAuthIdentityRepository must not be null");
+        this.refreshTokenRepository = Objects.requireNonNull(refreshTokenRepository,
+                "refreshTokenRepository must not be null");
+    }
+
+    @Transactional
+    public LoginResponse loginWithKakao(final KakaoLoginRequest kakaoLoginRequest) {
+        Objects.requireNonNull(kakaoLoginRequest, "kakaoLoginRequest must not be null");
+
+        final String kakaoAccessToken = kakaoOAuthClient.fetchAccessToken(kakaoLoginRequest.code(), kakaoLoginRequest
+                .redirectUri());
+        final KakaoUserInfo kakaoUserInfo = kakaoOAuthClient.fetchUserInfo(kakaoAccessToken);
+
+        final String providerUserId = String.valueOf(kakaoUserInfo.id());
+        final User user = oAuthIdentityRepository
+                .findByProviderAndProviderUserId(OAuthProvider.KAKAO, providerUserId)
+                .map(identity -> userRepository.findById(identity.getUserId()).orElseThrow())
+                .orElseGet(() -> createNewUser(kakaoUserInfo, providerUserId));
+
+        final String accessToken = jwtProvider.createAccessToken(user.getId());
+        final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
+        saveRefreshToken(user.getId(), refreshTokenValue);
+
+        final boolean isOnboarded = user.getRole() != null;
+
+        return new LoginResponse(accessToken, refreshTokenValue, isOnboarded);
+    }
+
+    private User createNewUser(final KakaoUserInfo kakaoUserInfo, final String providerUserId) {
+        final User user = userRepository.save(
+                new User(null, null, null, kakaoUserInfo.nickname(), null, null, null));
+
+        oAuthIdentityRepository.save(new OAuthIdentity(user.getId(), OAuthProvider.KAKAO, providerUserId));
+
+        return user;
+    }
+
+    private void saveRefreshToken(final Long userId, final String tokenValue) {
+        refreshTokenRepository.deleteByUserId(userId);
+
+        final LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(jwtProperties.refreshTokenExpiry() / 1000);
+        final RefreshToken refreshToken = new RefreshToken(userId, tokenValue, expiresAt);
+        refreshTokenRepository.save(refreshToken);
+    }
+}

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -116,10 +116,11 @@ public class AuthService {
     }
 
     private void saveRefreshToken(final Long userId, final String tokenValue) {
-        refreshTokenRepository.deleteByUserId(userId);
-
         final LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(jwtProperties.refreshTokenExpiry() / 1000);
-        final RefreshToken refreshToken = new RefreshToken(userId, tokenValue, expiresAt);
-        refreshTokenRepository.save(refreshToken);
+
+        refreshTokenRepository.findByUserId(userId)
+                .ifPresentOrElse(
+                        existing -> existing.rotate(tokenValue, expiresAt),
+                        () -> refreshTokenRepository.save(new RefreshToken(userId, tokenValue, expiresAt)));
     }
 }

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -10,6 +10,7 @@ import com.ppiyaki.user.RefreshToken;
 import com.ppiyaki.user.User;
 import com.ppiyaki.user.controller.dto.KakaoLoginRequest;
 import com.ppiyaki.user.controller.dto.LoginResponse;
+import com.ppiyaki.user.controller.dto.TokenResponse;
 import com.ppiyaki.user.repository.OAuthIdentityRepository;
 import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
@@ -76,6 +77,42 @@ public class AuthService {
         oAuthIdentityRepository.save(new OAuthIdentity(user.getId(), OAuthProvider.KAKAO, providerUserId));
 
         return user;
+    }
+
+    @Transactional
+    public TokenResponse refresh(final String refreshTokenValue) {
+        Objects.requireNonNull(refreshTokenValue, "refreshTokenValue must not be null");
+
+        final RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
+
+        if (refreshToken.isExpired()) {
+            refreshTokenRepository.delete(refreshToken);
+            throw new IllegalArgumentException("Refresh token expired");
+        }
+
+        final Long userId = refreshToken.getUserId();
+        final String newAccessToken = jwtProvider.createAccessToken(userId);
+        final String newRefreshTokenValue = jwtProvider.createRefreshToken(userId);
+
+        final LocalDateTime newExpiresAt = LocalDateTime.now().plusSeconds(jwtProperties.refreshTokenExpiry() / 1000);
+        refreshToken.rotate(newRefreshTokenValue, newExpiresAt);
+
+        return new TokenResponse(newAccessToken, newRefreshTokenValue);
+    }
+
+    @Transactional
+    public void logout(final String refreshTokenValue) {
+        Objects.requireNonNull(refreshTokenValue, "refreshTokenValue must not be null");
+        refreshTokenRepository.findByToken(refreshTokenValue)
+                .ifPresent(refreshTokenRepository::delete);
+    }
+
+    @Transactional(readOnly = true)
+    public User findUserById(final Long userId) {
+        Objects.requireNonNull(userId, "userId must not be null");
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
     }
 
     private void saveRefreshToken(final Long userId, final String tokenValue) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,3 +27,7 @@ jwt:
   secret: ${JWT_SECRET:local-dev-secret-key-must-be-at-least-32-bytes-long}
   access-token-expiry: ${JWT_ACCESS_EXPIRY:1800000}
   refresh-token-expiry: ${JWT_REFRESH_EXPIRY:1209600000}
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID:local-kakao-client-id}
+  client-secret: ${KAKAO_CLIENT_SECRET:local-kakao-client-secret}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,5 @@ jwt:
 kakao:
   client-id: ${KAKAO_CLIENT_ID:local-kakao-client-id}
   client-secret: ${KAKAO_CLIENT_SECRET:local-kakao-client-secret}
+  token-uri: ${KAKAO_TOKEN_URI:https://kauth.kakao.com/oauth/token}
+  user-info-uri: ${KAKAO_USER_INFO_URI:https://kapi.kakao.com/v2/user/me}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,8 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
+
+jwt:
+  secret: ${JWT_SECRET:local-dev-secret-key-must-be-at-least-32-bytes-long}
+  access-token-expiry: ${JWT_ACCESS_EXPIRY:1800000}
+  refresh-token-expiry: ${JWT_REFRESH_EXPIRY:1209600000}

--- a/src/test/java/com/ppiyaki/common/auth/JwtProviderTest.java
+++ b/src/test/java/com/ppiyaki/common/auth/JwtProviderTest.java
@@ -1,0 +1,88 @@
+package com.ppiyaki.common.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class JwtProviderTest {
+
+    private static final String TEST_SECRET = "test-secret-key-must-be-at-least-32-bytes-long!!";
+
+    private final JwtProvider jwtProvider = new JwtProvider(
+            new JwtProperties(TEST_SECRET, 1800000L, 1209600000L));
+
+    @Nested
+    @DisplayName("access token 발급")
+    class CreateAccessToken {
+
+        @Test
+        @DisplayName("발급된 토큰에서 userId를 추출할 수 있다")
+        void extractUserId() {
+            // given
+            final Long userId = 1L;
+
+            // when
+            final String token = jwtProvider.createAccessToken(userId);
+
+            // then
+            assertThat(jwtProvider.extractUserId(token)).isEqualTo(userId);
+        }
+
+        @Test
+        @DisplayName("발급된 토큰은 유효하다")
+        void isValid() {
+            // given
+            final String token = jwtProvider.createAccessToken(1L);
+
+            // when & then
+            assertThat(jwtProvider.isValid(token)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 검증")
+    class Validation {
+
+        @Test
+        @DisplayName("잘못된 토큰은 유효하지 않다")
+        void invalidToken() {
+            // given
+            final String invalidToken = "invalid.token.value";
+
+            // when & then
+            assertThat(jwtProvider.isValid(invalidToken)).isFalse();
+        }
+
+        @Test
+        @DisplayName("만료된 토큰은 유효하지 않다")
+        void expiredToken() {
+            // given
+            final JwtProvider shortLivedProvider = new JwtProvider(
+                    new JwtProperties(TEST_SECRET, -1000L, -1000L));
+            final String token = shortLivedProvider.createAccessToken(1L);
+
+            // when & then
+            assertThat(jwtProvider.isValid(token)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("refresh token 발급")
+    class CreateRefreshToken {
+
+        @Test
+        @DisplayName("발급된 refresh 토큰에서 userId를 추출할 수 있다")
+        void extractUserId() {
+            // given
+            final Long userId = 42L;
+
+            // when
+            final String token = jwtProvider.createRefreshToken(userId);
+
+            // then
+            assertThat(jwtProvider.extractUserId(token)).isEqualTo(userId);
+        }
+    }
+}

--- a/src/test/java/com/ppiyaki/user/controller/AuthControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/AuthControllerE2ETest.java
@@ -1,0 +1,219 @@
+package com.ppiyaki.user.controller;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "kakao.client-id=test-client-id",
+        "kakao.client-secret=test-client-secret",
+        "kakao.token-uri=http://localhost:19876/oauth/token",
+        "kakao.user-info-uri=http://localhost:19876/v2/user/me"
+})
+class AuthControllerE2ETest {
+
+    private static final int WIREMOCK_PORT = 19876;
+    private static WireMockServer wireMockServer;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeAll
+    static void startWireMock() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().port(WIREMOCK_PORT));
+        wireMockServer.start();
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        wireMockServer.stop();
+    }
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        wireMockServer.resetAll();
+        stubKakaoTokenEndpoint();
+    }
+
+    @Test
+    @DisplayName("신규 유저 카카오 로그인 시 JWT 발급 및 isOnboarded=false")
+    void kakaoLogin_newUser() {
+        // given
+        stubKakaoUserInfoEndpoint(12345L, "테스트닉네임");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "code": "test-auth-code",
+                            "redirectUri": "http://localhost/callback"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/kakao")
+                .then()
+                .statusCode(200)
+                .body("accessToken", notNullValue())
+                .body("refreshToken", notNullValue())
+                .body("isOnboarded", is(false));
+    }
+
+    @Test
+    @DisplayName("기존 유저 재로그인 시 JWT 재발급")
+    void kakaoLogin_existingUser() {
+        // given - 첫 로그인으로 유저 생성
+        stubKakaoUserInfoEndpoint(67890L, "기존유저");
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "code": "test-auth-code",
+                            "redirectUri": "http://localhost/callback"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/kakao")
+                .then()
+                .statusCode(200);
+
+        // when - 재로그인
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "code": "test-auth-code-2",
+                            "redirectUri": "http://localhost/callback"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/kakao")
+                .then()
+                .statusCode(200)
+                .body("accessToken", notNullValue())
+                .body("refreshToken", notNullValue());
+    }
+
+    @Test
+    @DisplayName("유효한 refresh token으로 새 토큰 쌍 발급")
+    void refresh_validToken() {
+        // given
+        stubKakaoUserInfoEndpoint(99999L, "리프레시유저");
+
+        final String refreshToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "code": "test-auth-code",
+                            "redirectUri": "http://localhost/callback"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/kakao")
+                .then()
+                .extract()
+                .path("refreshToken");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("{\"refreshToken\": \"" + refreshToken + "\"}")
+                .when()
+                .post("/api/v1/auth/refresh")
+                .then()
+                .statusCode(200)
+                .body("accessToken", notNullValue())
+                .body("refreshToken", notNullValue());
+    }
+
+    @Test
+    @DisplayName("인증된 유저의 정보를 조회한다")
+    void me_authenticated() {
+        // given
+        stubKakaoUserInfoEndpoint(77777L, "내정보유저");
+
+        final String accessToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "code": "test-auth-code",
+                            "redirectUri": "http://localhost/callback"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/kakao")
+                .then()
+                .extract()
+                .path("accessToken");
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .get("/api/v1/users/me")
+                .then()
+                .statusCode(200)
+                .body("nickname", is("내정보유저"))
+                .body("isOnboarded", is(false));
+    }
+
+    @Test
+    @DisplayName("인증 없이 호출하면 401")
+    void me_unauthorized() {
+        RestAssured.given()
+                .when()
+                .get("/api/v1/users/me")
+                .then()
+                .statusCode(401);
+    }
+
+    private void stubKakaoTokenEndpoint() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/oauth/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                    "access_token": "kakao-access-token-mock",
+                                    "token_type": "bearer",
+                                    "expires_in": 3600
+                                }
+                                """)));
+    }
+
+    private void stubKakaoUserInfoEndpoint(final Long kakaoId, final String nickname) {
+        wireMockServer.stubFor(get(urlPathEqualTo("/v2/user/me"))
+                .withHeader("Authorization", equalTo("Bearer kakao-access-token-mock"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                    "id": %d,
+                                    "kakao_account": {
+                                        "profile": {
+                                            "nickname": "%s"
+                                        }
+                                    }
+                                }
+                                """.formatted(kakaoId, nickname))));
+    }
+}


### PR DESCRIPTION
## AS-IS
- 카카오 로그인 관련 E2E 테스트 없음. 미인증 시 403 반환.

## TO-BE
- RestAssured + WireMock E2E 테스트 5건 추가
- 미인증 시 401 반환 (HttpStatusEntryPoint)
- 카카오 API URL 설정값 분리 (테스트 시 WireMock 오버라이드)
- refresh token 저장을 upsert 패턴으로 변경 (동일 초 재로그인 시 unique 충돌 방지)

## 의존성
- #67 → #69 → #71 → 본 PR 순서로 머지

## 보호 영역 변경
- `build.gradle` (rest-assured, wiremock 테스트 의존성 추가)
- `application.yml` (kakao.token-uri, kakao.user-info-uri 추가)

## Feature Spec
- `docs/features/kakao-login.md` §6 PR 4에 해당

## 테스트
- `./gradlew checkstyleMain spotlessCheck test` 전체 통과 (16/16)

## AI 체크리스트
- [x] `type:test` 라벨
- [x] `scope:user` 라벨
- [x] `ai-generated` 라벨
- [x] `needs-human-review` 라벨

closes #72