### PR TITLE
fix(infra): 에러 코드 CodeRabbit 리뷰 반영

### DIFF
--- a/docs/ai-harness/00-index.md
+++ b/docs/ai-harness/00-index.md
@@ -25,6 +25,7 @@
 - `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/task.md`: PR/이슈 템플릿
 - `docs/features/`: 기능 단위 living 명세서 (Feature Spec). 프로세스는 `02-agent-workflow.md §9`
 - `docs/decisions/`: Architecture Decision Records (ADR). 횡단 결정의 영속 이력
+- `docs/error-codes.md`: API 에러 코드 목록 (프론트엔드 참고용, ErrorCode enum과 동기화)
 - `CLAUDE.md`: Claude Code 세션 자동 로드 룰 요약
 
 ## 4) 정책 우선순위

--- a/src/main/java/com/ppiyaki/common/exception/BusinessException.java
+++ b/src/main/java/com/ppiyaki/common/exception/BusinessException.java
@@ -7,12 +7,12 @@ public class BusinessException extends RuntimeException {
     private final ErrorCode errorCode;
 
     public BusinessException(final ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = Objects.requireNonNull(errorCode, "errorCode must not be null");
+        super(Objects.requireNonNull(errorCode, "errorCode must not be null").getMessage());
+        this.errorCode = errorCode;
     }
 
     public BusinessException(final ErrorCode errorCode, final String detailMessage) {
-        super(detailMessage);
+        super(Objects.requireNonNull(detailMessage, "detailMessage must not be null"));
         this.errorCode = Objects.requireNonNull(errorCode, "errorCode must not be null");
     }
 

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -4,6 +4,8 @@ import com.ppiyaki.common.auth.JwtProperties;
 import com.ppiyaki.common.auth.JwtProvider;
 import com.ppiyaki.common.auth.KakaoOAuthClient;
 import com.ppiyaki.common.auth.KakaoOAuthClient.KakaoUserInfo;
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.user.OAuthIdentity;
 import com.ppiyaki.user.OAuthProvider;
 import com.ppiyaki.user.RefreshToken;
@@ -84,11 +86,11 @@ public class AuthService {
         Objects.requireNonNull(refreshTokenValue, "refreshTokenValue must not be null");
 
         final RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
 
         if (refreshToken.isExpired()) {
             refreshTokenRepository.delete(refreshToken);
-            throw new IllegalArgumentException("Refresh token expired");
+            throw new BusinessException(ErrorCode.AUTH_TOKEN_EXPIRED);
         }
 
         final Long userId = refreshToken.getUserId();
@@ -112,7 +114,7 @@ public class AuthService {
     public User findUserById(final Long userId) {
         Objects.requireNonNull(userId, "userId must not be null");
         return userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, "User not found: " + userId));
     }
 
     private void saveRefreshToken(final Long userId, final String tokenValue) {


### PR DESCRIPTION
## Summary
- BusinessException 생성자 null 검증 순서 수정 (`requireNonNull` 선행으로 명확한 에러 메시지 보장)
- `docs/ai-harness/00-index.md`에 `error-codes.md` 등록
- AuthService `IllegalArgumentException` → `BusinessException` 마이그레이션
  - `"Invalid refresh token"` → `BusinessException(AUTH_INVALID_TOKEN)`
  - `"Refresh token expired"` → `BusinessException(AUTH_TOKEN_EXPIRED)`
  - `"User not found"` → `BusinessException(USER_NOT_FOUND)`

## Test plan
- [x] 품질 게이트 통과
- [x] 기존 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)