### PR TITLE
feat(medicine): MedicineSearchService + MFDS 공통 인프라 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,10 @@ NCP_STORAGE_REGION=kr-standard
 NCP_STORAGE_ACCESS_KEY=your-ncp-sub-account-access-key
 NCP_STORAGE_SECRET_KEY=your-ncp-sub-account-secret-key
 NCP_STORAGE_BUCKET_NAME=ppiyaki-prod
+
+# -----------------------------------------------------------------------------
+# MFDS DUR API (식약처 공공 DUR 품목정보 서비스)
+# data.go.kr에서 활용신청 후 발급받은 인증키 (URL Encoding 형태)
+# 비워두면 약물 검색·DUR 점검 비활성.
+# -----------------------------------------------------------------------------
+MFDS_API_SERVICE_KEY=your-data-go-kr-service-key

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -73,6 +73,7 @@ jobs:
               -e NCP_STORAGE_ACCESS_KEY='${{ secrets.NCP_STORAGE_ACCESS_KEY }}' \
               -e NCP_STORAGE_SECRET_KEY='${{ secrets.NCP_STORAGE_SECRET_KEY }}' \
               -e NCP_STORAGE_BUCKET_NAME='${{ secrets.NCP_STORAGE_BUCKET_NAME }}' \
+              -e MFDS_API_SERVICE_KEY='${{ secrets.MFDS_API_SERVICE_KEY }}' \
               ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
             
             echo "Cleaning up old images..."

--- a/src/main/java/com/ppiyaki/common/mfds/CachedMfdsResponse.java
+++ b/src/main/java/com/ppiyaki/common/mfds/CachedMfdsResponse.java
@@ -1,0 +1,14 @@
+package com.ppiyaki.common.mfds;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record CachedMfdsResponse(
+        String operation,
+        String queryKey,
+        Instant fetchedAt,
+        int totalCount,
+        List<Map<String, Object>> items
+) {
+}

--- a/src/main/java/com/ppiyaki/common/mfds/InMemoryMfdsResponseCache.java
+++ b/src/main/java/com/ppiyaki/common/mfds/InMemoryMfdsResponseCache.java
@@ -1,0 +1,46 @@
+package com.ppiyaki.common.mfds;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class InMemoryMfdsResponseCache implements MfdsResponseCache {
+
+    private static final Duration TTL = Duration.ofHours(24);
+
+    private final Map<String, CachedMfdsResponse> cache = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<CachedMfdsResponse> get(final String operation, final String queryKey) {
+        final String key = buildKey(operation, queryKey);
+        final CachedMfdsResponse cached = cache.get(key);
+        if (cached == null) {
+            return Optional.empty();
+        }
+        if (cached.fetchedAt().plus(TTL).isBefore(Instant.now())) {
+            cache.remove(key);
+            return Optional.empty();
+        }
+        return Optional.of(cached);
+    }
+
+    @Override
+    public void put(final String operation, final String queryKey, final CachedMfdsResponse response) {
+        cache.put(buildKey(operation, queryKey), response);
+    }
+
+    @Override
+    public void invalidate(final String operation, final String queryKey) {
+        cache.remove(buildKey(operation, queryKey));
+    }
+
+    private String buildKey(final String operation, final String queryKey) {
+        return operation + ":" + queryKey;
+    }
+}

