### PR TITLE
feat(medicine): 약물 검색 REST API — GET /api/v1/medicines/search

### DIFF
--- a/src/main/java/com/ppiyaki/medicine/controller/MedicineSearchController.java
+++ b/src/main/java/com/ppiyaki/medicine/controller/MedicineSearchController.java
@@ -1,0 +1,35 @@
+package com.ppiyaki.medicine.controller;
+
+import com.ppiyaki.medicine.controller.dto.MedicineCandidate;
+import com.ppiyaki.medicine.service.MedicineSearchService;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/medicines")
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class MedicineSearchController {
+
+    private final MedicineSearchService medicineSearchService;
+
+    public MedicineSearchController(final MedicineSearchService medicineSearchService) {
+        this.medicineSearchService = medicineSearchService;
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<MedicineSearchResponse> search(
+            @RequestParam final String q,
+            @RequestParam(defaultValue = "10") final int limit
+    ) {
+        final List<MedicineCandidate> candidates = medicineSearchService.search(q, limit);
+        return ResponseEntity.ok(new MedicineSearchResponse(candidates));
+    }
+
+    public record MedicineSearchResponse(List<MedicineCandidate> responses) {
+    }
+}


### PR DESCRIPTION
Closes #147

## AS-IS
- MedicineSearchService 존재하지만 REST API 엔드포인트 없음

## TO-BE
- `GET /api/v1/medicines/search?q=타이레놀&limit=10`
- `MedicineSearchController` (별도 컨트롤러, `@ConditionalOnProperty`)
- 응답: `{ responses: [MedicineCandidate, ...] }`
- 인증 필수, limit 기본 10 / 최대 50

## Feature Spec
- `docs/features/medicine-search.md` PR 4

## 선행
- #148 SearchService, #149 MatchService 머지됨

## 후속
- 로컬 E2E 실테스트 (식약처 API 실호출)
- medicine-dur 구현 착수

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅

---

### AI 체크리스트
- [x] type:feat, scope:medicine, ai-generated
- [x] API 엔드포인트 추가 → Notion API 명세 갱신 대상 ⚠️