### PR TITLE
refactor(infra): 중간 null 가드 지양 규약 신설 및 common.auth 적용

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@
 - 엔티티는 `@NoArgsConstructor(access = AccessLevel.PROTECTED)` + `@AllArgsConstructor(access = AccessLevel.PACKAGE)` 조합 (PROTECTED no-args는 Hibernate 프록시 호환을 위해 필수)
 - Lombok: `@Data`/`@Setter` 금지. `@Getter`/`@NoArgsConstructor`/`@RequiredArgsConstructor`는 적극 사용
 - **null 검증은 DTO와 Domain 둘 다 수행**. Domain은 매개변수의 모든 값에 대해 `Objects.requireNonNull`
+- **Service/Controller 중간 null 가드 금지** (§6-3). 메서드 파라미터·DI 생성자 모두 `Objects.requireNonNull` 두지 않음. 예외: `application.yml` 바인딩 설정 값은 부트 fail-fast 목적으로 유지
 - 테스트는 BDD 스타일(`given/when/then`), **신규 엔드포인트는 성공 케이스 E2E(RestAssured) 필수**
 
 ### 도메인 / DDD

--- a/docs/ai-harness/08-code-conventions.md
+++ b/docs/ai-harness/08-code-conventions.md
@@ -135,6 +135,12 @@ public static Member create(final String loginId, final String nickname) {
 
 - "DTO에서 검증했으니 Domain은 생략"은 허용하지 않는다. Domain 객체는 **자체 불변식을 스스로** 지켜야 한다.
 
+### 6-3) Service/Controller/Config 중간 가드 지양
+- **Service/Controller 메서드 파라미터**에 대한 `Objects.requireNonNull` 가드는 **두지 않는다**.
+- **Service/Controller 생성자의 DI 주입 의존성**에도 `Objects.requireNonNull` 가드를 두지 않는다. Spring이 빈을 찾지 못하면 `NoSuchBeanDefinitionException`으로 부트 실패하므로 실행될 일이 없는 unreachable 코드다.
+- **`@ConfigurationProperties` 바인딩 레코드의 필드**는 수동 `Objects.requireNonNull` 대신 `@Validated` + `@NotBlank`/`@NotNull`/`@Positive` 등 **Bean Validation 어노테이션으로 선언적으로 검증**한다. 바인딩 실패 시 `BindValidationException`으로 부트 시점에 자동 fail-fast된다.
+- 근거: Controller 진입 시점에 DTO는 `@Valid`/`@NotBlank`, `@PathVariable`/`@AuthenticationPrincipal`은 프레임워크가 non-null을 보장하고, DI는 Spring이 보장하며, Domain 생성자/팩토리에서 최종 검증이 이루어진다. 중간 가드는 가독성만 해친다.
+
 ## 7) 오픈 항목 (컨벤션 미결)
 
 | # | 주제 | 상태 |

--- a/src/main/java/com/ppiyaki/PpiyakiApplication.java
+++ b/src/main/java/com/ppiyaki/PpiyakiApplication.java
@@ -2,10 +2,12 @@ package com.ppiyaki;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class PpiyakiApplication {
 
     public static void main(final String[] args) {

--- a/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -21,7 +20,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
 
     public JwtAuthenticationFilter(final JwtProvider jwtProvider) {
-        this.jwtProvider = Objects.requireNonNull(jwtProvider, "jwtProvider must not be null");
+        this.jwtProvider = jwtProvider;
     }
 
     @Override

--- a/src/main/java/com/ppiyaki/common/auth/JwtProperties.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtProperties.java
@@ -1,11 +1,15 @@
 package com.ppiyaki.common.auth;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 @ConfigurationProperties(prefix = "jwt")
 public record JwtProperties(
-        String secret,
-        long accessTokenExpiry,
-        long refreshTokenExpiry
+        @NotBlank String secret,
+        @Positive long accessTokenExpiry,
+        @Positive long refreshTokenExpiry
 ) {
 }

--- a/src/main/java/com/ppiyaki/common/auth/JwtProvider.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtProvider.java
@@ -6,7 +6,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
-import java.util.Objects;
 import javax.crypto.SecretKey;
 import org.springframework.stereotype.Component;
 
@@ -18,25 +17,20 @@ public class JwtProvider {
     private final long refreshTokenExpiry;
 
     public JwtProvider(final JwtProperties jwtProperties) {
-        Objects.requireNonNull(jwtProperties, "jwtProperties must not be null");
-        Objects.requireNonNull(jwtProperties.secret(), "jwt secret must not be null");
         this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
         this.accessTokenExpiry = jwtProperties.accessTokenExpiry();
         this.refreshTokenExpiry = jwtProperties.refreshTokenExpiry();
     }
 
     public String createAccessToken(final Long userId) {
-        Objects.requireNonNull(userId, "userId must not be null");
         return createToken(userId, accessTokenExpiry);
     }
 
     public String createRefreshToken(final Long userId) {
-        Objects.requireNonNull(userId, "userId must not be null");
         return createToken(userId, refreshTokenExpiry);
     }
 
     public Long extractUserId(final String token) {
-        Objects.requireNonNull(token, "token must not be null");
         final Claims claims = parseClaims(token);
         return claims.get("userId", Long.class);
     }

--- a/src/main/java/com/ppiyaki/common/auth/KakaoIdTokenVerifier.java
+++ b/src/main/java/com/ppiyaki/common/auth/KakaoIdTokenVerifier.java
@@ -20,14 +20,11 @@ import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 @Component
-@EnableConfigurationProperties(KakaoOidcProperties.class)
 public class KakaoIdTokenVerifier {
 
     private static final String RSA_KEY_TYPE = "RSA";
@@ -40,12 +37,6 @@ public class KakaoIdTokenVerifier {
 
     public KakaoIdTokenVerifier(final KakaoOidcProperties properties,
             final RestClient.Builder restClientBuilder) {
-        Objects.requireNonNull(properties, "properties must not be null");
-        Objects.requireNonNull(properties.issuer(), "kakao.oidc.issuer must not be null");
-        Objects.requireNonNull(properties.jwksUri(), "kakao.oidc.jwks-uri must not be null");
-        Objects.requireNonNull(properties.audience(), "kakao.oidc.audience must not be null");
-        Objects.requireNonNull(restClientBuilder, "restClientBuilder must not be null");
-
         this.properties = properties;
         this.restClient = restClientBuilder.build();
         this.objectMapper = new ObjectMapper();
@@ -90,7 +81,7 @@ public class KakaoIdTokenVerifier {
     }
 
     private Key resolveKey(final Header header) {
-        if (!(header instanceof JwsHeader jwsHeader)) {
+        if (!(header instanceof final JwsHeader jwsHeader)) {
             throw new SignatureException("not a JWS header");
         }
         final String kid = jwsHeader.getKeyId();

--- a/src/main/java/com/ppiyaki/common/auth/KakaoOidcProperties.java
+++ b/src/main/java/com/ppiyaki/common/auth/KakaoOidcProperties.java
@@ -1,11 +1,14 @@
 package com.ppiyaki.common.auth;
 
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 @ConfigurationProperties(prefix = "kakao.oidc")
 public record KakaoOidcProperties(
-        String issuer,
-        String jwksUri,
-        String audience
+        @NotBlank String issuer,
+        @NotBlank String jwksUri,
+        @NotBlank String audience
 ) {
 }

--- a/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
+++ b/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.ppiyaki.common.auth;
 
-import java.util.Objects;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
@@ -16,14 +14,12 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     public SecurityConfig(final JwtAuthenticationFilter jwtAuthenticationFilter) {
-        this.jwtAuthenticationFilter = Objects.requireNonNull(
-                jwtAuthenticationFilter, "jwtAuthenticationFilter must not be null");
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
     }
 
     @Bean


### PR DESCRIPTION
Closes #122

## AS-IS
- `Objects.requireNonNull`이 Service/Controller 메서드 파라미터, DI 주입 생성자, `@ConfigurationProperties` 값에까지 기계적으로 적용되어 unreachable 방어 코드가 다수 존재
- CLAUDE.md §4 / `08-code-conventions.md §6`은 DTO + Domain 2중 차단만 규정. Service/Controller/설정 영역은 규약 범위 밖이라 해석이 분분
- `KakaoIdTokenVerifier`(`@Component`)에 `@EnableConfigurationProperties`가 붙어 기능 빈과 설정 책임이 섞임

## TO-BE
### 규약 신설
- `docs/ai-harness/08-code-conventions.md §6-3` 신설: Service/Controller/Config 중간 가드 지양
- `CLAUDE.md §4` 요약에 §6-3 포인터 추가

### common.auth 적용
- `JwtProvider`, `JwtAuthenticationFilter`, `SecurityConfig`, `KakaoIdTokenVerifier`의 DI 생성자·메서드 파라미터 `Objects.requireNonNull` 제거
- `JwtProperties`, `KakaoOidcProperties`: 수동 `Objects.requireNonNull` 대신 `@Validated` + `@NotBlank`/`@Positive`로 선언적 검증 전환

### `@ConfigurationPropertiesScan` 마이그레이션
- `PpiyakiApplication`에 `@ConfigurationPropertiesScan` 추가
- `SecurityConfig`, `KakaoIdTokenVerifier`의 `@EnableConfigurationProperties` 제거 (기능 빈과 설정 책임 분리)

## 근거
- Spring DI는 빈 미발견 시 `NoSuchBeanDefinitionException`으로 부트 실패 → DI 가드 unreachable
- `@ConfigurationProperties` 바인딩 레코드는 `@Validated`로 부트 시점 자동 검증 가능 → 수동 guard 불필요
- Domain 생성자에서 최종 null 검증은 기존대로 유지 (컨벤션상 필수)

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅ BUILD SUCCESSFUL

## 선행/후속
- 본 PR이 신설한 §6-3 규약을 도메인(user, medicine)에 적용하는 작업은 후속 PR에서 진행

---

### AI 체크리스트
- [x] type:refactor 라벨
- [x] scope:infra 라벨
- [x] ai-generated 라벨
- [x] API 엔드포인트 변경 없음 → Notion API 명세 갱신 불필요