### PR TITLE
release: 2025-04-16 medicine-match-fix

### DIFF
--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -52,7 +52,7 @@ public class OpenAiClient {
 
             final String responseBody = restClient.post()
                     .uri(API_URL)
-                    .header("Authorization", "Bearer " + properties.apiKey())
+                    .header("Authorization", "Bearer " + properties.apiKey().strip())
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(requestBody)
                     .retrieve()

--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -52,7 +52,7 @@ public class OpenAiClient {
 
             final String responseBody = restClient.post()
                     .uri(API_URL)
-                    .header("Authorization", "Bearer " + properties.apiKey().strip())
+                    .header("Authorization", "Bearer " + properties.apiKey())
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(requestBody)
                     .retrieve()

--- a/src/main/java/com/ppiyaki/medicine/service/MedicineMatchService.java
+++ b/src/main/java/com/ppiyaki/medicine/service/MedicineMatchService.java
@@ -40,6 +40,11 @@ public class MedicineMatchService {
                 .toLowerCase();
     }
 
+    static String extractNameForSearch(final String normalizedText) {
+        final String nameOnly = normalizedText.replaceAll("[0-9]+(\\.[0-9]+)?(mg|g|ml|%|mcg|iu)?.*$", "");
+        return nameOnly.isEmpty() ? normalizedText : nameOnly;
+    }
+
     static double levenshteinSimilarity(final String a, final String b) {
         if (a.isEmpty() && b.isEmpty()) {
             return 1.0;
@@ -75,7 +80,8 @@ public class MedicineMatchService {
             final Optional<String> formHint
     ) {
         final String normalized = normalize(ocrText);
-        final List<MedicineCandidate> candidates = searchService.search(normalized, 20);
+        final String searchQuery = extractNameForSearch(normalized);
+        final List<MedicineCandidate> candidates = searchService.search(searchQuery, 20);
 
         if (candidates.isEmpty()) {
             return new MatchResult(MatchType.NO_MATCH, Optional.empty(), List.of(), 0.0,


### PR DESCRIPTION
## Changelog

### fix
- **medicine**: 약물 검색 시 용량 정보 분리하여 매칭률 개선 (#165)
- **infra**: OpenAI API 키 strip() 제거 — 불필요한 방어 코드 (#164)
- **infra**: OpenAI API 키 strip() — GitHub Secrets 줄바꿈 대응 (#163)

## Summary
OCR 추출 약물명에 용량(500mg 등)이 포함되어 식약처 API 검색 실패하던 문제 수정.
검색 쿼리에서 숫자+단위를 분리하여 약물명만으로 검색하도록 개선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)