### PR TITLE
feat(user): 로컬 회원가입/로그인 API 구현

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -34,6 +34,8 @@
 |---|---|---|---|
 | `AUTH_001` | 401 | Invalid token | 유효하지 않은 토큰 |
 | `AUTH_002` | 401 | Token expired | 만료된 토큰 |
+| `AUTH_003` | 409 | Login ID already exists | loginId 중복 (회원가입 시) |
+| `AUTH_004` | 401 | Invalid login ID or password | 로그인 실패 (ID 또는 비밀번호 불일치) |
 
 ### User
 | 코드 | HTTP | 메시지 | 설명 |

--- a/docs/features/local-auth.md
+++ b/docs/features/local-auth.md
@@ -1,0 +1,153 @@
+---
+feature: 로컬 회원가입/로그인
+slug: local-auth
+status: draft
+owner: @goohong
+scope: user
+related_issues: []
+related_prs: []
+last_reviewed: 2026-04-10
+---
+
+# 로컬 회원가입/로그인
+
+## 1) 개요 (What / Why)
+- `loginId` + `password` 기반의 로컬 회원가입/로그인 기능을 구현한다.
+- 카카오 OAuth와 병행하여 두 가지 인증 경로를 제공한다.
+- 카카오 계정이 없는 사용자(특히 시니어)도 서비스를 이용할 수 있어야 한다.
+
+## 2) 사용자 시나리오
+
+### SC-1: 로컬 회원가입
+1. 사용자가 "일반 가입" 화면에서 loginId, password, nickname을 입력한다.
+2. `POST /api/v1/auth/signup`으로 가입 요청을 보낸다.
+3. 서버가 loginId 중복 확인 → BCrypt 비밀번호 암호화 → users 생성 → JWT 발급.
+4. 응답에 `isOnboarded=false` 포함 → 앱이 온보딩 화면으로 이동.
+
+### SC-2: 로컬 로그인
+1. 사용자가 loginId, password를 입력한다.
+2. `POST /api/v1/auth/login`으로 로그인 요청을 보낸다.
+3. 서버가 loginId 조회 → 비밀번호 검증 → JWT 발급.
+4. `isOnboarded` 여부에 따라 온보딩 또는 메인 화면으로 이동.
+
+## 3) 요구사항
+
+### 기능 요구사항
+- [ ] 회원가입: loginId, password, nickname 필수 입력
+- [ ] loginId 중복 시 에러 응답 (409 Conflict)
+- [ ] 비밀번호는 BCrypt로 암호화 후 저장
+- [ ] 가입 성공 시 JWT(accessToken + refreshToken) 발급 + `isOnboarded=false`
+- [ ] 로그인: loginId + password 검증 후 JWT 발급
+- [ ] 잘못된 loginId 또는 password 시 401 응답 (어떤 필드가 틀렸는지 구분하지 않음)
+- [ ] 응답 형식은 카카오 로그인과 동일 (`LoginResponse`)
+- [ ] refresh/logout/me 엔드포인트는 기존 것 그대로 사용
+
+### 비기능 요구사항
+- 비밀번호 원문은 로그에 절대 노출 금지
+- BCrypt strength: Spring Security 기본값 (10 rounds)
+
+## 4) 범위 / 비범위
+
+### 포함
+- `POST /api/v1/auth/signup` — 회원가입
+- `POST /api/v1/auth/login` — 로그인
+- BCrypt PasswordEncoder 빈 등록
+- ErrorCode 추가 (AUTH_DUPLICATE_LOGIN_ID, AUTH_INVALID_CREDENTIALS)
+- E2E 테스트
+
+### 제외 (Out of Scope)
+- 비밀번호 변경/찾기
+- 이메일 인증
+- 로컬 계정 ↔ 카카오 계정 연결
+- 비밀번호 복잡도 정책 (후속 feature)
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+- `users` 테이블 기존 사용. `loginId`, `password` 필드 활용.
+- `password`는 nullable (카카오 전용 유저는 NULL).
+- 추가 마이그레이션 없음.
+
+### 5-2) API 엔드포인트
+
+| Method | Path | 설명 | 인증 | Req | Res |
+|---|---|---|---|---|---|
+| POST | /api/v1/auth/signup | 로컬 회원가입 | 없음 | `SignupRequest` | `LoginResponse` (201) |
+| POST | /api/v1/auth/login | 로컬 로그인 | 없음 | `LoginRequest` | `LoginResponse` (200) |
+
+#### DTO 설계
+
+**SignupRequest**
+```json
+{
+  "loginId": String (필수),
+  "password": String (필수),
+  "nickname": String (필수)
+}
+```
+
+**LoginRequest**
+```json
+{
+  "loginId": String (필수),
+  "password": String (필수)
+}
+```
+
+**LoginResponse** (기존 재사용)
+```json
+{
+  "accessToken": String,
+  "refreshToken": String,
+  "isOnboarded": boolean
+}
+```
+
+### 5-3) 외부 연동
+- 없음. Spring Security `BCryptPasswordEncoder` 사용.
+
+### 5-4) 데이터 흐름
+
+```text
+[회원가입]
+Client → POST /api/v1/auth/signup { loginId, password, nickname }
+       → AuthService.signup()
+       → loginId 중복 검사 (UserRepository.existsByLoginId)
+       → BCrypt 암호화 → User 저장 (role=null)
+       → JWT 발급 + RefreshToken 저장
+       → LoginResponse { accessToken, refreshToken, isOnboarded=false }
+
+[로그인]
+Client → POST /api/v1/auth/login { loginId, password }
+       → AuthService.login()
+       → UserRepository.findByLoginId(loginId)
+       → BCrypt 비밀번호 매칭
+       → JWT 발급 + RefreshToken 저장
+       → LoginResponse { accessToken, refreshToken, isOnboarded }
+```
+
+### 5-5) DB 마이그레이션
+- 없음. `users.login_id`(UNIQUE), `users.password`(nullable) 이미 존재.
+
+## 6) 작업 분할 (예상 PR 리스트)
+- [ ] PR 1: `feat(user)` BCryptPasswordEncoder 빈 + signup/login 엔드포인트 + ErrorCode 추가 + E2E 테스트
+
+## 7) 테스트 전략
+- **E2E (RestAssured)**: 
+  - 회원가입 성공 → 201 + JWT + isOnboarded=false
+  - 중복 loginId 가입 → 409
+  - 로그인 성공 → 200 + JWT
+  - 잘못된 비밀번호 → 401
+  - 존재하지 않는 loginId → 401
+- 기존 카카오/refresh/logout/me 테스트 회귀 없음
+
+## 8) 오픈 질문
+
+| # | 질문 | 선택지 | 담당/기한 |
+|---|---|---|---|
+| ~~Q1~~ | ~~비밀번호 암호화 방식~~ | ~~BCrypt~~ | **결정됨** → §9 참조 |
+
+## 9) 결정 로그
+- 2026-04-10: 초안 작성 (status=draft). 비밀번호 변경/찾기, 이메일 인증은 out-of-scope.
+- 2026-04-10: Q1 결정 — BCrypt 사용, Spring Security 기본 strength(10 rounds).
+- 2026-04-10: 응답 형식은 카카오 로그인과 동일한 `LoginResponse` 재사용. refresh/logout/me도 기존 그대로.

