### PR TITLE
fix(infra): MFDS API 클라이언트 버그 수정 + 파라미터 누락 핸들러

### DIFF
--- a/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -52,7 +53,8 @@ public class GlobalExceptionHandler {
         return lastDot < 0 ? propertyPath : propertyPath.substring(lastDot + 1);
     }
 
-    @ExceptionHandler({HttpMessageNotReadableException.class, MethodArgumentTypeMismatchException.class})
+    @ExceptionHandler({HttpMessageNotReadableException.class, MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class})
     public ResponseEntity<ErrorResponse> handleMalformedRequest(final Exception exception) {
         log.debug("Malformed request: {}", exception.getMessage());
         final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MALFORMED_REQUEST);

--- a/src/main/java/com/ppiyaki/common/mfds/MfdsApiClient.java
+++ b/src/main/java/com/ppiyaki/common/mfds/MfdsApiClient.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -18,7 +20,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 @ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
@@ -66,14 +67,17 @@ public class MfdsApiClient {
         final long startTime = System.currentTimeMillis();
 
         try {
-            final UriComponentsBuilder uriBuilder = UriComponentsBuilder
-                    .fromHttpUrl("https://" + properties.baseUrl() + "/" + operation)
-                    .queryParam("serviceKey", properties.serviceKey())
-                    .queryParam("type", "json");
+            final StringBuilder urlBuilder = new StringBuilder()
+                    .append("https://").append(properties.baseUrl()).append("/").append(operation)
+                    .append("?serviceKey=").append(properties.serviceKey())
+                    .append("&type=json");
 
-            params.forEach(uriBuilder::queryParam);
+            for (final Map.Entry<String, String> entry : params.entrySet()) {
+                urlBuilder.append("&").append(entry.getKey()).append("=")
+                        .append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
+            }
 
-            final URI uri = uriBuilder.build(true).toUri();
+            final URI uri = URI.create(urlBuilder.toString());
             final String responseBody = restClient.get()
                     .uri(uri)
                     .retrieve()
@@ -119,17 +123,25 @@ public class MfdsApiClient {
             final JsonNode itemsNode = body.path("items");
 
             if (!itemsNode.isMissingNode() && !itemsNode.isNull()) {
-                final JsonNode itemNode = itemsNode.path("item");
-                if (itemNode.isArray()) {
-                    for (final JsonNode item : itemNode) {
+                if (itemsNode.isArray()) {
+                    for (final JsonNode item : itemsNode) {
                         items.add(objectMapper.convertValue(item,
                                 new TypeReference<Map<String, Object>>() {
                                 }));
                     }
-                } else if (itemNode.isObject()) {
-                    items.add(objectMapper.convertValue(itemNode,
-                            new TypeReference<Map<String, Object>>() {
-                            }));
+                } else if (itemsNode.isObject()) {
+                    final JsonNode itemNode = itemsNode.path("item");
+                    if (itemNode.isArray()) {
+                        for (final JsonNode item : itemNode) {
+                            items.add(objectMapper.convertValue(item,
+                                    new TypeReference<Map<String, Object>>() {
+                                    }));
+                        }
+                    } else if (itemNode.isObject()) {
+                        items.add(objectMapper.convertValue(itemNode,
+                                new TypeReference<Map<String, Object>>() {
+                                }));
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
로컬 E2E 테스트에서 발견된 버그 2건 + 예외 핸들러 1건 수정.

### 1. URL 인코딩 혼재 (500 에러)
- serviceKey(이미 URL-encoded)와 한국어 파라미터(미인코딩)를 UriComponentsBuilder로 한 번에 처리 시 인코딩 충돌
- 수정: StringBuilder 직접 조립 + URLEncoder.encode(한국어 파라미터만)

### 2. JSON 응답 파싱 (빈 결과)
- data.go.kr `type=json` 응답은 `body.items`가 직접 배열이지만, 코드가 `body.items.item` 중첩 기대
- 수정: isArray() / isObject() 분기로 양쪽 처리

### 3. MissingServletRequestParameterException 핸들러
- `q` 파라미터 누락 시 500 → 400 `MALFORMED_REQUEST`로 변경
- GlobalExceptionHandler에 MissingServletRequestParameterException 추가

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅
- 로컬 E2E 10건 전체 통과 확인 (타이레놀/이부프로펜 검색, 캐시 히트 32배 속도 향상, 인증 401, limit 보정 등)

---
### AI 체크리스트
- [x] type:fix, scope:infra, ai-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **버그 수정**
  * API 요청 시 누락된 파라미터에 대한 에러 처리 개선
  * 외부 API 응답 파싱 안정성 강화 및 다양한 응답 형식 지원 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->