--- a/src/main/java/com/ppiyaki/common/mfds/MfdsApiClient.java
+++ b/src/main/java/com/ppiyaki/common/mfds/MfdsApiClient.java
@@ -1,0 +1,145 @@
+package com.ppiyaki.common.mfds;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class MfdsApiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(MfdsApiClient.class);
+    private static final String RESULT_CODE_SUCCESS = "00";
+
+    private final MfdsApiProperties properties;
+    private final MfdsResponseCache cache;
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    public MfdsApiClient(
+            final MfdsApiProperties properties,
+            final MfdsResponseCache cache,
+            final RestClient.Builder restClientBuilder,
+            final ObjectMapper objectMapper
+    ) {
+        this.properties = properties;
+        this.cache = cache;
+        this.objectMapper = objectMapper;
+
+        final SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofMillis(properties.connectTimeout()));
+        factory.setReadTimeout(Duration.ofMillis(properties.readTimeout()));
+
+        this.restClient = restClientBuilder
+                .requestFactory(factory)
+                .build();
+    }
+
+    public CachedMfdsResponse call(
+            final String operation,
+            final Map<String, String> params,
+            final String cacheKey
+    ) {
+        final Optional<CachedMfdsResponse> cached = cache.get(operation, cacheKey);
+        if (cached.isPresent()) {
+            log.debug("MFDS cache hit: operation={} key={}", operation, cacheKey);
+            return cached.get();
+        }
+
+        log.info("MFDS API call: operation={} key={}", operation, cacheKey);
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            final UriComponentsBuilder uriBuilder = UriComponentsBuilder
+                    .fromHttpUrl("https://" + properties.baseUrl() + "/" + operation)
+                    .queryParam("serviceKey", properties.serviceKey())
+                    .queryParam("type", "json");
+
+            params.forEach(uriBuilder::queryParam);
+
+            final URI uri = uriBuilder.build(true).toUri();
+            final String responseBody = restClient.get()
+                    .uri(uri)
+                    .retrieve()
+                    .body(String.class);
+
+            final long elapsed = System.currentTimeMillis() - startTime;
+            log.info("MFDS API response: operation={} key={} elapsed={}ms", operation, cacheKey, elapsed);
+
+            final CachedMfdsResponse response = parseResponse(operation, cacheKey, responseBody);
+            cache.put(operation, cacheKey, response);
+            return response;
+
+        } catch (final BusinessException e) {
+            throw e;
+        } catch (final Exception e) {
+            final long elapsed = System.currentTimeMillis() - startTime;
+            log.error("MFDS API failed: operation={} key={} elapsed={}ms error={}",
+                    operation, cacheKey, elapsed, e.getMessage());
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
+                    "MFDS API call failed: " + e.getMessage());
+        }
+    }
+
+    private CachedMfdsResponse parseResponse(
+            final String operation,
+            final String cacheKey,
+            final String responseBody
+    ) {
+        try {
+            final JsonNode root = objectMapper.readTree(responseBody);
+
+            final String resultCode = root.path("header").path("resultCode").asText();
+            if (!RESULT_CODE_SUCCESS.equals(resultCode)) {
+                final String resultMsg = root.path("header").path("resultMsg").asText();
+                throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
+                        "MFDS API error: " + resultCode + " " + resultMsg);
+            }
+
+            final JsonNode body = root.path("body");
+            final int totalCount = body.path("totalCount").asInt(0);
+
+            final List<Map<String, Object>> items = new ArrayList<>();
+            final JsonNode itemsNode = body.path("items");
+
+            if (!itemsNode.isMissingNode() && !itemsNode.isNull()) {
+                final JsonNode itemNode = itemsNode.path("item");
+                if (itemNode.isArray()) {
+                    for (final JsonNode item : itemNode) {
+                        items.add(objectMapper.convertValue(item,
+                                new TypeReference<Map<String, Object>>() {
+                                }));
+                    }
+                } else if (itemNode.isObject()) {
+                    items.add(objectMapper.convertValue(itemNode,
+                            new TypeReference<Map<String, Object>>() {
+                            }));
+                }
+            }
+
+            return new CachedMfdsResponse(operation, cacheKey, Instant.now(), totalCount, items);
+
+        } catch (final BusinessException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
+                    "MFDS response parse failed: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ppiyaki/common/mfds/MfdsApiProperties.java
+++ b/src/main/java/com/ppiyaki/common/mfds/MfdsApiProperties.java
@@ -1,0 +1,17 @@
+package com.ppiyaki.common.mfds;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "mfds.api")
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public record MfdsApiProperties(
+        @NotBlank String serviceKey,
+        @NotBlank String baseUrl,
+        int connectTimeout,
+        int readTimeout
+) {
+}

--- a/src/main/java/com/ppiyaki/common/mfds/MfdsResponseCache.java
+++ b/src/main/java/com/ppiyaki/common/mfds/MfdsResponseCache.java
@@ -1,0 +1,12 @@
+package com.ppiyaki.common.mfds;
+
+import java.util.Optional;
+
+public interface MfdsResponseCache {
+
+    Optional<CachedMfdsResponse> get(String operation, String queryKey);
+
+    void put(String operation, String queryKey, CachedMfdsResponse response);
+
+    void invalidate(String operation, String queryKey);
+}

--- a/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineCandidate.java
+++ b/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineCandidate.java
@@ -1,0 +1,33 @@
+package com.ppiyaki.medicine.controller.dto;
+
+import java.util.Map;
+
+public record MedicineCandidate(
+        String itemSeq,
+        String itemName,
+        String entpName,
+        String mainIngr,
+        String formName,
+        String etcOtcName,
+        String className,
+        String ingrCode
+) {
+
+    public static MedicineCandidate fromMfdsItem(final Map<String, Object> item) {
+        return new MedicineCandidate(
+                getString(item, "ITEM_SEQ"),
+                getString(item, "ITEM_NAME"),
+                getString(item, "ENTP_NAME"),
+                getString(item, "MATERIAL_NAME"),
+                getString(item, "CHART"),
+                getString(item, "ETC_OTC_CODE"),
+                getString(item, "CLASS_NO"),
+                null
+        );
+    }
+
+    private static String getString(final Map<String, Object> item, final String key) {
+        final Object value = item.get(key);
+        return value != null ? value.toString() : null;
+    }
+}

