### PR TITLE
feat(infra): 글로벌 예외 처리 확장 및 ErrorResponse 포맷 일관화

### DIFF
--- a/src/main/java/com/ppiyaki/common/auth/RestAccessDeniedHandler.java
+++ b/src/main/java/com/ppiyaki/common/auth/RestAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package com.ppiyaki.common.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.exception.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAccessDeniedHandler(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final AccessDeniedException accessDeniedException
+    ) throws IOException {
+        final ErrorCode errorCode = ErrorCode.FORBIDDEN;
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(errorCode));
+    }
+}

--- a/src/main/java/com/ppiyaki/common/auth/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/ppiyaki/common/auth/RestAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.ppiyaki.common.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.exception.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAuthenticationEntryPoint(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final AuthenticationException authException
+    ) throws IOException {
+        final ErrorCode errorCode = ErrorCode.AUTH_INVALID_TOKEN;
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(errorCode));
+    }
+}

--- a/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
+++ b/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.ppiyaki.common.auth;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -10,16 +9,23 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+    private final RestAccessDeniedHandler restAccessDeniedHandler;
 
-    public SecurityConfig(final JwtAuthenticationFilter jwtAuthenticationFilter) {
+    public SecurityConfig(
+            final JwtAuthenticationFilter jwtAuthenticationFilter,
+            final RestAuthenticationEntryPoint restAuthenticationEntryPoint,
+            final RestAccessDeniedHandler restAccessDeniedHandler
+    ) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.restAuthenticationEntryPoint = restAuthenticationEntryPoint;
+        this.restAccessDeniedHandler = restAccessDeniedHandler;
     }
 
     @Bean
@@ -42,7 +48,8 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex
-                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                        .authenticationEntryPoint(restAuthenticationEntryPoint)
+                        .accessDeniedHandler(restAccessDeniedHandler)
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -6,15 +6,15 @@ public enum ErrorCode {
 
     // Common
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_001", "Invalid input"),
+    MALFORMED_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_002", "Malformed request"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_003", "Internal server error"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_004", "Access denied"),
 
     // Auth
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "Invalid token"),
-    AUTH_TOKEN_EXPIRED(
-            HttpStatus.UNAUTHORIZED, "AUTH_002", "Token expired"),
-    AUTH_DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT,
-            "AUTH_003", "Login ID already exists"),
-    AUTH_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED,
-            "AUTH_004", "Invalid login ID or password"),
+    AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_002", "Token expired"),
+    AUTH_DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "AUTH_003", "Login ID already exists"),
+    AUTH_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_004", "Invalid login ID or password"),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "User not found"),
@@ -24,10 +24,8 @@ public enum ErrorCode {
 
     // Care Relation
     CARE_RELATION_NOT_FOUND(HttpStatus.FORBIDDEN, "CARE_001", "No active care relation"),
-    CARE_RELATION_REQUIRED(
-            HttpStatus.FORBIDDEN, "CARE_002", "Caregiver must specify seniorId"),
-    CARE_RELATION_NOT_CAREGIVER(
-            HttpStatus.FORBIDDEN, "CARE_003", "Only caregivers can specify seniorId");
+    CARE_RELATION_REQUIRED(HttpStatus.FORBIDDEN, "CARE_002", "Caregiver must specify seniorId"),
+    CARE_RELATION_NOT_CAREGIVER(HttpStatus.FORBIDDEN, "CARE_003", "Only caregivers can specify seniorId");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
@@ -1,16 +1,76 @@
 package com.ppiyaki.common.exception;
 
+import jakarta.validation.ConstraintViolationException;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException exception) {
         final ErrorCode errorCode = exception.getErrorCode();
+        log.debug("BusinessException: {} - {}", errorCode.getCode(), exception.getMessage());
         final ErrorResponse errorResponse = ErrorResponse.of(errorCode, exception.getMessage());
         return ResponseEntity.status(errorCode.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(final MethodArgumentNotValidException exception) {
+        final String message = exception.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        log.debug("Validation failed: {}", message);
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT,
+                message.isBlank() ? ErrorCode.INVALID_INPUT.getMessage() : message);
+        return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(final ConstraintViolationException exception) {
+        final String message = exception.getConstraintViolations().stream()
+                .map(violation -> leafProperty(violation.getPropertyPath().toString()) + ": " + violation.getMessage())
+                .collect(Collectors.joining(", "));
+        log.debug("Constraint violation: {}", message);
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT,
+                message.isBlank() ? ErrorCode.INVALID_INPUT.getMessage() : message);
+        return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus()).body(errorResponse);
+    }
+
+    private String leafProperty(final String propertyPath) {
+        final int lastDot = propertyPath.lastIndexOf('.');
+        return lastDot < 0 ? propertyPath : propertyPath.substring(lastDot + 1);
+    }
+
+    @ExceptionHandler({HttpMessageNotReadableException.class, MethodArgumentTypeMismatchException.class})
+    public ResponseEntity<ErrorResponse> handleMalformedRequest(final Exception exception) {
+        log.debug("Malformed request: {}", exception.getMessage());
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MALFORMED_REQUEST);
+        return ResponseEntity.status(ErrorCode.MALFORMED_REQUEST.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoHandlerFound(final NoHandlerFoundException exception) {
+        log.debug("No handler found: {}", exception.getMessage());
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MALFORMED_REQUEST,
+                "No endpoint " + exception.getHttpMethod() + " " + exception.getRequestURL());
+        return ResponseEntity.status(ErrorCode.MALFORMED_REQUEST.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(final Exception exception) {
+        log.error("Unhandled exception", exception);
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus()).body(errorResponse);
     }
 }

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -60,7 +60,9 @@ public class AuthService {
         final String providerUserId = payload.sub();
         final User user = oAuthIdentityRepository
                 .findByProviderAndProviderUserId(OAuthProvider.KAKAO, providerUserId)
-                .map(identity -> userRepository.findById(identity.getUserId()).orElseThrow())
+                .map(identity -> userRepository.findById(identity.getUserId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND,
+                                "User not found: " + identity.getUserId())))
                 .orElseGet(() -> createNewUser(payload, providerUserId));
 
         final String accessToken = jwtProvider.createAccessToken(user.getId());

