### PR TITLE
feat(infra): 에러 코드 체계 및 공통 예외 처리 도입

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,88 @@
+# API 에러 코드 목록
+
+> 프론트엔드 팀 참고용. 모든 에러 응답은 아래 양식을 따른다.
+
+## 응답 양식
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "MEDICINE_001",
+    "status": 404,
+    "message": "Medicine not found"
+  }
+}
+```
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `success` | boolean | 항상 `false` |
+| `error.code` | String | 에러 식별 코드 (`SCOPE_NNN` 형식) |
+| `error.status` | int | HTTP 상태 코드 |
+| `error.message` | String | 사람이 읽을 수 있는 에러 메시지 |
+
+## 에러 코드
+
+### Common
+| 코드 | HTTP | 메시지 | 설명 |
+|---|---|---|---|
+| `COMMON_001` | 400 | Invalid input | 요청 파라미터 검증 실패 |
+
+### Auth
+| 코드 | HTTP | 메시지 | 설명 |
+|---|---|---|---|
+| `AUTH_001` | 401 | Invalid token | 유효하지 않은 토큰 |
+| `AUTH_002` | 401 | Token expired | 만료된 토큰 |
+
+### User
+| 코드 | HTTP | 메시지 | 설명 |
+|---|---|---|---|
+| `USER_001` | 404 | User not found | 존재하지 않는 사용자 |
+
+### Medicine
+| 코드 | HTTP | 메시지 | 설명 |
+|---|---|---|---|
+| `MEDICINE_001` | 404 | Medicine not found | 존재하지 않는 약물 |
+
+### Care Relation
+| 코드 | HTTP | 메시지 | 설명 |
+|---|---|---|---|
+| `CARE_001` | 403 | No active care relation | 보호자-시니어 연동 관계 없음 |
+| `CARE_002` | 403 | Caregiver must specify seniorId | 보호자는 seniorId 필수 |
+| `CARE_003` | 403 | Only caregivers can specify seniorId | 시니어는 seniorId 지정 불가 |
+
+## 프론트엔드 처리 가이드
+
+```javascript
+// 에러 응답 처리 예시
+const response = await fetch('/api/v1/medicines', { ... });
+
+if (!response.ok) {
+  const body = await response.json();
+  
+  switch (body.error.code) {
+    case 'AUTH_001':
+    case 'AUTH_002':
+      // 토큰 갱신 시도 또는 로그인 화면 이동
+      break;
+    case 'MEDICINE_001':
+      // "약물을 찾을 수 없습니다" 알림
+      break;
+    case 'CARE_001':
+    case 'CARE_002':
+    case 'CARE_003':
+      // 권한 없음 안내
+      break;
+    default:
+      // body.error.message로 일반 에러 표시
+  }
+}
+```
+
+## 코드 추가 규칙
+
+새 에러 코드를 추가할 때:
+1. `ErrorCode.java` enum에 추가 (`SCOPE_NNN` 형식)
+2. 이 문서의 해당 scope 섹션에 추가
+3. 같은 PR에서 코드와 문서를 함께 갱신

--- a/src/main/java/com/ppiyaki/common/exception/BusinessException.java
+++ b/src/main/java/com/ppiyaki/common/exception/BusinessException.java
@@ -1,0 +1,22 @@
+package com.ppiyaki.common.exception;
+
+import java.util.Objects;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = Objects.requireNonNull(errorCode, "errorCode must not be null");
+    }
+
+    public BusinessException(final ErrorCode errorCode, final String detailMessage) {
+        super(detailMessage);
+        this.errorCode = Objects.requireNonNull(errorCode, "errorCode must not be null");
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -1,0 +1,46 @@
+package com.ppiyaki.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_001", "Invalid input"),
+
+    // Auth
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "Invalid token"), AUTH_TOKEN_EXPIRED(
+            HttpStatus.UNAUTHORIZED, "AUTH_002", "Token expired"),
+
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "User not found"),
+
+    // Medicine
+    MEDICINE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEDICINE_001", "Medicine not found"),
+
+    // Care Relation
+    CARE_RELATION_NOT_FOUND(HttpStatus.FORBIDDEN, "CARE_001", "No active care relation"), CARE_RELATION_REQUIRED(
+            HttpStatus.FORBIDDEN, "CARE_002", "Caregiver must specify seniorId"), CARE_RELATION_NOT_CAREGIVER(
+                    HttpStatus.FORBIDDEN, "CARE_003", "Only caregivers can specify seniorId");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(final HttpStatus status, final String code, final String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/ppiyaki/common/exception/ErrorResponse.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorResponse.java
@@ -1,0 +1,24 @@
+package com.ppiyaki.common.exception;
+
+public record ErrorResponse(
+        boolean success,
+        ErrorDetail error
+) {
+
+    public static ErrorResponse of(final ErrorCode errorCode) {
+        return new ErrorResponse(false, new ErrorDetail(errorCode.getCode(),
+                errorCode.getStatus().value(), errorCode.getMessage()));
+    }
+
+    public static ErrorResponse of(final ErrorCode errorCode, final String message) {
+        return new ErrorResponse(false, new ErrorDetail(errorCode.getCode(),
+                errorCode.getStatus().value(), message));
+    }
+
+    public record ErrorDetail(
+            String code,
+            int status,
+            String message
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.ppiyaki.common.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException exception) {
+        final ErrorCode errorCode = exception.getErrorCode();
+        final ErrorResponse errorResponse = ErrorResponse.of(errorCode, exception.getMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(errorResponse);
+    }
+}


### PR DESCRIPTION
## Summary
- `ErrorCode` enum: scope별 에러 코드 정의 (COMMON, AUTH, USER, MEDICINE, CARE)
- `BusinessException`: ErrorCode를 품는 공통 런타임 예외
- `ErrorResponse`: 프론트엔드와 합의된 에러 응답 양식
- `GlobalExceptionHandler`: BusinessException → 적절한 HTTP 상태 + 에러 코드 응답
- `docs/error-codes.md`: 프론트엔드용 에러 코드 목록 + 처리 가이드

## 에러 응답 양식
```json
{
  "success": false,
  "error": {
    "code": "MEDICINE_001",
    "status": 404,
    "message": "Medicine not found"
  }
}
```

## 참고
- 프론트엔드 팀이 제안한 양식에 `status` 필드를 추가하여 HTTP 상태 코드도 본문에 포함
- 기존 `IllegalArgumentException`/`SecurityException` → `BusinessException(ErrorCode)` 전환은 각 도메인 PR에서 순차 적용

## Test plan
- [x] 품질 게이트 통과
- [x] 기존 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 에러 코드 및 에러 응답 형식 문서를 추가했습니다. 모든 API 에러 응답이 일관된 구조를 따르며, 각 에러 코드의 상태와 메시지를 명확히 정의합니다.

* **Refactor**
  * 표준화된 에러 처리 체계를 도입했습니다. API 클라이언트는 일관된 에러 응답 형식을 통해 더 효율적으로 에러를 처리할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->