### PR TITLE
docs(infra): .env.example에 SPRING_PROFILES_ACTIVE 한계 안내 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 # Usage (local):
 #   cp .env.example .env
 #   # edit .env with real values
-#   ./gradlew bootRun
+#   ./gradlew bootRun --args='--spring.profiles.active=local'
 #
 # spring-dotenv (developmentOnly) auto-loads .env during bootRun; prod jar
 # does not include the library and relies on OS env vars / docker -e flags.
@@ -13,6 +13,15 @@
 
 # -----------------------------------------------------------------------------
 # Spring profile
+# NOTE: SPRING_PROFILES_ACTIVE 는 Spring Boot bootstrap 단계에서 결정되어
+#       spring-dotenv 가 .env 를 로드하기 전에 먼저 평가됩니다. 즉 아래 값은
+#       ./gradlew bootRun 만으로는 **무시**됩니다 (default 프로파일로 뜸).
+#       로컬 개발 시 프로파일을 강제하려면 다음 중 하나:
+#         1) CLI 인자:
+#            ./gradlew bootRun --args='--spring.profiles.active=local'
+#         2) 진짜 shell env var:
+#            SPRING_PROFILES_ACTIVE=local ./gradlew bootRun
+#         3) IDE Run Configuration 의 "Active profiles" 에 local 지정
 # -----------------------------------------------------------------------------
 SPRING_PROFILES_ACTIVE=local
 


### PR DESCRIPTION
Closes #139

## AS-IS
- `.env` 에 `SPRING_PROFILES_ACTIVE=local` 을 넣어도 `./gradlew bootRun` 실행 시 무시되고 default 프로파일로 기동됨
- 실제 업로드 E2E 테스트 중 H2 로 붙는 현상으로 확인

## 원인
spring-dotenv 는 Spring PropertySource 로 등록되어 애플리케이션 컨텍스트 refresh 시점에 로드됨.
반면 `SPRING_PROFILES_ACTIVE` 는 Spring Boot bootstrap 초기 단계에서 결정되어 spring-dotenv 로드 시점보다 이르게 평가됨 → `.env` 값 미반영.

## TO-BE
`.env.example` 주석에 다음 내용 추가:
- 현상 설명 (자동 로드 안 됨)
- 대응 방법 3가지:
  1. `./gradlew bootRun --args='--spring.profiles.active=local'`
  2. `SPRING_PROFILES_ACTIVE=local ./gradlew bootRun`
  3. IDE Run Configuration 의 Active profiles 에 local 지정
- Usage 예시의 실행 명령도 `--args` 포함 형태로 갱신

## 보호 영역
- `.env*` 변경 → `needs-human-review`

## 검증
- 문서(주석) 변경만 → 코드 변경 없음, 품질 게이트 영향 없음

---

### AI 체크리스트
- [x] type:docs 라벨
- [x] scope:infra 라벨
- [x] ai-generated 라벨
- [x] needs-human-review 라벨 (보호 영역)
- [x] API 엔드포인트 변경 없음 → Notion API 명세 갱신 불필요