### PR TITLE
fix(medicine): 약물 검색 시 용량 정보 분리하여 매칭률 개선

### DIFF
--- a/src/main/java/com/ppiyaki/medicine/service/MedicineMatchService.java
+++ b/src/main/java/com/ppiyaki/medicine/service/MedicineMatchService.java
@@ -40,6 +40,11 @@ public class MedicineMatchService {
                 .toLowerCase();
     }
 
+    static String extractNameForSearch(final String normalizedText) {
+        final String nameOnly = normalizedText.replaceAll("[0-9]+(\\.[0-9]+)?(mg|g|ml|%|mcg|iu)?.*$", "");
+        return nameOnly.isEmpty() ? normalizedText : nameOnly;
+    }
+
     static double levenshteinSimilarity(final String a, final String b) {
         if (a.isEmpty() && b.isEmpty()) {
             return 1.0;
@@ -75,7 +80,8 @@ public class MedicineMatchService {
             final Optional<String> formHint
     ) {
         final String normalized = normalize(ocrText);
-        final List<MedicineCandidate> candidates = searchService.search(normalized, 20);
+        final String searchQuery = extractNameForSearch(normalized);
+        final List<MedicineCandidate> candidates = searchService.search(searchQuery, 20);
 
         if (candidates.isEmpty()) {
             return new MatchResult(MatchType.NO_MATCH, Optional.empty(), List.of(), 0.0,


### PR DESCRIPTION
## AS-IS
OCR 추출 텍스트(예: `타이레놀정500밀리그람`)가 normalize 후 `타이레놀정500mg`으로 그대로 식약처 API `itemName` 파라미터에 전달됨. 식약처 API는 이렇게 구체적인 쿼리에 결과를 반환하지 않아 모든 후보가 `NO_MATCH`.

## TO-BE
`extractNameForSearch()` 메서드를 추가하여 검색 쿼리에서 숫자+단위(mg, g, ml 등)를 분리. 식약처 API에는 약물명만(`타이레놀정`)으로 검색하고, 유사도 비교는 전체 normalize 텍스트(`타이레놀정500mg`)로 수행.

## Test plan
- [ ] 프로덕션 배포 후 처방전 OCR E2E 재테스트
- [ ] 매칭 결과가 NO_MATCH → EXACT/FUZZY_AUTO로 개선되는지 확인

---

### AI 자기 점검 체크리스트
- [x] 기존 테스트 전체 통과
- [x] checkstyleMain + spotlessCheck 통과
- [x] 도메인 문서 변경 불필요 (로직 변경만)
- [x] API 엔드포인트 변경 없음 → Notion 갱신 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
  * 의약품 검색 시 복용량, 강도, 단위 등의 정보를 제외하여 검색 정확도를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->