--- a/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
+++ b/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -22,6 +24,11 @@ public class SecurityConfig {
     public SecurityConfig(final JwtAuthenticationFilter jwtAuthenticationFilter) {
         this.jwtAuthenticationFilter = Objects.requireNonNull(
                 jwtAuthenticationFilter, "jwtAuthenticationFilter must not be null");
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Bean

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -9,7 +9,9 @@ public enum ErrorCode {
 
     // Auth
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "Invalid token"), AUTH_TOKEN_EXPIRED(
-            HttpStatus.UNAUTHORIZED, "AUTH_002", "Token expired"),
+            HttpStatus.UNAUTHORIZED, "AUTH_002", "Token expired"), AUTH_DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT,
+                    "AUTH_003", "Login ID already exists"), AUTH_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED,
+                            "AUTH_004", "Invalid login ID or password"),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "User not found"),

--- a/src/main/java/com/ppiyaki/user/controller/AuthController.java
+++ b/src/main/java/com/ppiyaki/user/controller/AuthController.java
@@ -2,13 +2,17 @@ package com.ppiyaki.user.controller;
 
 import com.ppiyaki.user.User;
 import com.ppiyaki.user.controller.dto.KakaoLoginRequest;
+import com.ppiyaki.user.controller.dto.LoginRequest;
 import com.ppiyaki.user.controller.dto.LoginResponse;
 import com.ppiyaki.user.controller.dto.LogoutRequest;
 import com.ppiyaki.user.controller.dto.RefreshRequest;
