### PR TITLE
feat(medication): 복약 일정 CRUD API 구현

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -450,7 +450,7 @@ erDiagram
 | 7-17 | `caregiver_senior_mappings` → `care_relations` | 테이블 rename + `deleted_at` soft delete 도입 |
 | 7-18 | `Pet` 공통 시간 엔티티 상속 | `Pet.java`가 `BaseTimeEntity`를 상속하도록 변경해 `created_at`/`updated_at` 추가 |
 | 7-19 | 신규 엔티티 구현 | `oauth_identities`, `dur_checks`, `device_tokens`, `medication_reminders`, `reports` 엔티티 클래스 신설 |
-| 7-20 | `medication_schedules` 필드 확장 | `days_of_week`, `start_date`, `end_date` 추가 |
+| ~~7-20~~ | ~~`medication_schedules` 필드 확장~~ | ~~`days_of_week`, `start_date`, `end_date` 추가~~ ✅ 해소됨 (§5 반영) |
 | 7-21 | `medication_logs` 필드 확장 | `confirmed_by_user_id` 추가 |
 | 7-22 | `medicines` 소유 관계 | `owner_id` 추가, `prescription_id` nullable 전환 |
 

--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -183,7 +183,7 @@
 | end_date | date nullable | 복약 종료일. NULL이면 무기한 |
 | created_at | timestamp | `CreatedTimeEntity` |
 