--- a/src/test/java/com/ppiyaki/user/controller/AuthControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/AuthControllerE2ETest.java
@@ -189,13 +189,30 @@ class AuthControllerE2ETest {
     }
 
     @Test
-    @DisplayName("인증 없이 호출하면 401")
+    @DisplayName("인증 없이 호출하면 401 + AUTH_001 ErrorResponse")
     void me_unauthorized() {
         RestAssured.given()
                 .when()
                 .get("/api/v1/users/me")
                 .then()
-                .statusCode(401);
+                .statusCode(401)
+                .body("success", is(false))
+                .body("error.code", is("AUTH_001"))
+                .body("error.status", is(401));
+    }
+
+    @Test
+    @DisplayName("잘못된 JSON 바디는 400 + MALFORMED_REQUEST(COMMON_002)로 거부된다")
+    void kakaoLogin_malformedBody_returns400() {
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("{not valid json")
+                .when()
+                .post("/api/v1/auth/kakao")
+                .then()
+                .statusCode(400)
+                .body("success", is(false))
+                .body("error.code", is("COMMON_002"));
     }
 
     @Test


### PR DESCRIPTION
Closes #124

## AS-IS
- 기존 `GlobalExceptionHandler`는 `BusinessException`만 처리. Bean Validation 실패, 잘못된 JSON, 인증 실패, 예상치 못한 런타임 예외가 `ErrorResponse` 포맷 밖으로 새어 나감
- Spring Security 필터 체인의 `AuthenticationException`/`AccessDeniedException`은 `@RestControllerAdvice` 범위 밖이라 커스텀 핸들러 부재 → 401 응답 본문이 비어 있음
- `AuthService.loginWithKakao`의 인자 없는 `orElseThrow()`는 `NoSuchElementException`을 던져 500 fallback으로 빠져나감

## TO-BE
### ErrorCode 추가
- `MALFORMED_REQUEST`(400, COMMON_002)
- `INTERNAL_SERVER_ERROR`(500, COMMON_003)
- `FORBIDDEN`(403, COMMON_004)

### GlobalExceptionHandler 확장
- `MethodArgumentNotValidException` → `INVALID_INPUT` (필드별 검증 실패 메시지 합쳐 노출)
- `ConstraintViolationException` → `INVALID_INPUT` (property path leaf만 노출하여 내부 구조 은닉)
- `HttpMessageNotReadableException`, `MethodArgumentTypeMismatchException`, `NoHandlerFoundException` → `MALFORMED_REQUEST`
- `Exception` fallback → `INTERNAL_SERVER_ERROR` + SLF4J error 레벨 로그

### Security 예외 핸들러 신규
- `RestAuthenticationEntryPoint`: 401 + `AUTH_INVALID_TOKEN` `ErrorResponse` JSON 반환
- `RestAccessDeniedHandler`: 403 + `FORBIDDEN` `ErrorResponse` JSON 반환
- `SecurityConfig`에 wire (`HttpStatusEntryPoint` 대체)

### 버그 픽스
- `AuthService.loginWithKakao:63` 인자 없는 `orElseThrow()` → `BusinessException(USER_NOT_FOUND, ...)`로 변경

### E2E 테스트 추가
- 인증 없이 `/api/v1/users/me` 호출 시 401 + `AUTH_001` `ErrorResponse` 검증
- 잘못된 JSON 바디로 `/api/v1/auth/kakao` 호출 시 400 + `COMMON_002` `ErrorResponse` 검증

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅ BUILD SUCCESSFUL

## 후속
- `SecurityConfig`는 #122에서도 수정되므로 머지 순서상 충돌 가능. #122 머지 후 본 PR 리베이스 예정.

---

### AI 체크리스트
- [x] type:feat 라벨
- [x] scope:infra 라벨
- [x] ai-generated 라벨
- [x] API 엔드포인트 변경 없음 (응답 포맷 변경은 기존 엔드포인트 에러 응답에만 영향) → Notion API 명세 갱신 불필요