### PR TITLE
fix(infra): Spring AI MCP→경량 @Tool 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.28.29')
     implementation 'software.amazon.awssdk:s3'
     implementation platform('org.springframework.ai:spring-ai-bom:1.1.4')
-    implementation 'org.springframework.ai:spring-ai-starter-mcp-server-webmvc'
+    implementation 'org.springframework.ai:spring-ai-model'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,3 @@ mfds:
 
 openai:
   model: gpt-5.4-nano
-
-spring.ai.mcp.server:
-  type: SYNC


### PR DESCRIPTION
## Summary
PR #157의 MCP 서버 방식을 경량 @Tool 방식으로 전환.

### 변경 (2줄)
- `build.gradle`: `spring-ai-starter-mcp-server-webmvc` → `spring-ai-model` (@Tool 어노테이션만)
- `application.yml`: `spring.ai.mcp.server` 설정 제거

### 이유
- AI가 앱 내부 ChatClient로 동작 → MCP 프로토콜 불필요
- MCP starter의 auto-config이 불필요한 빈 생성 + 테스트 실패 유발
- `spring-ai-model`은 @Tool/@ToolParam 어노테이션만 제공, auto-config 0개

### 기존 tool 코드
- `MedicineTools.java`, `DurTools.java`의 `@Tool` 어노테이션 그대로 유지
- 향후 ChatClient 빈 구성 시 tool로 자동 연결

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅

---
- [x] type:fix, scope:infra, ai-generated, needs-human-review