### PR TITLE
feat(medicine): medicines 엔티티에 item_seq 컬럼 추가

### DIFF
--- a/src/main/java/com/ppiyaki/medicine/Medicine.java
+++ b/src/main/java/com/ppiyaki/medicine/Medicine.java
@@ -37,6 +37,9 @@ public class Medicine extends CreatedTimeEntity {
     @Column(name = "remaining_amount")
     private Integer remainingAmount;
 
+    @Column(name = "item_seq")
+    private String itemSeq;
+
     @Column(name = "dur_warning_text")
     private String durWarningText;
 
@@ -46,6 +49,7 @@ public class Medicine extends CreatedTimeEntity {
             final String name,
             final Integer totalAmount,
             final Integer remainingAmount,
+            final String itemSeq,
             final String durWarningText
     ) {
         this.ownerId = Objects.requireNonNull(ownerId, "ownerId must not be null");
@@ -53,6 +57,7 @@ public class Medicine extends CreatedTimeEntity {
         this.name = Objects.requireNonNull(name, "name must not be null");
         this.totalAmount = Objects.requireNonNull(totalAmount, "totalAmount must not be null");
         this.remainingAmount = Objects.requireNonNull(remainingAmount, "remainingAmount must not be null");
+        this.itemSeq = itemSeq;
         this.durWarningText = durWarningText;
     }
 
@@ -60,6 +65,7 @@ public class Medicine extends CreatedTimeEntity {
             final String name,
             final Integer totalAmount,
             final Integer remainingAmount,
+            final String itemSeq,
             final String durWarningText
     ) {
         if (name != null) {
@@ -70,6 +76,9 @@ public class Medicine extends CreatedTimeEntity {
         }
         if (remainingAmount != null) {
             this.remainingAmount = remainingAmount;
+        }
+        if (itemSeq != null) {
+            this.itemSeq = itemSeq;
         }
         if (durWarningText != null) {
             this.durWarningText = durWarningText;

--- a/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineCreateRequest.java
+++ b/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineCreateRequest.java
@@ -8,6 +8,7 @@ public record MedicineCreateRequest(
         @NotBlank String name,
         @NotNull Integer totalAmount,
         @NotNull Integer remainingAmount,
+        String itemSeq,
         String durWarningText
 ) {
 }

--- a/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineResponse.java
+++ b/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineResponse.java
@@ -9,6 +9,7 @@ public record MedicineResponse(
         Integer totalAmount,
         Integer remainingAmount,
         Long prescriptionId,
+        String itemSeq,
         String durWarningText,
         LocalDateTime createdAt
 ) {
@@ -20,6 +21,7 @@ public record MedicineResponse(
                 medicine.getTotalAmount(),
                 medicine.getRemainingAmount(),
                 medicine.getPrescriptionId(),
+                medicine.getItemSeq(),
                 medicine.getDurWarningText(),
                 medicine.getCreatedAt()
         );

--- a/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineUpdateRequest.java
+++ b/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineUpdateRequest.java
@@ -4,6 +4,7 @@ public record MedicineUpdateRequest(
         String name,
         Integer totalAmount,
         Integer remainingAmount,
+        String itemSeq,
         String durWarningText
 ) {
 }

--- a/src/main/java/com/ppiyaki/medicine/service/MedicineService.java
+++ b/src/main/java/com/ppiyaki/medicine/service/MedicineService.java
@@ -47,6 +47,7 @@ public class MedicineService {
                 medicineCreateRequest.name(),
                 medicineCreateRequest.totalAmount(),
                 medicineCreateRequest.remainingAmount(),
+                medicineCreateRequest.itemSeq(),
                 medicineCreateRequest.durWarningText()
         );
 
@@ -85,6 +86,7 @@ public class MedicineService {
                 medicineUpdateRequest.name(),
                 medicineUpdateRequest.totalAmount(),
                 medicineUpdateRequest.remainingAmount(),
+                medicineUpdateRequest.itemSeq(),
                 medicineUpdateRequest.durWarningText()
         );
 

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
@@ -237,7 +237,7 @@ class MedicationScheduleControllerE2ETest {
         final Long userId = readUserId(token);
 
         final Medicine medicine = medicineRepository.save(
-                new Medicine(userId, null, name, totalAmount, remainingAmount, null));
+                new Medicine(userId, null, name, totalAmount, remainingAmount, null, null));
         return medicine.getId().intValue();
     }
 


### PR DESCRIPTION
Closes #143

## AS-IS
- medicines 테이블에 식약처 품목기준코드(itemSeq) 없음 → DUR API·약물 검색 호출 불가

## TO-BE
- `Medicine.java`: `itemSeq` (varchar, nullable) 필드 추가
- DTO 3개 (Create/Response/Update)에 `itemSeq` 반영
- `MedicineService` create/update 전달

## 설계 결정
- 현재 **nullable**: 수동 등록 시 사용자가 itemSeq를 모를 수 있음
- `medicine-search` 구현 후 NOT NULL 전환 예정 (모든 등록이 검색 경유)

## Feature Spec
- `docs/features/medicine-dur.md` PR 2
- `docs/features/medicine-search.md` 선행 의존

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅ BUILD SUCCESSFUL

---

### AI 체크리스트
- [x] type:feat
- [x] scope:medicine
- [x] ai-generated
- [x] API 엔드포인트 변경 없음 (필드 추가만) → Notion 명세 갱신 보류 (itemSeq 필드 추가는 minor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 의약품 항목 일련번호 정보 추가: 의약품 데이터 모델에 항목 일련번호 필드를 추가했습니다. 의약품 생성 및 수정 시 항목 일련번호를 포함하여 관리할 수 있으며, 의약품 조회 시에도 항목 일련번호 정보가 함께 제공되어 의약품 추적 및 관리 기능이 강화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->