### PR TITLE
feat(infra): MCP 서버 도입 — Spring AI 1.1.4 + 도메인 tool 3개

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation platform('software.amazon.awssdk:bom:2.28.29')
     implementation 'software.amazon.awssdk:s3'
+    implementation platform('org.springframework.ai:spring-ai-bom:1.1.4')
+    implementation 'org.springframework.ai:spring-ai-starter-mcp-server-webmvc'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/com/ppiyaki/common/mcp/DurMcpTools.java
+++ b/src/main/java/com/ppiyaki/common/mcp/DurMcpTools.java
@@ -1,0 +1,30 @@
+package com.ppiyaki.common.mcp;
+
+import com.ppiyaki.health.controller.dto.DurCheckResponse;
+import com.ppiyaki.health.service.DurCheckService;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class DurMcpTools {
+
+    private final DurCheckService durCheckService;
+
+    public DurMcpTools(final DurCheckService durCheckService) {
+        this.durCheckService = durCheckService;
+    }
+
+    @Tool(description = "Run a DUR (Drug Utilization Review) safety check on a medicine. Checks drug interactions, elderly warnings, and therapeutic duplicates against the senior's active medications.")
+    public DurCheckResponse checkDur(
+            @ToolParam(description = "Medicine ID to check") final Long medicineId,
+            @ToolParam(description = "Bypass 24h cache if true") final Boolean forceRefresh
+    ) {
+        final Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final boolean refresh = forceRefresh != null && forceRefresh;
+        return durCheckService.check(userId, medicineId, refresh);
+    }
+}

--- a/src/main/java/com/ppiyaki/common/mcp/MedicineMcpTools.java
+++ b/src/main/java/com/ppiyaki/common/mcp/MedicineMcpTools.java
@@ -1,0 +1,50 @@
+package com.ppiyaki.common.mcp;
+
+import com.ppiyaki.medicine.controller.dto.MedicineCandidate;
+import com.ppiyaki.medicine.service.MatchResult;
+import com.ppiyaki.medicine.service.MedicineMatchService;
+import com.ppiyaki.medicine.service.MedicineSearchService;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class MedicineMcpTools {
+
+    private final MedicineSearchService searchService;
+    private final MedicineMatchService matchService;
+
+    public MedicineMcpTools(
+            final MedicineSearchService searchService,
+            final MedicineMatchService matchService
+    ) {
+        this.searchService = searchService;
+        this.matchService = matchService;
+    }
+
+    @Tool(description = "Search Korean MFDS DUR drug catalog by name. Returns candidates with itemSeq, name, manufacturer, ingredients.")
+    public List<MedicineCandidate> searchMedicine(
+            @ToolParam(description = "Drug name or partial name to search") final String query,
+            @ToolParam(description = "Max results, default 10") final Integer limit
+    ) {
+        final int effectiveLimit = limit != null ? limit : 10;
+        return searchService.search(query, effectiveLimit);
+    }
+
+    @Tool(description = "Match OCR-extracted drug text to MFDS itemSeq with auto-correction. Returns match type (EXACT/FUZZY_AUTO/MANUAL_REQUIRED/NO_MATCH) and reason.")
+    public MatchResult matchMedicineFromOcr(
+            @ToolParam(description = "OCR raw text of the drug name") final String ocrText,
+            @ToolParam(description = "Optional dosage hint (e.g. '500mg')") final String dosage,
+            @ToolParam(description = "Optional form hint (e.g. '정', '캡슐')") final String form
+    ) {
+        return matchService.match(
+                ocrText,
+                Optional.ofNullable(dosage),
+                Optional.ofNullable(form)
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,3 +42,6 @@ mfds:
 
 openai:
   model: gpt-5.4-nano
+
+spring.ai.mcp.server:
+  type: SYNC


### PR DESCRIPTION
Closes #156

## Summary
Spring AI MCP Server를 ppiyaki-backend에 내장. AI 에이전트가 약물 검색·DUR 점검을 MCP 프로토콜로 호출 가능.

### MCP Tools (3개)
- `searchMedicine(query, limit)` — 식약처 약물 검색
- `matchMedicineFromOcr(ocrText, dosage, form)` — OCR 텍스트 → itemSeq 자동 매칭
- `checkDur(medicineId, forceRefresh)` — DUR 안전성 점검

### 설정
- Spring AI BOM 1.1.4 + `spring-ai-starter-mcp-server-webmvc`
- SYNC 모드 (기존 WebMVC 스택 유지)
- JWT 인증 기존 필터 체인 적용

### 후속
- register_medicine, register_medication_schedule tool 추가
- Bucket4j rate limit

## Feature Spec
- docs/features/mcp-server-foundation.md

## 보호 영역
- build.gradle, application.yml 변경 → needs-human-review

---
### AI 체크리스트
- [x] type:feat, scope:infra, ai-generated, needs-human-review