### PR TITLE
fix(infra): Spring AI MCP→@Tool 경량 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation platform('software.amazon.awssdk:bom:2.28.29')
     implementation 'software.amazon.awssdk:s3'
+    implementation platform('org.springframework.ai:spring-ai-bom:1.1.4')
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.28.29')
     implementation 'software.amazon.awssdk:s3'
     implementation platform('org.springframework.ai:spring-ai-bom:1.1.4')
-    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+    implementation 'org.springframework.ai:spring-ai-model'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/com/ppiyaki/common/tool/DurTools.java
+++ b/src/main/java/com/ppiyaki/common/tool/DurTools.java
@@ -1,0 +1,30 @@
+package com.ppiyaki.common.tool;
+
+import com.ppiyaki.health.controller.dto.DurCheckResponse;
+import com.ppiyaki.health.service.DurCheckService;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class DurTools {
+
+    private final DurCheckService durCheckService;
+
+    public DurTools(final DurCheckService durCheckService) {
+        this.durCheckService = durCheckService;
+    }
+
+    @Tool(description = "Run a DUR (Drug Utilization Review) safety check on a medicine. Checks drug interactions, elderly warnings, and therapeutic duplicates against the senior's active medications.")
+    public DurCheckResponse checkDur(
+            @ToolParam(description = "Medicine ID to check") final Long medicineId,
+            @ToolParam(description = "Bypass 24h cache if true") final Boolean forceRefresh
+    ) {
+        final Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final boolean refresh = forceRefresh != null && forceRefresh;
+        return durCheckService.check(userId, medicineId, refresh);
+    }
+}

--- a/src/main/java/com/ppiyaki/common/tool/MedicineTools.java
+++ b/src/main/java/com/ppiyaki/common/tool/MedicineTools.java
@@ -1,0 +1,50 @@
+package com.ppiyaki.common.tool;
+
+import com.ppiyaki.medicine.controller.dto.MedicineCandidate;
+import com.ppiyaki.medicine.service.MatchResult;
+import com.ppiyaki.medicine.service.MedicineMatchService;
+import com.ppiyaki.medicine.service.MedicineSearchService;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class MedicineTools {
+
+    private final MedicineSearchService searchService;
+    private final MedicineMatchService matchService;
+
+    public MedicineTools(
+            final MedicineSearchService searchService,
+            final MedicineMatchService matchService
+    ) {
+        this.searchService = searchService;
+        this.matchService = matchService;
+    }
+
+    @Tool(description = "Search Korean MFDS DUR drug catalog by name. Returns candidates with itemSeq, name, manufacturer, ingredients.")
+    public List<MedicineCandidate> searchMedicine(
+            @ToolParam(description = "Drug name or partial name to search") final String query,
+            @ToolParam(description = "Max results, default 10") final Integer limit
+    ) {
+        final int effectiveLimit = limit != null ? limit : 10;
+        return searchService.search(query, effectiveLimit);
+    }
+
+    @Tool(description = "Match OCR-extracted drug text to MFDS itemSeq with auto-correction. Returns match type (EXACT/FUZZY_AUTO/MANUAL_REQUIRED/NO_MATCH) and reason.")
+    public MatchResult matchMedicineFromOcr(
+            @ToolParam(description = "OCR raw text of the drug name") final String ocrText,
+            @ToolParam(description = "Optional dosage hint (e.g. '500mg')") final String dosage,
+            @ToolParam(description = "Optional form hint (e.g. '정', '캡슐')") final String form
+    ) {
+        return matchService.match(
+                ocrText,
+                Optional.ofNullable(dosage),
+                Optional.ofNullable(form)
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,3 +42,8 @@ mfds:
 
 openai:
   model: gpt-5.4-nano
+
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,8 +42,3 @@ mfds:
 
 openai:
   model: gpt-5.4-nano
-
-spring:
-  ai:
-    openai:
-      api-key: ${OPENAI_API_KEY:}


### PR DESCRIPTION
## Summary
PR #157에서 도입한 Spring AI MCP 서버를 ChatClient @Tool 방식으로 전환.

### 변경
- `spring-ai-starter-model-openai` → `spring-ai-model` (어노테이션만 제공, auto-config 없음)
- OpenAI auto-config이 API 키 없을 때 부트 실패하던 문제 해결
- application.yml: MCP 서버 설정 제거 + YAML 중복 키 수정
- `@Tool`/`@ToolParam` 어노테이션 유지 (향후 ChatClient 통합 시 자동 연결)

## 검증
- `./gradlew checkstyleMain test` ✅ BUILD SUCCESSFUL

---
### AI 체크리스트
- [x] type:fix, scope:infra, ai-generated, needs-human-review (build.gradle)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * DUR 약물 안전 검사 기능 추가
  * 의약품 검색 및 매칭 기능 추가

* **기타 작업**
  * Spring AI 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->