+import com.ppiyaki.user.controller.dto.SignupRequest;
 import com.ppiyaki.user.controller.dto.TokenResponse;
 import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.service.AuthService;
+import jakarta.validation.Valid;
 import java.util.Objects;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +29,18 @@ public class AuthController {
 
     public AuthController(final AuthService authService) {
         this.authService = Objects.requireNonNull(authService, "authService must not be null");
+    }
+
+    @PostMapping("/auth/signup")
+    public ResponseEntity<LoginResponse> signup(@Valid @RequestBody final SignupRequest signupRequest) {
+        final LoginResponse loginResponse = authService.signup(signupRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(loginResponse);
+    }
+
+    @PostMapping("/auth/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody final LoginRequest loginRequest) {
+        final LoginResponse loginResponse = authService.login(loginRequest);
+        return ResponseEntity.ok(loginResponse);
     }
 
     @PostMapping("/auth/kakao")

--- a/src/main/java/com/ppiyaki/user/controller/dto/LoginRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.ppiyaki.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank String loginId,
+        @NotBlank String password
+) {
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/SignupRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/SignupRequest.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SignupRequest(
+        @NotBlank String loginId,
+        @NotBlank String password,
+        @NotBlank String nickname
+) {
+}

--- a/src/main/java/com/ppiyaki/user/repository/UserRepository.java
+++ b/src/main/java/com/ppiyaki/user/repository/UserRepository.java
@@ -1,7 +1,12 @@
 package com.ppiyaki.user.repository;
 
 import com.ppiyaki.user.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByLoginId(final String loginId);
+
+    Optional<User> findByLoginId(final String loginId);
 }

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -20,6 +20,7 @@ import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -87,9 +88,14 @@ public class AuthService {
         }
 
         final String encodedPassword = passwordEncoder.encode(signupRequest.password());
-        final User user = userRepository.save(
-                new User(signupRequest.loginId(), encodedPassword, null,
-                        signupRequest.nickname(), null, null, null));
+        final User user;
+        try {
+            user = userRepository.save(
+                    new User(signupRequest.loginId(), encodedPassword, null,
+                            signupRequest.nickname(), null, null, null));
+        } catch (final DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
+        }
 
         final String accessToken = jwtProvider.createAccessToken(user.getId());
         final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -11,13 +11,16 @@ import com.ppiyaki.user.OAuthProvider;
 import com.ppiyaki.user.RefreshToken;
 import com.ppiyaki.user.User;
 import com.ppiyaki.user.controller.dto.KakaoLoginRequest;
+import com.ppiyaki.user.controller.dto.LoginRequest;
 import com.ppiyaki.user.controller.dto.LoginResponse;
+import com.ppiyaki.user.controller.dto.SignupRequest;
 import com.ppiyaki.user.controller.dto.TokenResponse;
 import com.ppiyaki.user.repository.OAuthIdentityRepository;
 import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +30,7 @@ public class AuthService {
     private final KakaoOAuthClient kakaoOAuthClient;
     private final JwtProvider jwtProvider;
     private final JwtProperties jwtProperties;
+    private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
     private final OAuthIdentityRepository oAuthIdentityRepository;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -35,6 +39,7 @@ public class AuthService {
             final KakaoOAuthClient kakaoOAuthClient,
             final JwtProvider jwtProvider,
             final JwtProperties jwtProperties,
+            final PasswordEncoder passwordEncoder,
             final UserRepository userRepository,
             final OAuthIdentityRepository oAuthIdentityRepository,
             final RefreshTokenRepository refreshTokenRepository
@@ -42,6 +47,7 @@ public class AuthService {
         this.kakaoOAuthClient = Objects.requireNonNull(kakaoOAuthClient, "kakaoOAuthClient must not be null");
         this.jwtProvider = Objects.requireNonNull(jwtProvider, "jwtProvider must not be null");
         this.jwtProperties = Objects.requireNonNull(jwtProperties, "jwtProperties must not be null");
+        this.passwordEncoder = Objects.requireNonNull(passwordEncoder, "passwordEncoder must not be null");
         this.userRepository = Objects.requireNonNull(userRepository, "userRepository must not be null");
         this.oAuthIdentityRepository = Objects.requireNonNull(oAuthIdentityRepository,
                 "oAuthIdentityRepository must not be null");
@@ -62,6 +68,47 @@ public class AuthService {
                 .findByProviderAndProviderUserId(OAuthProvider.KAKAO, providerUserId)
                 .map(identity -> userRepository.findById(identity.getUserId()).orElseThrow())
                 .orElseGet(() -> createNewUser(kakaoUserInfo, providerUserId));
+
+        final String accessToken = jwtProvider.createAccessToken(user.getId());
+        final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
+        saveRefreshToken(user.getId(), refreshTokenValue);
+
+        final boolean isOnboarded = user.getRole() != null;
+
+        return new LoginResponse(accessToken, refreshTokenValue, isOnboarded);
+    }
+
+    @Transactional
+    public LoginResponse signup(final SignupRequest signupRequest) {
+        Objects.requireNonNull(signupRequest, "signupRequest must not be null");
+
+        if (userRepository.existsByLoginId(signupRequest.loginId())) {
+            throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
+        }
+
+        final String encodedPassword = passwordEncoder.encode(signupRequest.password());
+        final User user = userRepository.save(
+                new User(signupRequest.loginId(), encodedPassword, null,
+                        signupRequest.nickname(), null, null, null));
+
+        final String accessToken = jwtProvider.createAccessToken(user.getId());
+        final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
+        saveRefreshToken(user.getId(), refreshTokenValue);
+
+        return new LoginResponse(accessToken, refreshTokenValue, false);
+    }
+
+    @Transactional
+    public LoginResponse login(final LoginRequest loginRequest) {
+        Objects.requireNonNull(loginRequest, "loginRequest must not be null");
+
+        final User user = userRepository.findByLoginId(loginRequest.loginId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS));
+
+        if (user.getPassword() == null
+                || !passwordEncoder.matches(loginRequest.password(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        }
 
         final String accessToken = jwtProvider.createAccessToken(user.getId());
         final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());

--- a/src/test/java/com/ppiyaki/user/controller/LocalAuthE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/LocalAuthE2ETest.java
@@ -1,0 +1,183 @@
+package com.ppiyaki.user.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "kakao.client-id=test-client-id",
+        "kakao.client-secret=test-client-secret",
+        "kakao.token-uri=http://localhost:19878/oauth/token",
+        "kakao.user-info-uri=http://localhost:19878/v2/user/me"
+})
+class LocalAuthE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    private static long idSequence = 300000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("로컬 회원가입 시 201 응답과 JWT 발급, isOnboarded=false")
+    void signup_success() {
+        final String loginId = "user" + idSequence++;
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password123!",
+                            "nickname": "테스트유저"
+                        }
+                        """.formatted(loginId))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .body("accessToken", notNullValue())
+                .body("refreshToken", notNullValue())
+                .body("isOnboarded", is(false));
+    }
+
+    @Test
+    @DisplayName("중복 loginId로 가입 시 409 응답")
+    void signup_duplicateLoginId() {
+        final String loginId = "duplicate" + idSequence++;
+
+        // given - 첫 가입
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password123!",
+                            "nickname": "첫유저"
+                        }
+                        """.formatted(loginId))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201);
+
+        // when - 중복 가입
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "other456!",
+                            "nickname": "둘째유저"
+                        }
+                        """.formatted(loginId))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(409)
+                .body("error.code", is("AUTH_003"));
+    }
+
+    @Test
+    @DisplayName("로컬 로그인 성공 시 200 응답과 JWT 발급")
+    void login_success() {
+        final String loginId = "login" + idSequence++;
+
+        // given - 가입
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "mypassword!",
+                            "nickname": "로그인유저"
+                        }
+                        """.formatted(loginId))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201);
+
+        // when - 로그인
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "mypassword!"
+                        }
+                        """.formatted(loginId))
+                .when()
+                .post("/api/v1/auth/login")
+                .then()
+                .statusCode(200)
+                .body("accessToken", notNullValue())
+                .body("refreshToken", notNullValue())
+                .body("isOnboarded", is(false));
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호로 로그인 시 401 응답")
+    void login_wrongPassword() {
+        final String loginId = "wrongpw" + idSequence++;
+
+        // given - 가입
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "correctpw!",
+                            "nickname": "비번유저"
+                        }
+                        """.formatted(loginId))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201);
+
+        // when - 틀린 비밀번호
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "wrongpw!"
+                        }
+                        """.formatted(loginId))
+                .when()
+                .post("/api/v1/auth/login")
+                .then()
+                .statusCode(401)
+                .body("error.code", is("AUTH_004"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 loginId로 로그인 시 401 응답")
+    void login_nonexistentUser() {
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "nonexistent999",
+                            "password": "anything!"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/login")
+                .then()
+                .statusCode(401)
+                .body("error.code", is("AUTH_004"));
+    }
+}


### PR DESCRIPTION
## Summary
- `POST /api/v1/auth/signup` — 로컬 회원가입 (201, BCrypt 암호화)
- `POST /api/v1/auth/login` — 로컬 로그인 (200, JWT 발급)
- 기존 LoginResponse 재사용, refresh/logout/me 변경 없음
- ErrorCode AUTH_003(중복 ID, 409), AUTH_004(인증 실패, 401) 추가
- Feature Spec `docs/features/local-auth.md` 작성

## AS-IS
- 카카오 OAuth 로그인만 가능

## TO-BE
- 카카오 + 로컬 로그인 두 가지 인증 경로 제공

## Test plan
- [x] 회원가입 성공 → 201 + JWT + isOnboarded=false
- [x] 중복 loginId → 409 + AUTH_003
- [x] 로그인 성공 → 200 + JWT
- [x] 잘못된 비밀번호 → 401 + AUTH_004
- [x] 존재하지 않는 loginId → 401 + AUTH_004
- [x] Feature Spec §3 기능 요구사항 전수 검증 완료
- [x] `./gradlew checkstyleMain spotlessCheck test` 통과

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 로컬 인증 추가: loginId/비밀번호로 회원가입(201) 및 로그인(200) 지원
  * 중복 로그인 ID 처리 및 인증 실패 처리(에러 코드 및 상태 반영)

* **Documentation**
  * 로컬 인증 API 명세·흐름, 요청/응답 형식 및 오류 코드(AUTH_003, AUTH_004) 문서화
  * 구현 범위·테스트 체크리스트·결정 기록 포함

* **Tests**
  * 로컬 인증 통합(E2E) 테스트 추가: 가입·중복·로그인·오류 케이스
<!-- end of auto-generated comment: release notes by coderabbit.ai -->