### PR TITLE
fix(infra): CD 배포 시 JWT/KAKAO 환경변수 누락 수정

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -66,6 +66,8 @@ jobs:
               -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \
               -e DB_PASSWORD='${{ secrets.DB_PASSWORD }}' \
               -e JPA_DDL_AUTO='${{ secrets.JPA_DDL_AUTO }}' \
+              -e JWT_SECRET='${{ secrets.JWT_SECRET }}' \
+              -e KAKAO_OIDC_AUDIENCE='${{ secrets.KAKAO_OIDC_AUDIENCE }}' \
               ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
             
             echo "Cleaning up old images..."


### PR DESCRIPTION
## AS-IS
- `backend-cd.yml`의 `docker run`에서 `JWT_SECRET`, `KAKAO_OIDC_AUDIENCE` 환경변수를 컨테이너에 전달하지 않음
- 운영 서버가 `application.yml`의 기본값(`local-dev-secret-key...`, `local-kakao-app-key`)으로 기동
- 카카오 로그인 시 aud 불일치로 401 에러 발생

## TO-BE
- `docker run -e`에 `JWT_SECRET`, `KAKAO_OIDC_AUDIENCE` 추가
- GitHub Secrets에 등록된 값이 컨테이너에 정상 주입

## AI 자기 점검
- [x] 보호 영역 변경: `.github/workflows/**` → `needs-human-review` 라벨 부여 필요
- [x] 품질 게이트: 코드 변경 없음 (YAML만 수정)
- [x] Notion API 명세: 해당 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로덕션 배포 환경 설정을 개선하여 보안 및 인증 구성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->