### PR TITLE
chore(infra): AWS SDK 의존성 및 NCP Object Storage 설정

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -68,6 +68,11 @@ jobs:
               -e JPA_DDL_AUTO='${{ secrets.JPA_DDL_AUTO }}' \
               -e JWT_SECRET='${{ secrets.JWT_SECRET }}' \
               -e KAKAO_OIDC_AUDIENCE='${{ secrets.KAKAO_OIDC_AUDIENCE }}' \
+              -e NCP_STORAGE_ENDPOINT='${{ secrets.NCP_STORAGE_ENDPOINT }}' \
+              -e NCP_STORAGE_REGION='${{ secrets.NCP_STORAGE_REGION }}' \
+              -e NCP_STORAGE_ACCESS_KEY='${{ secrets.NCP_STORAGE_ACCESS_KEY }}' \
+              -e NCP_STORAGE_SECRET_KEY='${{ secrets.NCP_STORAGE_SECRET_KEY }}' \
+              -e NCP_STORAGE_BUCKET_NAME='${{ secrets.NCP_STORAGE_BUCKET_NAME }}' \
               ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
             
             echo "Cleaning up old images..."

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation platform('software.amazon.awssdk:bom:2.28.29')
+    implementation 'software.amazon.awssdk:s3'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/com/ppiyaki/common/storage/NcpStorageProperties.java
+++ b/src/main/java/com/ppiyaki/common/storage/NcpStorageProperties.java
@@ -1,0 +1,18 @@
+package com.ppiyaki.common.storage;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "ncp.storage")
+@ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")
+public record NcpStorageProperties(
+        @NotBlank String endpoint,
+        @NotBlank String region,
+        @NotBlank String accessKey,
+        @NotBlank String secretKey,
+        @NotBlank String bucketName
+) {
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,3 +18,11 @@ spring:
 
 server:
   port: ${SERVER_PORT:8080}
+
+ncp:
+  storage:
+    endpoint: ${NCP_STORAGE_ENDPOINT}
+    region: ${NCP_STORAGE_REGION}
+    access-key: ${NCP_STORAGE_ACCESS_KEY}
+    secret-key: ${NCP_STORAGE_SECRET_KEY}
+    bucket-name: ${NCP_STORAGE_BUCKET_NAME}


### PR DESCRIPTION
Closes #130

## AS-IS
- 파일 업로드 인프라를 위한 AWS SDK 및 NCP Object Storage 자격증명 구성 없음

## TO-BE
- `build.gradle`: AWS SDK v2 BOM(2.28.29) + `software.amazon.awssdk:s3` 추가
- `common/storage/NcpStorageProperties` 신설
  - `@Validated` + `@NotBlank` 필드 검증 (endpoint, region, accessKey, secretKey, bucketName)
  - `@ConditionalOnProperty(\"ncp.storage.bucket-name\")` — 로컬에서 bucket-name 없으면 빈 생성 안 함
- `application-prod.yml`: `ncp.storage.*` 환경변수 바인딩 (기본값 없음 → prod env 누락 시 부트 실패)
- `backend-cd.yml`: `NCP_STORAGE_*` 환경변수 5개 `docker run -e` 주입 추가

## Feature Spec
- `docs/features/file-upload.md`

## 사용자 직접 세팅 필요 항목
- [ ] GitHub Secrets 등록:
  - `NCP_STORAGE_ENDPOINT` (예: `https://kr.object.ncloudstorage.com`)
  - `NCP_STORAGE_REGION` (예: `kr-standard`)
  - `NCP_STORAGE_ACCESS_KEY`
  - `NCP_STORAGE_SECRET_KEY`
  - `NCP_STORAGE_BUCKET_NAME` (예: `ppiyaki-prod`)
- [ ] NCP 콘솔 작업: `ppiyaki-prod` 버킷 생성, private 설정, 액세스 키 발급

## 보호 영역 변경
- `build.gradle` — 의존성 추가
- `application-prod.yml` — ncp.storage 설정
- `.github/workflows/backend-cd.yml` — 환경변수 주입
→ `needs-human-review` 부여

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅ BUILD SUCCESSFUL

---

### AI 체크리스트
- [x] type:chore 라벨
- [x] scope:infra 라벨
- [x] ai-generated 라벨
- [x] needs-human-review 라벨 (보호 영역 변경)
- [x] API 엔드포인트 변경 없음 → Notion API 명세 갱신 불필요