--- a/src/main/java/com/ppiyaki/medicine/service/MedicineSearchService.java
+++ b/src/main/java/com/ppiyaki/medicine/service/MedicineSearchService.java
@@ -1,0 +1,46 @@
+package com.ppiyaki.medicine.service;
+
+import com.ppiyaki.common.mfds.CachedMfdsResponse;
+import com.ppiyaki.common.mfds.MfdsApiClient;
+import com.ppiyaki.medicine.controller.dto.MedicineCandidate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class MedicineSearchService {
+
+    private static final String OPERATION = "getDurPrdlstInfoList03";
+    private static final int DEFAULT_LIMIT = 10;
+    private static final int MAX_LIMIT = 50;
+
+    private final MfdsApiClient mfdsApiClient;
+
+    public MedicineSearchService(final MfdsApiClient mfdsApiClient) {
+        this.mfdsApiClient = mfdsApiClient;
+    }
+
+    public List<MedicineCandidate> search(final String query, final int limit) {
+        final int effectiveLimit = Math.min(Math.max(limit, 1), MAX_LIMIT);
+
+        final Map<String, String> params = new LinkedHashMap<>();
+        params.put("itemName", query);
+        params.put("numOfRows", String.valueOf(effectiveLimit));
+        params.put("pageNo", "1");
+
+        final String cacheKey = "search:" + query.strip().toLowerCase();
+        final CachedMfdsResponse response = mfdsApiClient.call(OPERATION, params, cacheKey);
+
+        return response.items().stream()
+                .map(MedicineCandidate::fromMfdsItem)
+                .limit(effectiveLimit)
+                .toList();
+    }
+
+    public List<MedicineCandidate> search(final String query) {
+        return search(query, DEFAULT_LIMIT);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,9 @@ kakao:
     issuer: ${KAKAO_OIDC_ISSUER:https://kauth.kakao.com}
     jwks-uri: ${KAKAO_OIDC_JWKS_URI:https://kauth.kakao.com/.well-known/jwks.json}
     audience: ${KAKAO_OIDC_AUDIENCE:local-kakao-app-key}
+
+mfds:
+  api:
+    base-url: apis.data.go.kr/1471000/DURPrdlstInfoService03
+    connect-timeout: 2000
+    read-timeout: 5000


### PR DESCRIPTION
Closes #145

## AS-IS
- 식약처 DUR 품목 정보를 호출하는 인프라 없음
- 약물 검색(itemName → itemSeq 매칭) 불가

## TO-BE
### MFDS 공통 인프라 (`com.ppiyaki.common.mfds`)
- `MfdsApiProperties`: 식약처 API 설정 (서비스키, base URL, 타임아웃). `@ConditionalOnProperty` — env 없으면 비활성
- `MfdsApiClient`: RestClient 기반 공용 호출기. 캐시 연동, JSON 파싱, 에러 처리 내장
- `MfdsResponseCache` 인터페이스 + `InMemoryMfdsResponseCache` (ConcurrentHashMap, 24h TTL). Redis 마이그레이션 인터페이스 추상화
- `CachedMfdsResponse`: 캐시 값 record

### 약물 검색 (`com.ppiyaki.medicine`)
- `MedicineSearchService`: `getDurPrdlstInfoList03` 호출 → `MedicineCandidate` 리스트 반환
- `MedicineCandidate` DTO: itemSeq, itemName, entpName, mainIngr, formName, className 등

### 환경변수
- `MFDS_API_SERVICE_KEY`: relaxed binding으로 `mfds.api.service-key`에 자동 매핑
- `application.yml`: base-url, 타임아웃만 (service-key는 env 전용 → 없으면 빈 미생성)
- `.env.example`, `backend-cd.yml` 갱신

## Feature Spec
- `docs/features/medicine-search.md` PR 2

## 보호 영역 변경
- `application.yml`, `.env.example`, `backend-cd.yml` → `needs-human-review`

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅ BUILD SUCCESSFUL
- 식약처 API 키 활성화 확인 (타이레놀 검색 200 OK)

## 후속
- #146 MedicineMatchService (fuzzy 매칭)
- #147 검색 REST API 엔드포인트

---

### AI 체크리스트
- [x] type:feat, scope:medicine, ai-generated, needs-human-review
- [x] API 엔드포인트 추가 없음 (서비스 계층만) → Notion 갱신 불필요