### PR TITLE
feat(medicine): MedicineMatchService — fuzzy 매칭 + 사유 메모 자동 생성

### DIFF
--- a/src/main/java/com/ppiyaki/medicine/service/MatchResult.java
+++ b/src/main/java/com/ppiyaki/medicine/service/MatchResult.java
@@ -1,0 +1,14 @@
+package com.ppiyaki.medicine.service;
+
+import com.ppiyaki.medicine.controller.dto.MedicineCandidate;
+import java.util.List;
+import java.util.Optional;
+
+public record MatchResult(
+        MatchType matchType,
+        Optional<MedicineCandidate> matched,
+        List<MedicineCandidate> alternatives,
+        double similarity,
+        String reason
+) {
+}

--- a/src/main/java/com/ppiyaki/medicine/service/MatchType.java
+++ b/src/main/java/com/ppiyaki/medicine/service/MatchType.java
@@ -1,0 +1,9 @@
+package com.ppiyaki.medicine.service;
+
+public enum MatchType {
+
+    EXACT,
+    FUZZY_AUTO,
+    MANUAL_REQUIRED,
+    NO_MATCH
+}

--- a/src/main/java/com/ppiyaki/medicine/service/MedicineMatchService.java
+++ b/src/main/java/com/ppiyaki/medicine/service/MedicineMatchService.java
@@ -1,0 +1,154 @@
+package com.ppiyaki.medicine.service;
+
+import com.ppiyaki.medicine.controller.dto.MedicineCandidate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class MedicineMatchService {
+
+    private static final Logger log = LoggerFactory.getLogger(MedicineMatchService.class);
+    private static final double MANUAL_REQUIRED_THRESHOLD = 0.50;
+
+    private final MedicineSearchService searchService;
+    private final double fuzzyAutoThreshold;
+
+    public MedicineMatchService(
+            final MedicineSearchService searchService,
+            @Value("${medicine.matching.fuzzy-auto-threshold:0.90}") final double fuzzyAutoThreshold
+    ) {
+        this.searchService = searchService;
+        this.fuzzyAutoThreshold = fuzzyAutoThreshold;
+    }
+
+    public MatchResult match(
+            final String ocrText,
+            final Optional<String> dosageHint,
+            final Optional<String> formHint
+    ) {
+        final String normalized = normalize(ocrText);
+        final List<MedicineCandidate> candidates = searchService.search(normalized, 20);
+
+        if (candidates.isEmpty()) {
+            return new MatchResult(MatchType.NO_MATCH, Optional.empty(), List.of(), 0.0,
+                    "유사한 약물을 찾지 못함");
+        }
+
+        for (final MedicineCandidate candidate : candidates) {
+            if (normalize(candidate.itemName()).equals(normalized)) {
+                log.debug("Exact match: '{}' → '{}'", ocrText, candidate.itemName());
+                return new MatchResult(MatchType.EXACT, Optional.of(candidate), List.of(), 1.0,
+                        "정확 일치");
+            }
+        }
+
+        final List<ScoredCandidate> scored = candidates.stream()
+                .map(c -> new ScoredCandidate(c, levenshteinSimilarity(normalized, normalize(c.itemName()))))
+                .sorted(Comparator.comparingDouble(ScoredCandidate::similarity).reversed())
+                .toList();
+
+        final ScoredCandidate top = scored.getFirst();
+
+        if (top.similarity() >= fuzzyAutoThreshold) {
+            final long highScoreCount = scored.stream()
+                    .filter(s -> s.similarity() >= fuzzyAutoThreshold)
+                    .count();
+
+            final boolean dosageMatches = dosageHint
+                    .map(hint -> top.candidate().mainIngr() != null
+                            && top.candidate().mainIngr().toLowerCase().contains(hint.toLowerCase()))
+                    .orElse(true);
+
+            if (highScoreCount == 1 && dosageMatches) {
+                final String reason = generateReason(ocrText, top.candidate(), top.similarity());
+                log.info("Fuzzy auto match: '{}' → '{}' (sim={})",
+                        ocrText, top.candidate().itemName(), top.similarity());
+                return new MatchResult(MatchType.FUZZY_AUTO, Optional.of(top.candidate()),
+                        List.of(), top.similarity(), reason);
+            }
+        }
+
+        final List<MedicineCandidate> eligible = scored.stream()
+                .filter(s -> s.similarity() >= MANUAL_REQUIRED_THRESHOLD)
+                .limit(5)
+                .map(ScoredCandidate::candidate)
+                .toList();
+
+        if (!eligible.isEmpty()) {
+            return new MatchResult(MatchType.MANUAL_REQUIRED, Optional.empty(), eligible,
+                    top.similarity(),
+                    "동명이품 또는 유사 약물 " + eligible.size() + "개. 수동 선택 필요.");
+        }
+
+        return new MatchResult(MatchType.NO_MATCH, Optional.empty(), List.of(), top.similarity(),
+                "유사한 약물을 찾지 못함");
+    }
+
+    private String generateReason(
+            final String ocrText,
+            final MedicineCandidate matched,
+            final double similarity
+    ) {
+        final int editDist = levenshteinDistance(normalize(ocrText), normalize(matched.itemName()));
+        final StringBuilder reason = new StringBuilder();
+        reason.append("OCR '").append(ocrText).append("'와 ");
+        if (editDist == 1) {
+            reason.append("1글자 차이. ");
+        } else {
+            reason.append(editDist).append("글자 차이. ");
+        }
+        reason.append("식약처 등록 약물 '").append(matched.itemName()).append("'(으)로 자동 매칭.");
+        return reason.toString();
+    }
+
+    static String normalize(final String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.strip()
+                .replaceAll("[\\s()\\[\\]\\-]", "")
+                .replaceAll("밀리그람|밀리그램", "mg")
+                .replaceAll("그람|그램", "g")
+                .replaceAll("밀리리터", "ml")
+                .toLowerCase();
+    }
+
+    static double levenshteinSimilarity(final String a, final String b) {
+        if (a.isEmpty() && b.isEmpty()) {
+            return 1.0;
+        }
+        final int maxLen = Math.max(a.length(), b.length());
+        return 1.0 - ((double) levenshteinDistance(a, b) / maxLen);
+    }
+
+    static int levenshteinDistance(final String a, final String b) {
+        final int lenA = a.length();
+        final int lenB = b.length();
+        final int[][] dp = new int[lenA + 1][lenB + 1];
+
+        for (int i = 0; i <= lenA; i++) {
+            dp[i][0] = i;
+        }
+        for (int j = 0; j <= lenB; j++) {
+            dp[0][j] = j;
+        }
+        for (int i = 1; i <= lenA; i++) {
+            for (int j = 1; j <= lenB; j++) {
+                final int cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
+                dp[i][j] = Math.min(Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1),
+                        dp[i - 1][j - 1] + cost);
+            }
+        }
+        return dp[lenA][lenB];
+    }
+
+    private record ScoredCandidate(MedicineCandidate candidate, double similarity) {
+    }
+}

