### PR TITLE
refactor(user, medicine): Service/Controller 중간 null 가드 제거

### DIFF
--- a/src/main/java/com/ppiyaki/medicine/controller/MedicineController.java
+++ b/src/main/java/com/ppiyaki/medicine/controller/MedicineController.java
@@ -8,7 +8,6 @@ import com.ppiyaki.medicine.controller.dto.MedicineUpdateRequest;
 import com.ppiyaki.medicine.service.MedicineService;
 import jakarta.validation.Valid;
 import java.util.List;
-import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,7 +28,7 @@ public class MedicineController {
     private final MedicineService medicineService;
 
     public MedicineController(final MedicineService medicineService) {
-        this.medicineService = Objects.requireNonNull(medicineService, "medicineService must not be null");
+        this.medicineService = medicineService;
     }
 
     @PostMapping

--- a/src/main/java/com/ppiyaki/medicine/service/MedicineService.java
+++ b/src/main/java/com/ppiyaki/medicine/service/MedicineService.java
@@ -14,7 +14,6 @@ import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.util.List;
-import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,21 +31,14 @@ public class MedicineService {
             final UserRepository userRepository,
             final CareRelationRepository careRelationRepository
     ) {
-        this.medicineRepository = Objects.requireNonNull(medicineRepository,
-                "medicineRepository must not be null");
-        this.medicationScheduleRepository = Objects.requireNonNull(medicationScheduleRepository,
-                "medicationScheduleRepository must not be null");
-        this.userRepository = Objects.requireNonNull(userRepository,
-                "userRepository must not be null");
-        this.careRelationRepository = Objects.requireNonNull(careRelationRepository,
-                "careRelationRepository must not be null");
+        this.medicineRepository = medicineRepository;
+        this.medicationScheduleRepository = medicationScheduleRepository;
+        this.userRepository = userRepository;
+        this.careRelationRepository = careRelationRepository;
     }
 
     @Transactional
     public MedicineResponse create(final Long userId, final MedicineCreateRequest medicineCreateRequest) {
-        Objects.requireNonNull(userId, "userId must not be null");
-        Objects.requireNonNull(medicineCreateRequest, "medicineCreateRequest must not be null");
-
         final Long ownerId = resolveOwnerId(userId, medicineCreateRequest.seniorId());
 
         final Medicine medicine = new Medicine(
@@ -64,8 +56,6 @@ public class MedicineService {
 
     @Transactional(readOnly = true)
     public List<MedicineResponse> readAll(final Long userId, final Long seniorId) {
-        Objects.requireNonNull(userId, "userId must not be null");
-
         final Long ownerId = resolveOwnerIdForRead(userId, seniorId);
 
         final List<Medicine> medicines = medicineRepository.findByOwnerId(ownerId);
@@ -76,9 +66,6 @@ public class MedicineService {
 
     @Transactional(readOnly = true)
     public MedicineResponse readById(final Long userId, final Long medicineId) {
-        Objects.requireNonNull(userId, "userId must not be null");
-        Objects.requireNonNull(medicineId, "medicineId must not be null");
-
         final Medicine medicine = findMedicineById(medicineId);
         validateAccess(userId, medicine.getOwnerId());
 
@@ -91,10 +78,6 @@ public class MedicineService {
             final Long medicineId,
             final MedicineUpdateRequest medicineUpdateRequest
     ) {
-        Objects.requireNonNull(userId, "userId must not be null");
-        Objects.requireNonNull(medicineId, "medicineId must not be null");
-        Objects.requireNonNull(medicineUpdateRequest, "medicineUpdateRequest must not be null");
-
         final Medicine medicine = findMedicineById(medicineId);
         validateAccess(userId, medicine.getOwnerId());
 
@@ -110,9 +93,6 @@ public class MedicineService {
 
     @Transactional
     public MedicineDeleteResponse delete(final Long userId, final Long medicineId) {
-        Objects.requireNonNull(userId, "userId must not be null");
-        Objects.requireNonNull(medicineId, "medicineId must not be null");
-
         final Medicine medicine = findMedicineById(medicineId);
         validateAccess(userId, medicine.getOwnerId());
 

--- a/src/main/java/com/ppiyaki/user/controller/AuthController.java
+++ b/src/main/java/com/ppiyaki/user/controller/AuthController.java
@@ -11,7 +11,6 @@ import com.ppiyaki.user.controller.dto.TokenResponse;
 import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.service.AuthService;
 import jakarta.validation.Valid;
-import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,7 +27,7 @@ public class AuthController {
     private final AuthService authService;
 
     public AuthController(final AuthService authService) {
-        this.authService = Objects.requireNonNull(authService, "authService must not be null");
+        this.authService = authService;
     }
 
     @PostMapping("/auth/signup")

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -19,7 +19,6 @@ import com.ppiyaki.user.repository.OAuthIdentityRepository;
 import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDateTime;
-import java.util.Objects;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -45,22 +44,17 @@ public class AuthService {
             final OAuthIdentityRepository oAuthIdentityRepository,
             final RefreshTokenRepository refreshTokenRepository
     ) {
-        this.kakaoIdTokenVerifier = Objects.requireNonNull(kakaoIdTokenVerifier,
-                "kakaoIdTokenVerifier must not be null");
-        this.jwtProvider = Objects.requireNonNull(jwtProvider, "jwtProvider must not be null");
-        this.jwtProperties = Objects.requireNonNull(jwtProperties, "jwtProperties must not be null");
-        this.passwordEncoder = Objects.requireNonNull(passwordEncoder, "passwordEncoder must not be null");
-        this.userRepository = Objects.requireNonNull(userRepository, "userRepository must not be null");
-        this.oAuthIdentityRepository = Objects.requireNonNull(oAuthIdentityRepository,
-                "oAuthIdentityRepository must not be null");
-        this.refreshTokenRepository = Objects.requireNonNull(refreshTokenRepository,
-                "refreshTokenRepository must not be null");
+        this.kakaoIdTokenVerifier = kakaoIdTokenVerifier;
+        this.jwtProvider = jwtProvider;
+        this.jwtProperties = jwtProperties;
+        this.passwordEncoder = passwordEncoder;
+        this.userRepository = userRepository;
+        this.oAuthIdentityRepository = oAuthIdentityRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
     }
 
     @Transactional
     public LoginResponse loginWithKakao(final KakaoLoginRequest kakaoLoginRequest) {
-        Objects.requireNonNull(kakaoLoginRequest, "kakaoLoginRequest must not be null");
-
         final KakaoIdTokenPayload payload = kakaoIdTokenVerifier.verify(kakaoLoginRequest.idToken());
 
         final String providerUserId = payload.sub();
@@ -80,8 +74,6 @@ public class AuthService {
 
     @Transactional
     public LoginResponse signup(final SignupRequest signupRequest) {
-        Objects.requireNonNull(signupRequest, "signupRequest must not be null");
-
         if (userRepository.existsByLoginId(signupRequest.loginId())) {
             throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
         }
@@ -105,8 +97,6 @@ public class AuthService {
 
     @Transactional
     public LoginResponse login(final LoginRequest loginRequest) {
-        Objects.requireNonNull(loginRequest, "loginRequest must not be null");
-
         final User user = userRepository.findByLoginId(loginRequest.loginId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS));
 
@@ -135,8 +125,6 @@ public class AuthService {
 
     @Transactional
     public TokenResponse refresh(final String refreshTokenValue) {
-        Objects.requireNonNull(refreshTokenValue, "refreshTokenValue must not be null");
-
         final RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
                 .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
 
@@ -157,14 +145,12 @@ public class AuthService {
 
     @Transactional
     public void logout(final String refreshTokenValue) {
-        Objects.requireNonNull(refreshTokenValue, "refreshTokenValue must not be null");
         refreshTokenRepository.findByToken(refreshTokenValue)
                 .ifPresent(refreshTokenRepository::delete);
     }
 
     @Transactional(readOnly = true)
     public User findUserById(final Long userId) {
-        Objects.requireNonNull(userId, "userId must not be null");
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, "User not found: " + userId));
     }


### PR DESCRIPTION
Closes #123

## AS-IS
- Service/Controller의 메서드 파라미터 및 DI 생성자에 `Objects.requireNonNull` 가드가 기계적으로 삽입되어 unreachable 방어 코드 다수

## TO-BE
- `AuthService`, `AuthController`: 메서드 파라미터 및 DI 생성자 `Objects.requireNonNull` 제거
- `MedicineService`, `MedicineController`: 동일

## 근거
- 선행 PR #126에서 신설된 `docs/ai-harness/08-code-conventions.md §6-3` 규약 적용
- DTO `@Valid`/`@NotBlank`, `@PathVariable`, `@AuthenticationPrincipal`로 상위 non-null 보장 유지
- Domain 생성자(`RefreshToken`, `Medicine`)의 `Objects.requireNonNull`은 컨벤션상 필수이므로 유지

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅ BUILD SUCCESSFUL
- 기존 E2E 테스트(`AuthControllerE2ETest`, `LocalAuthE2ETest`, `MedicineControllerE2ETest`) 전량 통과

## 선행
- #122 (규약 §6-3 신설) 머지 후 리베이스 권장

---

### AI 체크리스트
- [x] type:refactor 라벨
- [x] scope:user 라벨
- [x] scope:medicine 라벨
- [x] ai-generated 라벨
- [x] API 엔드포인트 변경 없음 → Notion API 명세 갱신 불필요