### PR TITLE
test(infra): presigned upload API 단위/통합 테스트 추가

### DIFF
--- a/src/test/java/com/ppiyaki/common/storage/UploadControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/common/storage/UploadControllerE2ETest.java
@@ -1,0 +1,195 @@
+package com.ppiyaki.common.storage;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test",
+        "spring.main.allow-bean-definition-overriding=true"
+})
+@Import(UploadControllerE2ETest.MockS3PresignerConfig.class)
+class UploadControllerE2ETest {
+
+    private static final String MOCK_PRESIGNED_URL = "https://kr.object.ncloudstorage.com/ppiyaki-test/prescription/1/uuid.jpg?X-Amz-Signature=mock";
+
+    @LocalServerPort
+    private int port;
+
+    private static long userSequence = 500000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("유효한 요청이면 200 + presigned URL 응답")
+    void createPresigned_success() {
+        // given
+        final String token = loginAsNewUser("업로드유저");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body("""
+                        {
+                            "purpose": "PRESCRIPTION",
+                            "extension": "jpg",
+                            "contentType": "image/jpeg"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/uploads/presigned")
+                .then()
+                .statusCode(200)
+                .body("objectKey", startsWith("prescription/"))
+                .body("presignedUrl", is(MOCK_PRESIGNED_URL))
+                .body("expiresAt", notNullValue());
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 확장자는 400 + COMMON_001")
+    void createPresigned_invalidExtension() {
+        // given
+        final String token = loginAsNewUser("잘못된확장자유저");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body("""
+                        {
+                            "purpose": "PRESCRIPTION",
+                            "extension": "gif",
+                            "contentType": "image/gif"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/uploads/presigned")
+                .then()
+                .statusCode(400)
+                .body("error.code", is("COMMON_001"));
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 Content-Type은 400 + COMMON_001")
+    void createPresigned_unsupportedContentType() {
+        // given
+        final String token = loginAsNewUser("잘못된MIME유저");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body("""
+                        {
+                            "purpose": "PRESCRIPTION",
+                            "extension": "jpg",
+                            "contentType": "application/pdf"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/uploads/presigned")
+                .then()
+                .statusCode(400)
+                .body("error.code", is("COMMON_001"));
+    }
+
+    @Test
+    @DisplayName("purpose 누락은 400")
+    void createPresigned_missingPurpose() {
+        // given
+        final String token = loginAsNewUser("필드누락유저");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body("""
+                        {
+                            "extension": "jpg",
+                            "contentType": "image/jpeg"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/uploads/presigned")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("인증 없이 호출하면 401 + AUTH_001")
+    void createPresigned_unauthorized() {
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "purpose": "PRESCRIPTION",
+                            "extension": "jpg",
+                            "contentType": "image/jpeg"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/uploads/presigned")
+                .then()
+                .statusCode(401)
+                .body("error.code", is("AUTH_001"));
+    }
+
+    private String loginAsNewUser(final String nickname) {
+        final String loginId = "uploadtest" + userSequence++;
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .extract()
+                .path("accessToken");
+    }
+
+    @TestConfiguration
+    static class MockS3PresignerConfig {
+
+        @Bean
+        @Primary
+        S3Presigner s3Presigner() throws Exception {
+            final S3Presigner mockPresigner = mock(S3Presigner.class);
+            final PresignedPutObjectRequest presignedResponse = mock(PresignedPutObjectRequest.class);
+            when(presignedResponse.url()).thenReturn(URI.create(MOCK_PRESIGNED_URL).toURL());
+            when(mockPresigner.presignPutObject(any(PutObjectPresignRequest.class))).thenReturn(presignedResponse);
+            return mockPresigner;
+        }
+    }
+}

--- a/src/test/java/com/ppiyaki/common/storage/UploadServiceTest.java
+++ b/src/test/java/com/ppiyaki/common/storage/UploadServiceTest.java
@@ -1,0 +1,94 @@
+package com.ppiyaki.common.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.storage.dto.PresignedUploadRequest;
+import com.ppiyaki.common.storage.dto.PresignedUploadResponse;
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+class UploadServiceTest {
+
+    private static final String MOCK_PRESIGNED_URL = "https://kr.object.ncloudstorage.com/ppiyaki-test/prescription/1/uuid.jpg?X-Amz-Signature=mock";
+
+    private S3Presigner s3Presigner;
+    private UploadService uploadService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        s3Presigner = mock(S3Presigner.class);
+        final NcpStorageProperties properties = new NcpStorageProperties(
+                "https://kr.object.ncloudstorage.com",
+                "kr-standard",
+                "test-access-key",
+                "test-secret-key",
+                "ppiyaki-test"
+        );
+        uploadService = new UploadService(s3Presigner, properties);
+
+        final PresignedPutObjectRequest presignedResponse = mock(PresignedPutObjectRequest.class);
+        when(presignedResponse.url()).thenReturn(URI.create(MOCK_PRESIGNED_URL).toURL());
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenReturn(presignedResponse);
+    }
+
+    @Test
+    @DisplayName("유효한 요청이면 presigned URL과 objectKey를 반환한다")
+    void createPresignedPutUrl_success() {
+        // given
+        final Long userId = 42L;
+        final PresignedUploadRequest request = new PresignedUploadRequest(
+                UploadPurpose.PRESCRIPTION, "jpg", "image/jpeg");
+
+        // when
+        final PresignedUploadResponse response = uploadService.createPresignedPutUrl(userId, request);
+
+        // then
+        assertThat(response.presignedUrl()).isEqualTo(MOCK_PRESIGNED_URL);
+        assertThat(response.expiresAt()).isNotNull();
+        assertThat(response.objectKey())
+                .startsWith("prescription/42/")
+                .endsWith(".jpg");
+    }
+
+    @Test
+    @DisplayName("objectKey는 purpose prefix, userId, uuid, extension 순으로 조합된다")
+    void createPresignedPutUrl_objectKeyFormat() {
+        // given
+        final Long userId = 7L;
+        final PresignedUploadRequest request = new PresignedUploadRequest(
+                UploadPurpose.MEDICATION_LOG, "png", "image/png");
+
+        // when
+        final PresignedUploadResponse response = uploadService.createPresignedPutUrl(userId, request);
+
+        // then
+        assertThat(response.objectKey())
+                .startsWith("medication-log/7/")
+                .endsWith(".png");
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 Content-Type이면 INVALID_INPUT 예외를 던진다")
+    void createPresignedPutUrl_unsupportedContentType() {
+        // given
+        final PresignedUploadRequest request = new PresignedUploadRequest(
+                UploadPurpose.PROFILE_IMAGE, "gif", "image/gif");
+
+        // when & then
+        assertThatThrownBy(() -> uploadService.createPresignedPutUrl(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+}


### PR DESCRIPTION
Closes #132

## AS-IS
- PR #131에서 추가한 UploadService/UploadController에 대한 테스트 부재

## TO-BE
### `UploadServiceTest` (단위 3건)
- 유효 요청 시 presigned URL과 objectKey 반환
- objectKey 포맷 `{purpose-prefix}/{userId}/{uuid}.{ext}` 검증
- 허용되지 않은 Content-Type → `BusinessException(INVALID_INPUT)`

### `UploadControllerE2ETest` (통합 5건, RestAssured + @SpringBootTest)
- 유효 요청 200 + presigned URL
- 허용되지 않은 확장자 400 + `COMMON_001`
- 허용되지 않은 Content-Type 400 + `COMMON_001`
- `purpose` 필드 누락 400
- 인증 없음 401 + `AUTH_001`

### 테스트 전략
- `@TestConfiguration` + `@Primary`로 `S3Presigner` mock 빈 주입
- `spring.main.allow-bean-definition-overriding=true`로 프로덕션 `S3Presigner` 대체 허용
- `ncp.storage.*` 테스트 property 설정으로 모든 `@ConditionalOnProperty` 빈 활성화
- 로그인은 기존 `/api/v1/auth/signup` 로컬 회원가입 사용 (Kakao mocking 불필요)

## Feature Spec
- `docs/features/file-upload.md` Q5 결정 대응 (LocalStack 미도입, mock 기반)

## 선행
- #131 presigned API 구현 머지 후 리베이스 가능

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅ BUILD SUCCESSFUL

---

### AI 체크리스트
- [x] type:test 라벨
- [x] scope:infra 라벨
- [x] ai-generated 라벨
- [x] API 엔드포인트 변경 없음 → Notion API 명세 갱신 불필요