### PR TITLE
chore(infra): .env / .env.example 기반 환경변수 관리 도입

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,57 @@
+# Copy to .env and fill in real values for local development.
+# .env is gitignored — never commit real secrets.
+#
+# Usage (local):
+#   cp .env.example .env
+#   # edit .env with real values
+#   ./gradlew bootRun
+#
+# spring-dotenv (developmentOnly) auto-loads .env during bootRun; prod jar
+# does not include the library and relies on OS env vars / docker -e flags.
+#
+# Values below are placeholders; replace before using.
+
+# -----------------------------------------------------------------------------
+# Spring profile
+# -----------------------------------------------------------------------------
+SPRING_PROFILES_ACTIVE=local
+
+# -----------------------------------------------------------------------------
+# Database (prod profile)
+# local/default profile uses in-memory H2 and does not need these.
+# -----------------------------------------------------------------------------
+DB_URL=jdbc:mysql://localhost:3306/ppiyaki?useSSL=false&serverTimezone=Asia/Seoul
+DB_USERNAME=your-db-username
+DB_PASSWORD=your-db-password
+JPA_DDL_AUTO=validate
+
+# -----------------------------------------------------------------------------
+# Server
+# -----------------------------------------------------------------------------
+SERVER_PORT=8080
+
+# -----------------------------------------------------------------------------
+# JWT
+# secret must be at least 32 bytes for HS256.
+# -----------------------------------------------------------------------------
+JWT_SECRET=change-me-to-a-random-at-least-32-bytes-secret
+JWT_ACCESS_EXPIRY=1800000
+JWT_REFRESH_EXPIRY=1209600000
+
+# -----------------------------------------------------------------------------
+# Kakao OIDC
+# audience is the Kakao app REST API key registered as OIDC audience.
+# -----------------------------------------------------------------------------
+KAKAO_OIDC_ISSUER=https://kauth.kakao.com
+KAKAO_OIDC_JWKS_URI=https://kauth.kakao.com/.well-known/jwks.json
+KAKAO_OIDC_AUDIENCE=your-kakao-rest-api-key
+
+# -----------------------------------------------------------------------------
+# NCP Object Storage (prod profile; required to enable upload feature)
+# Omit these locally to keep the upload endpoint disabled.
+# -----------------------------------------------------------------------------
+NCP_STORAGE_ENDPOINT=https://kr.object.ncloudstorage.com
+NCP_STORAGE_REGION=kr-standard
+NCP_STORAGE_ACCESS_KEY=your-ncp-sub-account-access-key
+NCP_STORAGE_SECRET_KEY=your-ncp-sub-account-secret-key
+NCP_STORAGE_BUCKET_NAME=ppiyaki-prod

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 HELP.md
 .gradle
 build/
+
+### Environment files ###
+.env
+.env.*
+!.env.example
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    developmentOnly 'me.paulschwarz:springboot3-dotenv:5.1.0'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'


### PR DESCRIPTION
Closes #137

## AS-IS
- 로컬 개발 시 환경변수를 각자 shell export로 세팅해야 해서 설정 공유·재현성 부족
- 어떤 env var가 필요한지 문서화된 단일 소스가 없음

## TO-BE
### `.env` 자동 로드 (spring-dotenv)
- `build.gradle`에 `me.paulschwarz:spring-dotenv-bom:5.1.0` + `springboot3-dotenv` 추가 (**developmentOnly**)
- `./gradlew bootRun` 시 `.env` 자동으로 읽혀 환경변수로 주입됨
- prod jar에는 라이브러리 미포함 → 운영은 기존대로 docker `-e` 플래그로 env 주입

### 파일 관리
- `.gitignore`: `.env`, `.env.local` 등 커밋 차단. `.env.example`만 추적
- `.env.example` 신설: 프로젝트에서 사용하는 모든 env var를 그룹별로 정리
  - Spring profile / DB (prod) / Server / JWT / Kakao OIDC / NCP Object Storage

## 사용 방법
```bash
cp .env.example .env
# .env 편집 (실제 값 주입)
./gradlew bootRun
```

## 보호 영역
- `.env*`, `build.gradle`은 CLAUDE.md §4 AI 보호 영역 → `needs-human-review`
- `.env.example`에는 실제 시크릿 없음 (자리표시자/기본 엔드포인트만)

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅ BUILD SUCCESSFUL

## 후속 활용
- 로컬에서 prod 프로파일로 파일 업로드 기능 실제 테스트 가능해짐
- 새 env var 추가 시 `.env.example` 같은 PR에서 갱신하는 관례 필요 (후속 문서화 검토)

---

### AI 체크리스트
- [x] type:chore 라벨
- [x] scope:infra 라벨
- [x] ai-generated 라벨
- [x] needs-human-review 라벨 (보호 영역 변경)
- [x] API 엔드포인트 변경 없음 → Notion API 명세 갱신 불필요