### PR TITLE
feat(infra): presigned PUT URL 발급 API 구현

### DIFF
--- a/src/main/java/com/ppiyaki/common/storage/StorageConfig.java
+++ b/src/main/java/com/ppiyaki/common/storage/StorageConfig.java
@@ -1,0 +1,25 @@
+package com.ppiyaki.common.storage;
+
+import java.net.URI;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")
+public class StorageConfig {
+
+    @Bean
+    public S3Presigner s3Presigner(final NcpStorageProperties properties) {
+        return S3Presigner.builder()
+                .endpointOverride(URI.create(properties.endpoint()))
+                .region(Region.of(properties.region()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(properties.accessKey(), properties.secretKey())))
+                .build();
+    }
+}

--- a/src/main/java/com/ppiyaki/common/storage/UploadController.java
+++ b/src/main/java/com/ppiyaki/common/storage/UploadController.java
@@ -1,0 +1,32 @@
+package com.ppiyaki.common.storage;
+
+import com.ppiyaki.common.storage.dto.PresignedUploadRequest;
+import com.ppiyaki.common.storage.dto.PresignedUploadResponse;
+import jakarta.validation.Valid;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/uploads")
+@ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")
+public class UploadController {
+
+    private final UploadService uploadService;
+
+    public UploadController(final UploadService uploadService) {
+        this.uploadService = uploadService;
+    }
+
+    @PostMapping("/presigned")
+    public ResponseEntity<PresignedUploadResponse> createPresigned(
+            @AuthenticationPrincipal final Long userId,
+            @Valid @RequestBody final PresignedUploadRequest request
+    ) {
+        return ResponseEntity.ok(uploadService.createPresignedPutUrl(userId, request));
+    }
+}

--- a/src/main/java/com/ppiyaki/common/storage/UploadPurpose.java
+++ b/src/main/java/com/ppiyaki/common/storage/UploadPurpose.java
@@ -1,0 +1,18 @@
+package com.ppiyaki.common.storage;
+
+public enum UploadPurpose {
+
+    PRESCRIPTION("prescription"),
+    MEDICATION_LOG("medication-log"),
+    PROFILE_IMAGE("profile-image");
+
+    private final String prefix;
+
+    UploadPurpose(final String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+}

--- a/src/main/java/com/ppiyaki/common/storage/UploadService.java
+++ b/src/main/java/com/ppiyaki/common/storage/UploadService.java
@@ -1,0 +1,86 @@
+package com.ppiyaki.common.storage;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.storage.dto.PresignedUploadRequest;
+import com.ppiyaki.common.storage.dto.PresignedUploadResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Service
+@ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")
+public class UploadService {
+
+    private static final Logger log = LoggerFactory.getLogger(UploadService.class);
+    private static final Duration PRESIGN_TTL = Duration.ofMinutes(5);
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+    );
+
+    private final S3Presigner s3Presigner;
+    private final NcpStorageProperties properties;
+
+    public UploadService(final S3Presigner s3Presigner, final NcpStorageProperties properties) {
+        this.s3Presigner = s3Presigner;
+        this.properties = properties;
+    }
+
+    public PresignedUploadResponse createPresignedPutUrl(
+            final Long userId,
+            final PresignedUploadRequest request
+    ) {
+        validateContentType(request.contentType());
+
+        final String objectKey = buildObjectKey(userId, request);
+
+        final PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(properties.bucketName())
+                .key(objectKey)
+                .contentType(request.contentType())
+                .build();
+
+        final PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(PRESIGN_TTL)
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        final PresignedPutObjectRequest presigned = s3Presigner.presignPutObject(presignRequest);
+
+        log.info("Presigned upload URL issued: purpose={} userId={} objectKey={}",
+                request.purpose(), userId, objectKey);
+
+        return new PresignedUploadResponse(
+                objectKey,
+                presigned.url().toString(),
+                Instant.now().plus(PRESIGN_TTL)
+        );
+    }
+
+    private void validateContentType(final String contentType) {
+        if (!ALLOWED_CONTENT_TYPES.contains(contentType)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
+                    "Unsupported content type: " + contentType);
+        }
+    }
+
+    private String buildObjectKey(final Long userId, final PresignedUploadRequest request) {
+        return "%s/%d/%s.%s".formatted(
+                request.purpose().getPrefix(),
+                userId,
+                UUID.randomUUID(),
+                request.extension()
+        );
+    }
+}

