### PR TITLE
fix(infra): CD에 CLOVA_OCR + OPENAI 환경변수 누락 추가

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -74,6 +74,9 @@ jobs:
               -e NCP_STORAGE_SECRET_KEY='${{ secrets.NCP_STORAGE_SECRET_KEY }}' \
               -e NCP_STORAGE_BUCKET_NAME='${{ secrets.NCP_STORAGE_BUCKET_NAME }}' \
               -e MFDS_API_SERVICE_KEY='${{ secrets.MFDS_API_SERVICE_KEY }}' \
+              -e CLOVA_OCR_SECRET='${{ secrets.CLOVA_OCR_SECRET }}' \
+              -e CLOVA_OCR_INVOKE_URL='${{ secrets.CLOVA_OCR_INVOKE_URL }}' \
+              -e OPENAI_API_KEY='${{ secrets.OPENAI_API_KEY }}' \
               ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
             
             echo "Cleaning up old images..."


### PR DESCRIPTION
backend-cd.yml docker run에 CLOVA_OCR_SECRET, CLOVA_OCR_INVOKE_URL, OPENAI_API_KEY 환경변수 3개 추가. 이 없이는 처방전 OCR 컨트롤러가 @ConditionalOnProperty로 비활성.