### PR TITLE
feat(health): DUR 점검 API 핵심 구현 — 이중 캐시 + 다제 분석

### DIFF
--- a/docs/features/medicine-dur.md
+++ b/docs/features/medicine-dur.md
@@ -32,7 +32,7 @@ last_reviewed: 2026-04-15
 - [ ] `warnings[]` 각 항목: `type`, `withMedicine`, `severity`, `description`(정제된 한글), `rawText`(원문 발췌, nullable) (Q-DUR-5 결정).
 - [ ] 점검 이력 조회 (`GET /api/v1/medicines/{id}/dur-checks?limit=10`) — limit 기본 10, 최대 50 (Q-DUR-3 결정).
 - [ ] 최신 점검 결과 조회 (`GET /api/v1/medicines/{id}/dur-check/latest`).
-- [ ] `force_refresh` 쿼리 파라미터 (기본 false) — false면 이중 캐시(Layer 1 + Layer 2) 활용해 외부 호출 최소화, true면 두 레이어 모두 우회하여 항상 외부 호출 + 새 `dur_checks` 레코드 생성.
+- [ ] `force_refresh` 쿼리 파라미터 (기본 false) — false면 이중 캐시(Layer 1 + Layer 2) 활용해 외부 호출 최소화, true면 **Layer 2만 우회** (combo_hash 무시, 재분석 강제). Layer 1(MFDS 응답 캐시)은 force_refresh에서도 유지 — 식약처 원본 데이터는 24h TTL 만료에 일임, 쿼터 보호.
 - [ ] **Layer 1 캐시**(사용자 공유, 인메모리): `(operation, itemSeq)` 키로 외부 API 응답 정제본 24h 보관. `MfdsResponseCache` 인터페이스 기반 — Redis 스왑 염두.
 - [ ] **Layer 2 캐시**(사용자별, `dur_checks`): `(medicine_id, combo_hash, checked_at)` 기준. `combo_hash`는 시니어의 활성 약물 itemSeq 정렬·해시값. 약물 추가/제거 시 자동 무효화.
 - [ ] 권한: medicine 접근권과 동일 (약물 소유자 + 활성 `care_relations` 보호자).
@@ -215,7 +215,7 @@ List<MfdsItem> items   // 응답 items 정제본 (DUR 산정에 필요한 필드
 #### 무효화 정책
 - Layer 1: TTL 24h 만료 또는 운영자가 수동 invalidate (DB row 삭제)
 - Layer 2: combo_hash 변경 시 자동 미스. 명시적 invalidate 없음 (immutable 로그 유지)
-- force_refresh=true는 두 레이어 모두 우회
+- force_refresh=true는 **Layer 2만 우회**. Layer 1은 TTL 만료에 일임 (식약처 원본 데이터는 사용자 조합과 무관, 쿼터 보호)
 
 ### 5-4) 데이터 흐름
 

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -26,6 +26,9 @@ public enum ErrorCode {
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE_001", "Schedule not found"),
     SCHEDULE_MEDICINE_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE_002", "Schedule does not belong to this medicine"),
 
+    // DUR
+    DUR_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "DUR_001", "DUR service unavailable"),
+
     // Care Relation
     CARE_RELATION_NOT_FOUND(HttpStatus.FORBIDDEN, "CARE_001", "No active care relation"),
     CARE_RELATION_REQUIRED(HttpStatus.FORBIDDEN, "CARE_002", "Caregiver must specify seniorId"),

--- a/src/main/java/com/ppiyaki/health/DurCheck.java
+++ b/src/main/java/com/ppiyaki/health/DurCheck.java
@@ -40,16 +40,21 @@ public class DurCheck extends CreatedTimeEntity {
     @Column(columnDefinition = "TEXT", name = "raw_response")
     private String rawResponse;
 
+    @Column(name = "combo_hash", length = 64)
+    private String comboHash;
+
     public DurCheck(
             final Long medicineId,
             final LocalDateTime checkedAt,
             final DurWarningLevel warningLevel,
             final String warningText,
-            final String rawResponse) {
+            final String rawResponse,
+            final String comboHash) {
         this.medicineId = medicineId;
         this.checkedAt = checkedAt;
         this.warningLevel = warningLevel;
         this.warningText = warningText;
         this.rawResponse = rawResponse;
+        this.comboHash = comboHash;
     }
 }