--- a/src/test/java/com/ppiyaki/medicine/service/MedicineMatchServiceTest.java
+++ b/src/test/java/com/ppiyaki/medicine/service/MedicineMatchServiceTest.java
@@ -1,0 +1,84 @@
+package com.ppiyaki.medicine.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MedicineMatchServiceTest {
+
+    @Nested
+    @DisplayName("normalize")
+    class NormalizeTest {
+
+        @Test
+        @DisplayName("공백·괄호·하이픈 제거")
+        void removesWhitespaceAndBrackets() {
+            assertThat(MedicineMatchService.normalize("타이레놀정 500mg (아세트아미노펜)"))
+                    .isEqualTo("타이레놀정500mg아세트아미노펜");
+        }
+
+        @Test
+        @DisplayName("밀리그람 → mg 변환")
+        void convertsMilligrams() {
+            assertThat(MedicineMatchService.normalize("타이레놀정500밀리그람"))
+                    .isEqualTo("타이레놀정500mg");
+        }
+
+        @Test
+        @DisplayName("null은 빈 문자열")
+        void nullReturnsEmpty() {
+            assertThat(MedicineMatchService.normalize(null)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("levenshteinDistance")
+    class LevenshteinTest {
+
+        @Test
+        @DisplayName("동일 문자열 거리 0")
+        void identicalStringsZero() {
+            assertThat(MedicineMatchService.levenshteinDistance("이부프로펜", "이부프로펜")).isZero();
+        }
+
+        @Test
+        @DisplayName("1글자 차이 거리 1")
+        void oneCharDifference() {
+            assertThat(MedicineMatchService.levenshteinDistance("이부프로펜", "이부프로멘")).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("완전히 다른 문자열")
+        void completelyDifferent() {
+            assertThat(MedicineMatchService.levenshteinDistance("타이레놀", "아스피린"))
+                    .isGreaterThan(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("levenshteinSimilarity")
+    class SimilarityTest {
+
+        @Test
+        @DisplayName("동일 문자열 유사도 1.0")
+        void identicalIsOne() {
+            assertThat(MedicineMatchService.levenshteinSimilarity("타이레놀", "타이레놀"))
+                    .isEqualTo(1.0);
+        }
+
+        @Test
+        @DisplayName("1글자 차이면 0.8 이상")
+        void oneCharHighSimilarity() {
+            final double sim = MedicineMatchService.levenshteinSimilarity("이부프로펜", "이부프로멘");
+            assertThat(sim).isGreaterThanOrEqualTo(0.8);
+        }
+
+        @Test
+        @DisplayName("빈 문자열끼리 유사도 1.0")
+        void emptyStringsAreIdentical() {
+            assertThat(MedicineMatchService.levenshteinSimilarity("", "")).isEqualTo(1.0);
+        }
+    }
+}


### PR DESCRIPTION
Closes #146

## AS-IS
- 약물명 검색은 가능하나 OCR 텍스트 → itemSeq 자동 매칭 없음

## TO-BE
- `MatchType` enum: EXACT / FUZZY_AUTO / MANUAL_REQUIRED / NO_MATCH
- `MatchResult` record: 매칭 결과 + 유사도 + 사유 메모
- `MedicineMatchService`:
  - 정규화 (공백·괄호 제거, 밀리그람→mg 등 단위 변환)
  - 1단계 정확 매칭 → 2단계 Levenshtein 편집거리 fuzzy → 3단계 후보 분류
  - 임계치 **0.90** (`medicine.matching.fuzzy-auto-threshold` config 노출)
  - 사유 메모 자동 생성 ("OCR '이부프로멘정'와 1글자 차이. 식약처 등록 약물 '이부프로펜정'으로 자동 매칭.")

## 단위 테스트
- `normalize` — 공백·괄호·단위 변환
- `levenshteinDistance` — 동일/1글자/완전 다른 문자열
- `levenshteinSimilarity` — 경계값 검증

## Feature Spec
- `docs/features/medicine-search.md` PR 3

## 선행
- #148 (MedicineSearchService) 머지됨

## 후속
- #147 검색 REST API 엔드포인트

---

### AI 체크리스트
- [x] type:feat, scope:medicine, ai-generated
- [x] API 엔드포인트 추가 없음 (서비스 계층만)