--- a/src/main/java/com/ppiyaki/common/storage/dto/PresignedUploadRequest.java
+++ b/src/main/java/com/ppiyaki/common/storage/dto/PresignedUploadRequest.java
@@ -1,0 +1,13 @@
+package com.ppiyaki.common.storage.dto;
+
+import com.ppiyaki.common.storage.UploadPurpose;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record PresignedUploadRequest(
+        @NotNull UploadPurpose purpose,
+        @NotBlank @Pattern(regexp = "jpg|jpeg|png|webp", message = "extension must be one of: jpg, jpeg, png, webp") String extension,
+        @NotBlank String contentType
+) {
+}

--- a/src/main/java/com/ppiyaki/common/storage/dto/PresignedUploadResponse.java
+++ b/src/main/java/com/ppiyaki/common/storage/dto/PresignedUploadResponse.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.common.storage.dto;
+
+import java.time.Instant;
+
+public record PresignedUploadResponse(
+        String objectKey,
+        String presignedUrl,
+        Instant expiresAt
+) {
+}


### PR DESCRIPTION
Closes #131

## AS-IS
- 파일 업로드를 위한 API가 없음. 클라이언트가 직접 NCP Object Storage에 업로드할 방법 부재.

## TO-BE
### 엔드포인트
- `POST /api/v1/uploads/presigned` (인증 필수)
  - 요청: `{ purpose, extension, contentType }`
  - 응답: `{ objectKey, presignedUrl, expiresAt }`

### 구성 요소
- `UploadPurpose` enum: `PRESCRIPTION`, `MEDICATION_LOG`, `PROFILE_IMAGE`
- `PresignedUploadRequest` (`@NotNull purpose`, `@NotBlank @Pattern(jpg|jpeg|png|webp) extension`, `@NotBlank contentType`)
- `PresignedUploadResponse` (objectKey, presignedUrl, expiresAt)
- `StorageConfig` — `S3Presigner` 빈 (NCP 엔드포인트/리전/자격증명 주입)
- `UploadService` — Content-Type 화이트리스트 검증, objectKey `{purpose}/{userId}/{uuid}.{ext}`, 5분 TTL presigned URL 발급, info 로그
- `UploadController` — 인증 + `@Valid`

### 조건부 빈 생성
모든 빈에 `@ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")` 적용.
- 로컬(환경변수 미설정): 빈 생성 안 됨 → 부트 영향 없음
- prod(선행 PR #134에서 주입): 정상 활성화

## 알려진 제약
- `content-length-range` 서버 강제는 이번 PR에 미포함. AWS SDK v2 `S3Presigner.presignPutObject`는 PUT 용도로는 content-length-range 조건을 직접 지원하지 않음 (POST policy 전용). 서버 측 용량 제한은 후속 작업에서 bucket policy 또는 업로드 완료 후 검증으로 처리 예정.

## Feature Spec
- `docs/features/file-upload.md` (선행 PR #133 머지됨)

## 선행
- #134 (AWS SDK 의존성 + properties) 머지 완료 — 이 PR은 그 위에 얹힘

## 후속
- #132 테스트 PR

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅ BUILD SUCCESSFUL

---

### AI 체크리스트
- [x] type:feat 라벨
- [x] scope:infra 라벨
- [x] ai-generated 라벨
- [x] API 엔드포인트 추가 — Notion API 명세 갱신 필요 ⚠️ (presigned 발급은 내부 인프라성 엔드포인트인지, 클라이언트 공개 명세 대상인지 리뷰 시 판단 요청)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 안전한 파일 업로드를 위한 Presigned URL 생성 API 추가
  * 처방전, 투약 기록, 프로필 이미지 등 다양한 업로드 유형 지원
  * JPEG, PNG, WebP 형식의 이미지 파일 업로드 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->