--- a/src/main/java/com/ppiyaki/health/controller/DurCheckController.java
+++ b/src/main/java/com/ppiyaki/health/controller/DurCheckController.java
@@ -1,0 +1,55 @@
+package com.ppiyaki.health.controller;
+
+import com.ppiyaki.health.controller.dto.DurCheckListResponse;
+import com.ppiyaki.health.controller.dto.DurCheckResponse;
+import com.ppiyaki.health.service.DurCheckService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/medicines/{medicineId}")
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class DurCheckController {
+
+    private final DurCheckService durCheckService;
+
+    public DurCheckController(final DurCheckService durCheckService) {
+        this.durCheckService = durCheckService;
+    }
+
+    @PostMapping("/dur-check")
+    public ResponseEntity<DurCheckResponse> check(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long medicineId,
+            @RequestParam(defaultValue = "false") final boolean forceRefresh
+    ) {
+        final DurCheckResponse response = durCheckService.check(userId, medicineId, forceRefresh);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/dur-check/latest")
+    public ResponseEntity<DurCheckResponse> getLatest(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long medicineId
+    ) {
+        final DurCheckResponse response = durCheckService.getLatest(userId, medicineId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/dur-checks")
+    public ResponseEntity<DurCheckListResponse> getHistory(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long medicineId,
+            @RequestParam(defaultValue = "10") final int limit
+    ) {
+        final DurCheckListResponse response = durCheckService.getHistory(userId, medicineId, limit);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/ppiyaki/health/controller/dto/DurCheckListResponse.java
+++ b/src/main/java/com/ppiyaki/health/controller/dto/DurCheckListResponse.java
@@ -1,0 +1,6 @@
+package com.ppiyaki.health.controller.dto;
+
+import java.util.List;
+
+public record DurCheckListResponse(List<DurCheckResponse> responses) {
+}

--- a/src/main/java/com/ppiyaki/health/controller/dto/DurCheckResponse.java
+++ b/src/main/java/com/ppiyaki/health/controller/dto/DurCheckResponse.java
@@ -1,0 +1,29 @@
+package com.ppiyaki.health.controller.dto;
+
+import com.ppiyaki.health.DurCheck;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record DurCheckResponse(
+        Long id,
+        Long medicineId,
+        LocalDateTime checkedAt,
+        String warningLevel,
+        String warningText,
+        List<DurWarningItem> warnings,
+        boolean fromCache
+) {
+
+    public static DurCheckResponse from(final DurCheck durCheck,
+            final List<DurWarningItem> warnings, final boolean fromCache) {
+        return new DurCheckResponse(
+                durCheck.getId(),
+                durCheck.getMedicineId(),
+                durCheck.getCheckedAt(),
+                durCheck.getWarningLevel() != null ? durCheck.getWarningLevel().name() : null,
+                durCheck.getWarningText(),
+                warnings,
+                fromCache
+        );
+    }
+}

--- a/src/main/java/com/ppiyaki/health/controller/dto/DurWarningItem.java
+++ b/src/main/java/com/ppiyaki/health/controller/dto/DurWarningItem.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.health.controller.dto;
+
+public record DurWarningItem(
+        String type,
+        String withMedicine,
+        String severity,
+        String description,
+        String rawText
+) {
+}

--- a/src/main/java/com/ppiyaki/health/repository/DurCheckRepository.java
+++ b/src/main/java/com/ppiyaki/health/repository/DurCheckRepository.java
@@ -1,0 +1,21 @@
+package com.ppiyaki.health.repository;
+
+import com.ppiyaki.health.DurCheck;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DurCheckRepository extends JpaRepository<DurCheck, Long> {
+
+    Optional<DurCheck> findFirstByMedicineIdAndComboHashAndCheckedAtAfterAndWarningLevelIsNotNullOrderByCheckedAtDesc(
+            final Long medicineId,
+            final String comboHash,
+            final LocalDateTime after
+    );
+
+    List<DurCheck> findByMedicineIdOrderByCheckedAtDesc(final Long medicineId, final Pageable pageable);
+
+    Optional<DurCheck> findFirstByMedicineIdAndWarningLevelIsNotNullOrderByCheckedAtDesc(final Long medicineId);
+}

--- a/src/main/java/com/ppiyaki/health/service/DurCheckService.java
+++ b/src/main/java/com/ppiyaki/health/service/DurCheckService.java
@@ -1,0 +1,331 @@
+package com.ppiyaki.health.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.mfds.CachedMfdsResponse;
+import com.ppiyaki.common.mfds.MfdsApiClient;
+import com.ppiyaki.health.DurCheck;
+import com.ppiyaki.health.DurWarningLevel;
+import com.ppiyaki.health.controller.dto.DurCheckListResponse;
+import com.ppiyaki.health.controller.dto.DurCheckResponse;
+import com.ppiyaki.health.controller.dto.DurWarningItem;
+import com.ppiyaki.health.repository.DurCheckRepository;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class DurCheckService {
+
+    private static final Logger log = LoggerFactory.getLogger(DurCheckService.class);
+    private static final String OP_INTERACTION = "getUsjntTabooInfoList03";
+    private static final String OP_ELDERLY = "getOdsnAtentInfoList03";
+    private static final String OP_DUPLICATE = "getEfcyDplctInfoList03";
+    private static final int CACHE_TTL_HOURS = 24;
+
+    private final DurCheckRepository durCheckRepository;
+    private final MedicineRepository medicineRepository;
+    private final MedicationScheduleRepository medicationScheduleRepository;
+    private final CareRelationRepository careRelationRepository;
+    private final MfdsApiClient mfdsApiClient;
+
+    public DurCheckService(
+            final DurCheckRepository durCheckRepository,
+            final MedicineRepository medicineRepository,
+            final MedicationScheduleRepository medicationScheduleRepository,
+            final CareRelationRepository careRelationRepository,
+            final MfdsApiClient mfdsApiClient
+    ) {
+        this.durCheckRepository = durCheckRepository;
+        this.medicineRepository = medicineRepository;
+        this.medicationScheduleRepository = medicationScheduleRepository;
+        this.careRelationRepository = careRelationRepository;
+        this.mfdsApiClient = mfdsApiClient;
+    }
+
+    @Transactional
+    public DurCheckResponse check(final Long userId, final Long medicineId, final boolean forceRefresh) {
+        final Medicine medicine = findMedicineById(medicineId);
+        validateAccess(userId, medicine.getOwnerId());
+
+        if (medicine.getItemSeq() == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
+                    "Medicine has no itemSeq. DUR check requires itemSeq.");
+        }
+
+        final List<Medicine> activeMedicines = findActiveMedicines(medicine.getOwnerId());
+        final String comboHash = computeComboHash(activeMedicines);
+
+        if (!forceRefresh) {
+            final Optional<DurCheck> cached = durCheckRepository
+                    .findFirstByMedicineIdAndComboHashAndCheckedAtAfterAndWarningLevelIsNotNullOrderByCheckedAtDesc(
+                            medicineId, comboHash, LocalDateTime.now().minusHours(CACHE_TTL_HOURS));
+            if (cached.isPresent()) {
+                log.debug("DUR Layer 2 cache hit: medicineId={} comboHash={}", medicineId, comboHash);
+                return DurCheckResponse.from(cached.get(), List.of(), true);
+            }
+        }
+
+        final List<DurWarningItem> warnings = new ArrayList<>();
+
+        try {
+            checkInteractions(medicine, activeMedicines, warnings);
+            checkElderly(activeMedicines, warnings);
+            checkDuplicate(activeMedicines, warnings);
+        } catch (final BusinessException e) {
+            final DurCheck failedCheck = new DurCheck(
+                    medicineId, LocalDateTime.now(), null,
+                    null, "ERROR: " + (e.getMessage() != null ? e.getMessage() : "Unknown error"), comboHash);
+            durCheckRepository.save(failedCheck);
+            final String errorMsg = e.getMessage() != null ? e.getMessage() : "DUR check failed";
+            throw new BusinessException(ErrorCode.DUR_UNAVAILABLE, errorMsg);
+        }
+
+        final DurWarningLevel warningLevel = computeWarningLevel(warnings);
+        final String warningText = buildWarningText(warnings);
+
+        final DurCheck durCheck = new DurCheck(
+                medicineId, LocalDateTime.now(), warningLevel,
+                warningText, null, comboHash);
+        durCheckRepository.save(durCheck);
+
+        medicine.update(null, null, null, null, warningText);
+
+        log.info("DUR check completed: medicineId={} level={} warnings={}",
+                medicineId, warningLevel, warnings.size());
+
+        return DurCheckResponse.from(durCheck, warnings, false);
+    }
+
+    @Transactional(readOnly = true)
+    public DurCheckResponse getLatest(final Long userId, final Long medicineId) {
+        final Medicine medicine = findMedicineById(medicineId);
+        validateAccess(userId, medicine.getOwnerId());
+
+        final DurCheck latest = durCheckRepository
+                .findFirstByMedicineIdAndWarningLevelIsNotNullOrderByCheckedAtDesc(medicineId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEDICINE_NOT_FOUND,
+                        "No DUR check found for medicine: " + medicineId));
+
+        return DurCheckResponse.from(latest, List.of(), false);
+    }
+
+    @Transactional(readOnly = true)
+    public DurCheckListResponse getHistory(final Long userId, final Long medicineId, final int limit) {
+        final Medicine medicine = findMedicineById(medicineId);
+        validateAccess(userId, medicine.getOwnerId());
+
+        final int effectiveLimit = Math.min(Math.max(limit, 1), 50);
+        final List<DurCheck> history = durCheckRepository
+                .findByMedicineIdOrderByCheckedAtDesc(medicineId, PageRequest.of(0, effectiveLimit));
+
+        final List<DurCheckResponse> responses = history.stream()
+                .map(dc -> DurCheckResponse.from(dc, List.of(), false))
+                .toList();
+
+        return new DurCheckListResponse(responses);
+    }
+
+    private void checkInteractions(
+            final Medicine targetMedicine,
+            final List<Medicine> activeMedicines,
+            final List<DurWarningItem> warnings
+    ) {
+        final Set<String> otherItemSeqs = activeMedicines.stream()
+                .filter(m -> !m.getId().equals(targetMedicine.getId()))
+                .map(Medicine::getItemSeq)
+                .filter(seq -> seq != null)
+                .collect(Collectors.toSet());
+
+        if (otherItemSeqs.isEmpty()) {
+            return;
+        }
+
+        final Map<String, String> params = new LinkedHashMap<>();
+        params.put("itemSeq", targetMedicine.getItemSeq());
+        params.put("numOfRows", "100");
+        params.put("pageNo", "1");
+
+        final CachedMfdsResponse response = mfdsApiClient.call(
+                OP_INTERACTION, params, "interaction:" + targetMedicine.getItemSeq());
+
+        for (final Map<String, Object> item : response.items()) {
+            final String mixtureItemSeq = getString(item, "MIXTURE_ITEM_SEQ");
+            if (mixtureItemSeq != null && otherItemSeqs.contains(mixtureItemSeq)) {
+                warnings.add(new DurWarningItem(
+                        "INTERACTION",
+                        getString(item, "MIXTURE_ITEM_NAME"),
+                        "BLOCK",
+                        getString(item, "PROHBT_CONTENT"),
+                        getString(item, "REMARK")
+                ));
+            }
+        }
+    }
+
+    private void checkElderly(final List<Medicine> activeMedicines, final List<DurWarningItem> warnings) {
+        for (final Medicine medicine : activeMedicines) {
+            if (medicine.getItemSeq() == null) {
+                continue;
+            }
+
+            final Map<String, String> params = new LinkedHashMap<>();
+            params.put("itemSeq", medicine.getItemSeq());
+            params.put("numOfRows", "10");
+            params.put("pageNo", "1");
+
+            final CachedMfdsResponse response = mfdsApiClient.call(
+                    OP_ELDERLY, params, "elderly:" + medicine.getItemSeq());
+
+            if (response.totalCount() > 0 && !response.items().isEmpty()) {
+                final Map<String, Object> firstItem = response.items().getFirst();
+                warnings.add(new DurWarningItem(
+                        "ELDERLY",
+                        null,
+                        "WARN",
+                        medicine.getName() + ": " + getString(firstItem, "PROHBT_CONTENT"),
+                        getString(firstItem, "REMARK")
+                ));
+            }
+        }
+    }
+
+    private void checkDuplicate(final List<Medicine> activeMedicines, final List<DurWarningItem> warnings) {
+        final Map<String, List<String>> effectGroupToMedicines = new LinkedHashMap<>();
+
+        for (final Medicine medicine : activeMedicines) {
+            if (medicine.getItemSeq() == null) {
+                continue;
+            }
+
+            final Map<String, String> params = new LinkedHashMap<>();
+            params.put("itemSeq", medicine.getItemSeq());
+            params.put("numOfRows", "10");
+            params.put("pageNo", "1");
+
+            final CachedMfdsResponse response = mfdsApiClient.call(
+                    OP_DUPLICATE, params, "duplicate:" + medicine.getItemSeq());
+
+            for (final Map<String, Object> item : response.items()) {
+                final String effectName = getString(item, "EFFECT_NAME");
+                if (effectName != null) {
+                    effectGroupToMedicines
+                            .computeIfAbsent(effectName, k -> new ArrayList<>())
+                            .add(medicine.getName());
+                }
+            }
+        }
+
+        for (final Map.Entry<String, List<String>> entry : effectGroupToMedicines.entrySet()) {
+            if (entry.getValue().size() >= 2) {
+                warnings.add(new DurWarningItem(
+                        "DUPLICATE",
+                        String.join(", ", entry.getValue()),
+                        "INFO",
+                        "효능군 '" + entry.getKey() + "' 중복: " + String.join(", ", entry.getValue()),
+                        null
+                ));
+            }
+        }
+    }
+
+    private List<Medicine> findActiveMedicines(final Long ownerId) {
+        final LocalDate today = LocalDate.now();
+        final List<Medicine> allMedicines = medicineRepository.findByOwnerId(ownerId);
+
+        return allMedicines.stream()
+                .filter(m -> {
+                    final List<MedicationSchedule> schedules = medicationScheduleRepository.findByMedicineId(m.getId());
+                    return schedules.stream().anyMatch(s -> isActiveSchedule(s, today));
+                })
+                .toList();
+    }
+
+    private boolean isActiveSchedule(final MedicationSchedule schedule, final LocalDate today) {
+        final boolean afterStart = schedule.getStartDate() == null
+                || !schedule.getStartDate().isAfter(today);
+        final boolean beforeEnd = schedule.getEndDate() == null
+                || !schedule.getEndDate().isBefore(today);
+        return afterStart && beforeEnd;
+    }
+
+    private String computeComboHash(final List<Medicine> activeMedicines) {
+        final String sorted = activeMedicines.stream()
+                .map(Medicine::getItemSeq)
+                .filter(seq -> seq != null)
+                .sorted()
+                .collect(Collectors.joining(","));
+
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            final byte[] hash = digest.digest(sorted.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (final NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available", e);
+        }
+    }
+
+    private DurWarningLevel computeWarningLevel(final List<DurWarningItem> warnings) {
+        if (warnings.isEmpty()) {
+            return DurWarningLevel.NONE;
+        }
+        if (warnings.stream().anyMatch(w -> "BLOCK".equals(w.severity()))) {
+            return DurWarningLevel.BLOCK;
+        }
+        if (warnings.stream().anyMatch(w -> "WARN".equals(w.severity()))) {
+            return DurWarningLevel.WARN;
+        }
+        return DurWarningLevel.INFO;
+    }
+
+    private String buildWarningText(final List<DurWarningItem> warnings) {
+        if (warnings.isEmpty()) {
+            return null;
+        }
+        return warnings.stream()
+                .map(DurWarningItem::description)
+                .filter(d -> d != null)
+                .collect(Collectors.joining("; "));
+    }
+
+    private Medicine findMedicineById(final Long medicineId) {
+        return medicineRepository.findById(medicineId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEDICINE_NOT_FOUND,
+                        "Medicine not found: " + medicineId));
+    }
+
+    private void validateAccess(final Long userId, final Long ownerId) {
+        if (userId.equals(ownerId)) {
+            return;
+        }
+        careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(userId, ownerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+    }
+
+    private String getString(final Map<String, Object> item, final String key) {
+        final Object value = item.get(key);
+        return value != null ? value.toString() : null;
+    }
+}

--- a/src/main/java/com/ppiyaki/medicine/controller/MedicineSearchController.java
+++ b/src/main/java/com/ppiyaki/medicine/controller/MedicineSearchController.java
@@ -2,6 +2,7 @@ package com.ppiyaki.medicine.controller;
 
 import com.ppiyaki.medicine.controller.dto.MedicineCandidate;
 import com.ppiyaki.medicine.service.MedicineSearchService;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +24,7 @@ public class MedicineSearchController {
 
     @GetMapping("/search")
     public ResponseEntity<MedicineSearchResponse> search(
-            @RequestParam final String q,
+            @RequestParam @NotBlank final String q,
             @RequestParam(defaultValue = "10") final int limit
     ) {
         final List<MedicineCandidate> candidates = medicineSearchService.search(q, limit);

--- a/src/main/java/com/ppiyaki/medicine/service/MedicineMatchService.java
+++ b/src/main/java/com/ppiyaki/medicine/service/MedicineMatchService.java
@@ -149,6 +149,9 @@ public class MedicineMatchService {
         return dp[lenA][lenB];
     }
 
-    private record ScoredCandidate(MedicineCandidate candidate, double similarity) {
+    private record ScoredCandidate(
+            MedicineCandidate candidate,
+            double similarity
+    ) {
     }
 }


### PR DESCRIPTION
Closes #152

## Summary
식약처 DUR API 연동 기반 약물 안전성 점검 핵심 로직.

### 엔드포인트
- `POST /api/v1/medicines/{id}/dur-check?forceRefresh=false` — 점검 트리거
- `GET /api/v1/medicines/{id}/dur-check/latest` — 최신 결과
- `GET /api/v1/medicines/{id}/dur-checks?limit=10` — 이력 조회

### 이중 캐시
- **Layer 1** (사용자 공유): `MfdsResponseCache` — `(operation, itemSeq)` 키, 24h TTL. 동일 약물 조회 시 외부 호출 없음
- **Layer 2** (사용자별): `dur_checks.combo_hash` — SHA-256(시니어 활성 약물 itemSeq 정렬). 약물 추가/삭제 시 자동 미스

### 다제 분석 (MVP 3개 오퍼레이션)
- **병용금기**: `MIXTURE_ITEM_SEQ` ↔ 시니어 다른 약물 교차 매칭
- **노인주의**: `totalCount > 0` 감지
- **효능군중복**: `EFFECT_NAME` 그룹화, 2개+ 중복 시 경고

### 기타
- 활성 약물 판별: `medication_schedules` 기준 (`start_date <= today <= end_date`)
- 권한: medicine 접근권과 동일 (소유자 + 연동 보호자)
- 외부 API 실패 시 실패 레코드 저장 + 503 `DUR_UNAVAILABLE`
- `medicine.dur_warning_text` 최신 요약 자동 복사

## Feature Spec
- `docs/features/medicine-dur.md` PR 4

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅

## 후속
- E2E 테스트 PR
- 로컬 실테스트 (식약처 실호출)

---
### AI 체크리스트
- [x] type:feat, scope:health, ai-generated
- [x] API 엔드포인트 3개 추가 → Notion API 명세 갱신 대상 ⚠️