-> **코드 갭**: 현재 코드에는 `days_of_week`, `start_date`, `end_date`가 없음. 추적: §7-16.
+> **코드 갭 해소됨**: `days_of_week`, `start_date`, `end_date` 추가 완료 (#16). 현재 코드와 타깃 스키마 일치.
 
 ### medication_logs (`@Table(name = "medication_logs")`, extends `CreatedTimeEntity`)
 복약 이행 기록. 일자별 × 스케줄별 1행.

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -47,6 +47,12 @@
 |---|---|---|---|
 | `MEDICINE_001` | 404 | Medicine not found | 존재하지 않는 약물 |
 
+### Medication Schedule
+| 코드 | HTTP | 메시지 | 설명 |
+|---|---|---|---|
+| `SCHEDULE_001` | 404 | Schedule not found | 존재하지 않는 복약 일정 |
+| `SCHEDULE_002` | 400 | Schedule does not belong to this medicine | 일정이 해당 약물에 속하지 않음 |
+
 ### Care Relation
 | 코드 | HTTP | 메시지 | 설명 |
 |---|---|---|---|

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -25,11 +25,13 @@
 ## 에러 코드
 
 ### Common
+
 | 코드 | HTTP | 메시지 | 설명 |
 |---|---|---|---|
 | `COMMON_001` | 400 | Invalid input | 요청 파라미터 검증 실패 |
 
 ### Auth
+
 | 코드 | HTTP | 메시지 | 설명 |
 |---|---|---|---|
 | `AUTH_001` | 401 | Invalid token | 유효하지 않은 토큰 |
@@ -38,22 +40,26 @@
 | `AUTH_004` | 401 | Invalid login ID or password | 로그인 실패 (ID 또는 비밀번호 불일치) |
 
 ### User
+
 | 코드 | HTTP | 메시지 | 설명 |
 |---|---|---|---|
 | `USER_001` | 404 | User not found | 존재하지 않는 사용자 |
 
 ### Medicine
+
 | 코드 | HTTP | 메시지 | 설명 |
 |---|---|---|---|
 | `MEDICINE_001` | 404 | Medicine not found | 존재하지 않는 약물 |
 
 ### Medication Schedule
+
 | 코드 | HTTP | 메시지 | 설명 |
 |---|---|---|---|
 | `SCHEDULE_001` | 404 | Schedule not found | 존재하지 않는 복약 일정 |
 | `SCHEDULE_002` | 400 | Schedule does not belong to this medicine | 일정이 해당 약물에 속하지 않음 |
 
 ### Care Relation
+
 | 코드 | HTTP | 메시지 | 설명 |
 |---|---|---|---|
 | `CARE_001` | 403 | No active care relation | 보호자-시니어 연동 관계 없음 |

--- a/docs/features/medication-schedule-crud.md
+++ b/docs/features/medication-schedule-crud.md
@@ -1,11 +1,11 @@
 ---
 feature: 복약 일정 등록/조회/수정/삭제
 slug: medication-schedule-crud
-status: draft
+status: in-review
 owner: @goohong
 scope: medication
 related_issues: []
-related_prs: []
+related_prs: [91]
 last_reviewed: 2026-04-11
 ---
 
@@ -38,14 +38,14 @@ last_reviewed: 2026-04-11
 ## 3) 요구사항
 
 ### 기능 요구사항
-- [ ] 약물에 복약 일정을 등록할 수 있다 (scheduledTime, dosage 필수)
-- [ ] 등록 시 medicineId가 존재하는지 검증
-- [ ] 등록 시 해당 약물의 소유자(또는 연동된 보호자)인지 검증
-- [ ] 약물별 복약 일정 목록 조회 (페이징 없이 전체 반환)
-- [ ] 복약 일정 단건 상세 조회
-- [ ] 복약 일정 수정 (scheduledTime, dosage, daysOfWeek, startDate, endDate)
-- [ ] 복약 일정 삭제
-- [ ] 소유자 또는 연동된 보호자가 아닌 사용자의 접근 시 403 응답
+- [x] 약물에 복약 일정을 등록할 수 있다 (scheduledTime, dosage 필수)
+- [x] 등록 시 medicineId가 존재하는지 검증
+- [x] 등록 시 해당 약물의 소유자(또는 연동된 보호자)인지 검증
+- [x] 약물별 복약 일정 목록 조회 (페이징 없이 전체 반환)
+- [x] 복약 일정 단건 상세 조회
+- [x] 복약 일정 수정 (scheduledTime, dosage, daysOfWeek, startDate, endDate)
+- [x] 복약 일정 삭제
+- [x] 소유자 또는 연동된 보호자가 아닌 사용자의 접근 시 403 응답
 
 ### 비기능 요구사항
 - daysOfWeek는 "MON,TUE,WED" 또는 "DAILY" 형식의 문자열
@@ -150,7 +150,7 @@ Client → [Authorization: Bearer token]
 - 없음. `medication_schedules` 테이블과 `MedicationSchedule.java` 엔티티가 이미 타깃 스키마와 일치.
 
 ## 6) 작업 분할 (예상 PR 리스트)
-- [ ] PR 1: `feat(medication)` MedicationScheduleService + MedicationScheduleController (CRUD 5개) + DTO + E2E 테스트
+- [x] PR 1 (#91): `feat(medication)` MedicationScheduleService + MedicationScheduleController (CRUD 5개) + DTO + E2E 테스트
 
 ## 7) 테스트 전략
 - **E2E (RestAssured)**:

--- a/docs/features/medication-schedule-crud.md
+++ b/docs/features/medication-schedule-crud.md
@@ -1,0 +1,174 @@
+---
+feature: 복약 일정 등록/조회/수정/삭제
+slug: medication-schedule-crud
+status: draft
+owner: @goohong
+scope: medication
+related_issues: []
+related_prs: []
+last_reviewed: 2026-04-11
+---
+
+# 복약 일정 등록/조회/수정/삭제
+
+## 1) 개요 (What / Why)
+- 약물(Medicine)에 대한 복약 일정(시간, 용량, 요일, 기간)을 등록·관리할 수 있도록 한다.
+- 복약 일정은 알림(MedicationReminder), 복약 기록(MedicationLog)의 기반이 되므로 선행 구현이 필수이다.
+- 하나의 약물에 여러 시간대의 일정을 등록할 수 있다 (예: 아침 8시 1정, 저녁 8시 1정).
+
+## 2) 사용자 시나리오
+
+### SC-1: 시니어가 약물에 복약 일정 등록
+1. 시니어가 약 상세 화면에서 "일정 추가"를 탭한다.
+2. 복용 시각, 1회 복용량, 요일 패턴, 시작일을 입력한다.
+3. `POST /api/v1/medicines/{medicineId}/schedules`로 일정이 생성된다.
+
+### SC-2: 시니어가 약물의 복약 일정 목록 확인
+1. 약 상세 화면에서 해당 약물의 복약 일정 목록을 본다.
+2. `GET /api/v1/medicines/{medicineId}/schedules`로 조회.
+
+### SC-3: 시니어가 복약 일정 수정
+1. 복용 시각이나 용량을 변경한다.
+2. `PATCH /api/v1/medicines/{medicineId}/schedules/{scheduleId}`로 수정.
+
+### SC-4: 시니어가 복약 일정 삭제
+1. 더 이상 필요 없는 일정을 삭제한다.
+2. `DELETE /api/v1/medicines/{medicineId}/schedules/{scheduleId}`로 삭제.
+
+## 3) 요구사항
+
+### 기능 요구사항
+- [ ] 약물에 복약 일정을 등록할 수 있다 (scheduledTime, dosage 필수)
+- [ ] 등록 시 medicineId가 존재하는지 검증
+- [ ] 등록 시 해당 약물의 소유자(또는 연동된 보호자)인지 검증
+- [ ] 약물별 복약 일정 목록 조회 (페이징 없이 전체 반환)
+- [ ] 복약 일정 단건 상세 조회
+- [ ] 복약 일정 수정 (scheduledTime, dosage, daysOfWeek, startDate, endDate)
+- [ ] 복약 일정 삭제
+- [ ] 소유자 또는 연동된 보호자가 아닌 사용자의 접근 시 403 응답
+
+### 비기능 요구사항
+- daysOfWeek는 "MON,TUE,WED" 또는 "DAILY" 형식의 문자열
+
+## 4) 범위 / 비범위
+
+### 포함
+- MedicationSchedule CRUD 5개 엔드포인트
+- 약물 소유자 기반 접근 검증 (medicine.ownerId + care_relations)
+- MedicationScheduleRepository 확장
+- MedicationScheduleService + MedicationScheduleController 구현
+- E2E 테스트
+
+### 제외 (Out of Scope)
+- 복약 알림(MedicationReminder) 발송 (별도 feature)
+- 복약 기록(MedicationLog) 생성 (별도 feature)
+- 일정 충돌 검사 (같은 시간에 다른 약물 일정 겹침)
+- 반복 패턴 복잡 로직 (매월 N일 등 — 현재 요일 패턴만 지원)
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+- `medication_schedules` 테이블 사용. `docs/ai-harness/06-domain-model.md §5 medication_schedules` 참조.
+- MedicationSchedule 엔티티 이미 존재 (모든 필드 구현 완료).
+- 소유자 검증: `scheduleId → medicine.ownerId` 경로로 간접 검증.
+
+### 5-2) API 엔드포인트
+
+| Method | Path | 설명 | 인증 | Req | Res |
+|---|---|---|---|---|---|
+| POST | /api/v1/medicines/{medicineId}/schedules | 일정 등록 | 필수 | `ScheduleCreateRequest` | `ScheduleResponse` (201) |
+| GET | /api/v1/medicines/{medicineId}/schedules | 일정 목록 조회 | 필수 | - | `ScheduleListResponse` (200) |
+| GET | /api/v1/medicines/{medicineId}/schedules/{scheduleId} | 일정 상세 조회 | 필수 | - | `ScheduleResponse` (200) |
+| PATCH | /api/v1/medicines/{medicineId}/schedules/{scheduleId} | 일정 수정 | 필수 | `ScheduleUpdateRequest` | `ScheduleResponse` (200) |
+| DELETE | /api/v1/medicines/{medicineId}/schedules/{scheduleId} | 일정 삭제 | 필수 | - | 204 |
+
+#### 접근 권한 규칙
+- medicineId로 Medicine 조회 → `medicine.ownerId`와 현재 사용자 비교
+- 본인 소유 또는 care_relations 활성 관계가 있는 보호자만 접근 가능
+
+#### DTO 설계
+
+**ScheduleCreateRequest**
+```json
+{
+  "scheduledTime": "08:00" (필수, HH:mm),
+  "dosage": "1정" (필수),
+  "daysOfWeek": "DAILY" (선택, 기본값 "DAILY"),
+  "startDate": "2026-04-11" (선택, 기본값 오늘),
+  "endDate": null (선택, null이면 무기한)
+}
+```
+
+**ScheduleUpdateRequest**
+```json
+{
+  "scheduledTime": "09:00" (선택),
+  "dosage": "2정" (선택),
+  "daysOfWeek": "MON,WED,FRI" (선택),
+  "startDate": "2026-04-15" (선택),
+  "endDate": "2026-07-15" (선택)
+}
+```
+
+**ScheduleResponse**
+```json
+{
+  "id": Long,
+  "medicineId": Long,
+  "scheduledTime": "08:00",
+  "dosage": "1정",
+  "daysOfWeek": "DAILY",
+  "startDate": "2026-04-11",
+  "endDate": null,
+  "createdAt": LocalDateTime
+}
+```
+
+**ScheduleListResponse**
+```json
+{
+  "responses": List<ScheduleResponse>
+}
+```
+
+### 5-3) 외부 연동
+- 없음. 순수 CRUD.
+
+### 5-4) 데이터 흐름
+
+```text
+Client → [Authorization: Bearer token]
+       → MedicationScheduleController
+       → MedicationScheduleService
+         → MedicineRepository.findById(medicineId)  // 약물 존재 검증
+         → medicine.ownerId 기반 접근 검증           // 소유자/보호자 확인
+         → MedicationScheduleRepository              // CRUD
+       → medication_schedules 테이블
+```
+
+### 5-5) DB 마이그레이션
+- 없음. `medication_schedules` 테이블과 `MedicationSchedule.java` 엔티티가 이미 타깃 스키마와 일치.
+
+## 6) 작업 분할 (예상 PR 리스트)
+- [ ] PR 1: `feat(medication)` MedicationScheduleService + MedicationScheduleController (CRUD 5개) + DTO + E2E 테스트
+
+## 7) 테스트 전략
+- **E2E (RestAssured)**:
+  - 일정 등록 → 201 + 응답 검증
+  - 목록 조회 → 200 + 해당 약물의 일정만 반환
+  - 상세 조회 → 200
+  - 수정 → 200 + 변경된 필드 검증
+  - 삭제 → 204
+  - 다른 사용자의 약물에 일정 등록 시도 → 403
+
+## 8) 오픈 질문
+
+| # | 질문 | 선택지 | 담당/기한 |
+|---|---|---|---|
+| ~~Q1~~ | ~~소유자 검증 방식~~ | ~~medicine.ownerId 경로로 간접 검증~~ | **결정됨** → §9 참조 |
+| ~~Q2~~ | ~~URI 구조~~ | ~~중첩: /medicines/{id}/schedules~~ | **결정됨** → §9 참조 |
+
+## 9) 결정 로그
+- 2026-04-11: 초안 작성 (status=draft). 알림/복약 기록은 out-of-scope.
+- 2026-04-11: Q1 결정 — 소유자 검증은 medicine.ownerId를 통한 간접 검증. schedule 자체에 ownerId를 두지 않음.
+- 2026-04-11: Q2 결정 — URI는 중첩 방식(`/medicines/{medicineId}/schedules`). schedule은 medicine의 종속 리소스이므로 관계가 URL에 드러나는 게 RESTful.

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -22,6 +22,10 @@ public enum ErrorCode {
     // Medicine
     MEDICINE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEDICINE_001", "Medicine not found"),
 
+    // Medication Schedule
+    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE_001", "Schedule not found"),
+    SCHEDULE_MEDICINE_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE_002", "Schedule does not belong to this medicine"),
+
     // Care Relation
     CARE_RELATION_NOT_FOUND(HttpStatus.FORBIDDEN, "CARE_001", "No active care relation"),
     CARE_RELATION_REQUIRED(HttpStatus.FORBIDDEN, "CARE_002", "Caregiver must specify seniorId"),

--- a/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
+++ b/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -49,11 +50,35 @@ public class MedicationSchedule extends CreatedTimeEntity {
             final LocalDate startDate,
             final LocalDate endDate
     ) {
-        this.medicineId = medicineId;
-        this.scheduledTime = scheduledTime;
-        this.dosage = dosage;
+        this.medicineId = Objects.requireNonNull(medicineId, "medicineId must not be null");
+        this.scheduledTime = Objects.requireNonNull(scheduledTime, "scheduledTime must not be null");
+        this.dosage = Objects.requireNonNull(dosage, "dosage must not be null");
         this.daysOfWeek = daysOfWeek;
         this.startDate = startDate;
         this.endDate = endDate;
+    }
+
+    public void update(
+            final LocalTime scheduledTime,
+            final String dosage,
+            final String daysOfWeek,
+            final LocalDate startDate,
+            final LocalDate endDate
+    ) {
+        if (scheduledTime != null) {
+            this.scheduledTime = scheduledTime;
+        }
+        if (dosage != null) {
+            this.dosage = dosage;
+        }
+        if (daysOfWeek != null) {
+            this.daysOfWeek = daysOfWeek;
+        }
+        if (startDate != null) {
+            this.startDate = startDate;
+        }
+        if (endDate != null) {
+            this.endDate = endDate;
+        }
     }
 }

--- a/src/main/java/com/ppiyaki/medication/controller/MedicationScheduleController.java
+++ b/src/main/java/com/ppiyaki/medication/controller/MedicationScheduleController.java
@@ -1,0 +1,87 @@
+package com.ppiyaki.medication.controller;
+
+import com.ppiyaki.medication.controller.dto.ScheduleCreateRequest;
+import com.ppiyaki.medication.controller.dto.ScheduleListResponse;
+import com.ppiyaki.medication.controller.dto.ScheduleResponse;
+import com.ppiyaki.medication.controller.dto.ScheduleUpdateRequest;
+import com.ppiyaki.medication.service.MedicationScheduleService;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/medicines/{medicineId}/schedules")
+public class MedicationScheduleController {
+
+    private final MedicationScheduleService medicationScheduleService;
+
+    public MedicationScheduleController(final MedicationScheduleService medicationScheduleService) {
+        this.medicationScheduleService = Objects.requireNonNull(
+                medicationScheduleService, "medicationScheduleService must not be null");
+    }
+
+    @PostMapping
+    public ResponseEntity<ScheduleResponse> create(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long medicineId,
+            @Valid @RequestBody final ScheduleCreateRequest scheduleCreateRequest
+    ) {
+        final ScheduleResponse scheduleResponse = medicationScheduleService.create(
+                userId, medicineId, scheduleCreateRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(scheduleResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<ScheduleListResponse> readAll(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long medicineId
+    ) {
+        final List<ScheduleResponse> responses = medicationScheduleService.readAll(userId, medicineId);
+        final ScheduleListResponse scheduleListResponse = ScheduleListResponse.from(responses);
+        return ResponseEntity.ok(scheduleListResponse);
+    }
+
+    @GetMapping("/{scheduleId}")
+    public ResponseEntity<ScheduleResponse> readById(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long medicineId,
+            @PathVariable final Long scheduleId
+    ) {
+        final ScheduleResponse scheduleResponse = medicationScheduleService.readById(
+                userId, medicineId, scheduleId);
+        return ResponseEntity.ok(scheduleResponse);
+    }
+
+    @PatchMapping("/{scheduleId}")
+    public ResponseEntity<ScheduleResponse> update(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long medicineId,
+            @PathVariable final Long scheduleId,
+            @Valid @RequestBody final ScheduleUpdateRequest scheduleUpdateRequest
+    ) {
+        final ScheduleResponse scheduleResponse = medicationScheduleService.update(
+                userId, medicineId, scheduleId, scheduleUpdateRequest);
+        return ResponseEntity.ok(scheduleResponse);
+    }
+
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long medicineId,
+            @PathVariable final Long scheduleId
+    ) {
+        medicationScheduleService.delete(userId, medicineId, scheduleId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleCreateRequest.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleCreateRequest.java
@@ -10,8 +10,7 @@ public record ScheduleCreateRequest(
         @NotNull LocalTime scheduledTime,
         @NotBlank String dosage,
         @Pattern(
-                regexp = "^(DAILY|(?:MON|TUE|WED|THU|FRI|SAT|SUN)(?:,(?:MON|TUE|WED|THU|FRI|SAT|SUN))*)$",
-                message = "daysOfWeek must be DAILY or comma-separated weekday codes"
+                regexp = "^(DAILY|(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN))*)$", message = "daysOfWeek must be 'DAILY' or a comma-separated list of MON,TUE,WED,THU,FRI,SAT,SUN"
         ) String daysOfWeek,
         LocalDate startDate,
         LocalDate endDate

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleCreateRequest.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleCreateRequest.java
@@ -1,0 +1,19 @@
+package com.ppiyaki.medication.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record ScheduleCreateRequest(
+        @NotNull LocalTime scheduledTime,
+        @NotBlank String dosage,
+        @Pattern(
+                regexp = "^(DAILY|(?:MON|TUE|WED|THU|FRI|SAT|SUN)(?:,(?:MON|TUE|WED|THU|FRI|SAT|SUN))*)$",
+                message = "daysOfWeek must be DAILY or comma-separated weekday codes"
+        ) String daysOfWeek,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+}

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleListResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleListResponse.java
@@ -1,0 +1,17 @@
+package com.ppiyaki.medication.controller.dto;
+
+import java.util.List;
+import java.util.Objects;
+
+public record ScheduleListResponse(
+        List<ScheduleResponse> responses
+) {
+
+    public ScheduleListResponse {
+        Objects.requireNonNull(responses, "responses must not be null");
+    }
+
+    public static ScheduleListResponse from(final List<ScheduleResponse> responses) {
+        return new ScheduleListResponse(responses);
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleResponse.java
@@ -1,0 +1,31 @@
+package com.ppiyaki.medication.controller.dto;
+
+import com.ppiyaki.medication.MedicationSchedule;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record ScheduleResponse(
+        Long id,
+        Long medicineId,
+        LocalTime scheduledTime,
+        String dosage,
+        String daysOfWeek,
+        LocalDate startDate,
+        LocalDate endDate,
+        LocalDateTime createdAt
+) {
+
+    public static ScheduleResponse from(final MedicationSchedule schedule) {
+        return new ScheduleResponse(
+                schedule.getId(),
+                schedule.getMedicineId(),
+                schedule.getScheduledTime(),
+                schedule.getDosage(),
+                schedule.getDaysOfWeek(),
+                schedule.getStartDate(),
+                schedule.getEndDate(),
+                schedule.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleUpdateRequest.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleUpdateRequest.java
@@ -8,8 +8,7 @@ public record ScheduleUpdateRequest(
         LocalTime scheduledTime,
         String dosage,
         @Pattern(
-                regexp = "^(DAILY|(?:MON|TUE|WED|THU|FRI|SAT|SUN)(?:,(?:MON|TUE|WED|THU|FRI|SAT|SUN))*)$",
-                message = "daysOfWeek must be DAILY or comma-separated weekday codes"
+                regexp = "^(DAILY|(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN))*)$", message = "daysOfWeek must be 'DAILY' or a comma-separated list of MON,TUE,WED,THU,FRI,SAT,SUN"
         ) String daysOfWeek,
         LocalDate startDate,
         LocalDate endDate

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleUpdateRequest.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.ppiyaki.medication.controller.dto;
+
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record ScheduleUpdateRequest(
+        LocalTime scheduledTime,
+        String dosage,
+        @Pattern(
+                regexp = "^(DAILY|(?:MON|TUE|WED|THU|FRI|SAT|SUN)(?:,(?:MON|TUE|WED|THU|FRI|SAT|SUN))*)$",
+                message = "daysOfWeek must be DAILY or comma-separated weekday codes"
+        ) String daysOfWeek,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+}

--- a/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
@@ -1,9 +1,12 @@
 package com.ppiyaki.medication.repository;
 
 import com.ppiyaki.medication.MedicationSchedule;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MedicationScheduleRepository extends JpaRepository<MedicationSchedule, Long> {
+
+    List<MedicationSchedule> findByMedicineId(final Long medicineId);
 
     int deleteByMedicineId(final Long medicineId);
 }

--- a/src/main/java/com/ppiyaki/medication/service/MedicationScheduleService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationScheduleService.java
@@ -1,0 +1,168 @@
+package com.ppiyaki.medication.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.controller.dto.ScheduleCreateRequest;
+import com.ppiyaki.medication.controller.dto.ScheduleResponse;
+import com.ppiyaki.medication.controller.dto.ScheduleUpdateRequest;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MedicationScheduleService {
+
+    private final MedicationScheduleRepository medicationScheduleRepository;
+    private final MedicineRepository medicineRepository;
+    private final CareRelationRepository careRelationRepository;
+
+    public MedicationScheduleService(
+            final MedicationScheduleRepository medicationScheduleRepository,
+            final MedicineRepository medicineRepository,
+            final CareRelationRepository careRelationRepository
+    ) {
+        this.medicationScheduleRepository = Objects.requireNonNull(
+                medicationScheduleRepository, "medicationScheduleRepository must not be null");
+        this.medicineRepository = Objects.requireNonNull(
+                medicineRepository, "medicineRepository must not be null");
+        this.careRelationRepository = Objects.requireNonNull(
+                careRelationRepository, "careRelationRepository must not be null");
+    }
+
+    @Transactional
+    public ScheduleResponse create(
+            final Long userId,
+            final Long medicineId,
+            final ScheduleCreateRequest scheduleCreateRequest
+    ) {
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(medicineId, "medicineId must not be null");
+        Objects.requireNonNull(scheduleCreateRequest, "scheduleCreateRequest must not be null");
+
+        final Medicine medicine = findMedicineAndValidateAccess(userId, medicineId);
+
+        final String daysOfWeek = scheduleCreateRequest.daysOfWeek() != null
+                ? scheduleCreateRequest.daysOfWeek() : "DAILY";
+        final LocalDate startDate = scheduleCreateRequest.startDate() != null
+                ? scheduleCreateRequest.startDate() : LocalDate.now();
+
+        final MedicationSchedule schedule = new MedicationSchedule(
+                medicine.getId(),
+                scheduleCreateRequest.scheduledTime(),
+                scheduleCreateRequest.dosage(),
+                daysOfWeek,
+                startDate,
+                scheduleCreateRequest.endDate()
+        );
+
+        final MedicationSchedule savedSchedule = medicationScheduleRepository.save(schedule);
+        return ScheduleResponse.from(savedSchedule);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ScheduleResponse> readAll(final Long userId, final Long medicineId) {
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(medicineId, "medicineId must not be null");
+
+        findMedicineAndValidateAccess(userId, medicineId);
+
+        final List<MedicationSchedule> schedules = medicationScheduleRepository.findByMedicineId(medicineId);
+        return schedules.stream()
+                .map(ScheduleResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ScheduleResponse readById(
+            final Long userId,
+            final Long medicineId,
+            final Long scheduleId
+    ) {
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(medicineId, "medicineId must not be null");
+        Objects.requireNonNull(scheduleId, "scheduleId must not be null");
+
+        findMedicineAndValidateAccess(userId, medicineId);
+        final MedicationSchedule schedule = findScheduleAndValidateMedicine(scheduleId, medicineId);
+
+        return ScheduleResponse.from(schedule);
+    }
+
+    @Transactional
+    public ScheduleResponse update(
+            final Long userId,
+            final Long medicineId,
+            final Long scheduleId,
+            final ScheduleUpdateRequest scheduleUpdateRequest
+    ) {
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(medicineId, "medicineId must not be null");
+        Objects.requireNonNull(scheduleId, "scheduleId must not be null");
+        Objects.requireNonNull(scheduleUpdateRequest, "scheduleUpdateRequest must not be null");
+
+        findMedicineAndValidateAccess(userId, medicineId);
+        final MedicationSchedule schedule = findScheduleAndValidateMedicine(scheduleId, medicineId);
+
+        schedule.update(
+                scheduleUpdateRequest.scheduledTime(),
+                scheduleUpdateRequest.dosage(),
+                scheduleUpdateRequest.daysOfWeek(),
+                scheduleUpdateRequest.startDate(),
+                scheduleUpdateRequest.endDate()
+        );
+
+        return ScheduleResponse.from(schedule);
+    }
+
+    @Transactional
+    public void delete(
+            final Long userId,
+            final Long medicineId,
+            final Long scheduleId
+    ) {
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(medicineId, "medicineId must not be null");
+        Objects.requireNonNull(scheduleId, "scheduleId must not be null");
+
+        findMedicineAndValidateAccess(userId, medicineId);
+        final MedicationSchedule schedule = findScheduleAndValidateMedicine(scheduleId, medicineId);
+
+        medicationScheduleRepository.delete(schedule);
+    }
+
+    private Medicine findMedicineAndValidateAccess(final Long userId, final Long medicineId) {
+        final Medicine medicine = medicineRepository.findById(medicineId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.MEDICINE_NOT_FOUND, "Medicine not found: " + medicineId));
+
+        final Long ownerId = medicine.getOwnerId();
+        if (!userId.equals(ownerId)) {
+            careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(userId, ownerId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+        }
+
+        return medicine;
+    }
+
+    private MedicationSchedule findScheduleAndValidateMedicine(
+            final Long scheduleId,
+            final Long medicineId
+    ) {
+        final MedicationSchedule schedule = medicationScheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.SCHEDULE_NOT_FOUND, "Schedule not found: " + scheduleId));
+
+        if (!schedule.getMedicineId().equals(medicineId)) {
+            throw new BusinessException(ErrorCode.SCHEDULE_MEDICINE_MISMATCH);
+        }
+
+        return schedule;
+    }
+}

--- a/src/main/java/com/ppiyaki/user/repository/CareRelationRepository.java
+++ b/src/main/java/com/ppiyaki/user/repository/CareRelationRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CareRelationRepository extends JpaRepository<CareRelation, Long> {
 
     Optional<CareRelation> findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
-            Long caregiverId,
-            Long seniorId
+            final Long caregiverId,
+            final Long seniorId
     );
 }

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
@@ -1,24 +1,15 @@
 package com.ppiyaki.medication.controller;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,16 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
-        "kakao.client-id=test-client-id",
-        "kakao.client-secret=test-client-secret",
-        "kakao.token-uri=http://localhost:19879/oauth/token",
-        "kakao.user-info-uri=http://localhost:19879/v2/user/me"
-})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class MedicationScheduleControllerE2ETest {
-
-    private static final int WIREMOCK_PORT = 19879;
-    private static WireMockServer wireMockServer;
 
     @LocalServerPort
     private int port;
@@ -46,24 +29,11 @@ class MedicationScheduleControllerE2ETest {
     @Autowired
     private CareRelationRepository careRelationRepository;
 
-    private static long kakaoIdSequence = 400000L;
-
-    @BeforeAll
-    static void startWireMock() {
-        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().port(WIREMOCK_PORT));
-        wireMockServer.start();
-    }
-
-    @AfterAll
-    static void stopWireMock() {
-        wireMockServer.stop();
-    }
+    private static long userSequence = 400000L;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
-        wireMockServer.resetAll();
-        stubKakaoTokenEndpoint();
     }
 
     @Test
@@ -245,19 +215,18 @@ class MedicationScheduleControllerE2ETest {
     }
 
     private String loginAsNewUser(final String nickname) {
-        final long kakaoId = kakaoIdSequence++;
-        stubKakaoUserInfoEndpoint(kakaoId, nickname);
-
+        final String loginId = "scheduletest" + userSequence++;
         return RestAssured.given()
                 .contentType(ContentType.JSON)
                 .body("""
                         {
-                            "code": "test-auth-code",
-                            "redirectUri": "http://localhost/callback"
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
                         }
-                        """)
+                        """.formatted(loginId, nickname))
                 .when()
-                .post("/api/v1/auth/kakao")
+                .post("/api/v1/auth/signup")
                 .then()
                 .extract()
                 .path("accessToken");
@@ -303,37 +272,5 @@ class MedicationScheduleControllerE2ETest {
                 .then()
                 .extract()
                 .path("id");
-    }
-
-    private void stubKakaoTokenEndpoint() {
-        wireMockServer.stubFor(post(urlPathEqualTo("/oauth/token"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody("""
-                                {
-                                    "access_token": "kakao-access-token-mock",
-                                    "token_type": "bearer",
-                                    "expires_in": 3600
-                                }
-                                """)));
-    }
-
-    private void stubKakaoUserInfoEndpoint(final Long kakaoId, final String nickname) {
-        wireMockServer.stubFor(get(urlPathEqualTo("/v2/user/me"))
-                .withHeader("Authorization", equalTo("Bearer kakao-access-token-mock"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody("""
-                                {
-                                    "id": %d,
-                                    "kakao_account": {
-                                        "profile": {
-                                            "nickname": "%s"
-                                        }
-                                    }
-                                }
-                                """.formatted(kakaoId, nickname))));
     }
 }

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
@@ -13,6 +13,8 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.repository.CareRelationRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.AfterAll;
@@ -40,6 +42,9 @@ class MedicationScheduleControllerE2ETest {
 
     @Autowired
     private MedicineRepository medicineRepository;
+
+    @Autowired
+    private CareRelationRepository careRelationRepository;
 
     private static long kakaoIdSequence = 400000L;
 
@@ -173,6 +178,48 @@ class MedicationScheduleControllerE2ETest {
     }
 
     @Test
+    @DisplayName("연동된 보호자는 시니어 약물에 대한 일정 등록/조회에 성공한다")
+    void caregiver_canAccessSeniorSchedules() {
+        // given
+        final String seniorToken = loginAsNewUser("시니어");
+        final Long seniorUserId = readUserId(seniorToken);
+        final Integer medicineId = createMedicine(seniorToken, "시니어약", 30, 20);
+
+        final String caregiverToken = loginAsNewUser("보호자");
+        final Long caregiverUserId = readUserId(caregiverToken);
+
+        careRelationRepository.save(new CareRelation(seniorUserId, caregiverUserId, "INVITE"));
+
+        // when & then: caregiver create
+        final Integer scheduleId = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + caregiverToken)
+                .body("""
+                        {
+                            "scheduledTime": "07:30",
+                            "dosage": "1정",
+                            "daysOfWeek": "DAILY"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/medicines/" + medicineId + "/schedules")
+                .then()
+                .statusCode(201)
+                .body("medicineId", is(medicineId))
+                .extract()
+                .path("id");
+
+        // and: caregiver can read it back
+        RestAssured.given()
+                .header("Authorization", "Bearer " + caregiverToken)
+                .when()
+                .get("/api/v1/medicines/" + medicineId + "/schedules/" + scheduleId)
+                .then()
+                .statusCode(200)
+                .body("dosage", is("1정"));
+    }
+
+    @Test
     @DisplayName("다른 사용자의 약물에 일정 등록 시 403 응답")
     void create_forbidden() {
         // given
@@ -218,6 +265,14 @@ class MedicationScheduleControllerE2ETest {
 
     private Integer createMedicine(final String token, final String name,
             final int totalAmount, final int remainingAmount) {
+        final Long userId = readUserId(token);
+
+        final Medicine medicine = medicineRepository.save(
+                new Medicine(userId, null, name, totalAmount, remainingAmount, null));
+        return medicine.getId().intValue();
+    }
+
+    private Long readUserId(final String token) {
         final Integer userId = RestAssured.given()
                 .header("Authorization", "Bearer " + token)
                 .when()
@@ -225,10 +280,7 @@ class MedicationScheduleControllerE2ETest {
                 .then()
                 .extract()
                 .path("id");
-
-        final Medicine medicine = medicineRepository.save(
-                new Medicine(Long.valueOf(userId), null, name, totalAmount, remainingAmount, null));
-        return medicine.getId().intValue();
+        return Long.valueOf(userId);
     }
 
     private Integer createSchedule(

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
@@ -1,0 +1,287 @@
+package com.ppiyaki.medication.controller;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "kakao.client-id=test-client-id",
+        "kakao.client-secret=test-client-secret",
+        "kakao.token-uri=http://localhost:19879/oauth/token",
+        "kakao.user-info-uri=http://localhost:19879/v2/user/me"
+})
+class MedicationScheduleControllerE2ETest {
+
+    private static final int WIREMOCK_PORT = 19879;
+    private static WireMockServer wireMockServer;
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MedicineRepository medicineRepository;
+
+    private static long kakaoIdSequence = 400000L;
+
+    @BeforeAll
+    static void startWireMock() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().port(WIREMOCK_PORT));
+        wireMockServer.start();
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        wireMockServer.stop();
+    }
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        wireMockServer.resetAll();
+        stubKakaoTokenEndpoint();
+    }
+
+    @Test
+    @DisplayName("복약 일정 등록 시 201 응답과 생성된 일정 정보를 반환한다")
+    void create_success() {
+        // given
+        final String token = loginAsNewUser("일정등록유저");
+        final Integer medicineId = createMedicine(token, "타이레놀정", 30, 25);
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body("""
+                        {
+                            "scheduledTime": "08:00",
+                            "dosage": "1정",
+                            "daysOfWeek": "DAILY",
+                            "startDate": "2026-04-11"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/medicines/" + medicineId + "/schedules")
+                .then()
+                .statusCode(201)
+                .body("id", notNullValue())
+                .body("medicineId", is(medicineId))
+                .body("scheduledTime", is("08:00:00"))
+                .body("dosage", is("1정"))
+                .body("daysOfWeek", is("DAILY"));
+    }
+
+    @Test
+    @DisplayName("약물의 복약 일정 목록을 조회한다")
+    void readAll_success() {
+        // given
+        final String token = loginAsNewUser("목록유저");
+        final Integer medicineId = createMedicine(token, "비타민C", 60, 50);
+        createSchedule(token, medicineId, "08:00", "1정");
+        createSchedule(token, medicineId, "20:00", "1정");
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/medicines/" + medicineId + "/schedules")
+                .then()
+                .statusCode(200)
+                .body("responses", hasSize(2));
+    }
+
+    @Test
+    @DisplayName("복약 일정 상세 조회에 성공한다")
+    void readById_success() {
+        // given
+        final String token = loginAsNewUser("상세유저");
+        final Integer medicineId = createMedicine(token, "오메가3", 90, 80);
+        final Integer scheduleId = createSchedule(token, medicineId, "09:00", "2정");
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/medicines/" + medicineId + "/schedules/" + scheduleId)
+                .then()
+                .statusCode(200)
+                .body("dosage", is("2정"))
+                .body("scheduledTime", is("09:00:00"));
+    }
+
+    @Test
+    @DisplayName("복약 일정을 수정한다")
+    void update_success() {
+        // given
+        final String token = loginAsNewUser("수정유저");
+        final Integer medicineId = createMedicine(token, "아스피린", 20, 15);
+        final Integer scheduleId = createSchedule(token, medicineId, "08:00", "1정");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body("""
+                        {
+                            "scheduledTime": "09:30",
+                            "dosage": "2정"
+                        }
+                        """)
+                .when()
+                .patch("/api/v1/medicines/" + medicineId + "/schedules/" + scheduleId)
+                .then()
+                .statusCode(200)
+                .body("scheduledTime", is("09:30:00"))
+                .body("dosage", is("2정"));
+    }
+
+    @Test
+    @DisplayName("복약 일정을 삭제한다")
+    void delete_success() {
+        // given
+        final String token = loginAsNewUser("삭제유저");
+        final Integer medicineId = createMedicine(token, "삭제약", 10, 5);
+        final Integer scheduleId = createSchedule(token, medicineId, "12:00", "1정");
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .delete("/api/v1/medicines/" + medicineId + "/schedules/" + scheduleId)
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 약물에 일정 등록 시 403 응답")
+    void create_forbidden() {
+        // given
+        final String ownerToken = loginAsNewUser("소유자");
+        final Integer medicineId = createMedicine(ownerToken, "소유자약", 10, 5);
+
+        final String otherToken = loginAsNewUser("다른유저");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + otherToken)
+                .body("""
+                        {
+                            "scheduledTime": "08:00",
+                            "dosage": "1정"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/medicines/" + medicineId + "/schedules")
+                .then()
+                .statusCode(403);
+    }
+
+    private String loginAsNewUser(final String nickname) {
+        final long kakaoId = kakaoIdSequence++;
+        stubKakaoUserInfoEndpoint(kakaoId, nickname);
+
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "code": "test-auth-code",
+                            "redirectUri": "http://localhost/callback"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/kakao")
+                .then()
+                .extract()
+                .path("accessToken");
+    }
+
+    private Integer createMedicine(final String token, final String name,
+            final int totalAmount, final int remainingAmount) {
+        final Integer userId = RestAssured.given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/users/me")
+                .then()
+                .extract()
+                .path("id");
+
+        final Medicine medicine = medicineRepository.save(
+                new Medicine(Long.valueOf(userId), null, name, totalAmount, remainingAmount, null));
+        return medicine.getId().intValue();
+    }
+
+    private Integer createSchedule(
+            final String token,
+            final Integer medicineId,
+            final String time,
+            final String dosage
+    ) {
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body("""
+                        {
+                            "scheduledTime": "%s",
+                            "dosage": "%s"
+                        }
+                        """.formatted(time, dosage))
+                .when()
+                .post("/api/v1/medicines/" + medicineId + "/schedules")
+                .then()
+                .extract()
+                .path("id");
+    }
+
+    private void stubKakaoTokenEndpoint() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/oauth/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                    "access_token": "kakao-access-token-mock",
+                                    "token_type": "bearer",
+                                    "expires_in": 3600
+                                }
+                                """)));
+    }
+
+    private void stubKakaoUserInfoEndpoint(final Long kakaoId, final String nickname) {
+        wireMockServer.stubFor(get(urlPathEqualTo("/v2/user/me"))
+                .withHeader("Authorization", equalTo("Bearer kakao-access-token-mock"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                    "id": %d,
+                                    "kakao_account": {
+                                        "profile": {
+                                            "nickname": "%s"
+                                        }
+                                    }
+                                }
+                                """.formatted(kakaoId, nickname))));
+    }
+}


### PR DESCRIPTION
## Summary
- 약물에 대한 복약 일정 CRUD 5개 엔드포인트 구현
- 중첩 URI: `/api/v1/medicines/{medicineId}/schedules`
- medicine 소유자 기반 접근 검증 (본인 + care_relations 보호자)
- Feature Spec `docs/features/medication-schedule-crud.md` 작성

## 엔드포인트
- `POST /api/v1/medicines/{id}/schedules` — 일정 등록 (201)
- `GET /api/v1/medicines/{id}/schedules` — 목록 조회 (200)
- `GET /api/v1/medicines/{id}/schedules/{sid}` — 상세 조회 (200)
- `PATCH /api/v1/medicines/{id}/schedules/{sid}` — 수정 (200)
- `DELETE /api/v1/medicines/{id}/schedules/{sid}` — 삭제 (204)

## Test plan
- [x] 일정 등록 → 201 + 응답 검증
- [x] 목록 조회 → 200 + 해당 약물 일정만 반환
- [x] 상세 조회 → 200
- [x] 수정 → 200 + 변경된 필드 검증
- [x] 삭제 → 204
- [x] 다른 사용자의 약물에 일정 등록 → 403
- [x] Feature Spec §3 기능 요구사항 전수 검증 완료
- [x] `./gradlew checkstyleMain spotlessCheck test` 통과

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 약물별 복용 일정 CRUD API 추가 — 인증된 사용자가 일정 생성·조회·수정·삭제 가능
  * 약물 소유자 및 보호자(케어기버) 접근 제어 지원

* **문서**
  * 약물 복용 일정 CRUD 기능 문서화 및 관련 에러 코드(SCHEDULE_001, SCHEDULE_002) 추가

* **테스트**
  * 일정 관리 기능에 대한 엔드투엔드(E2E) 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->