### PR TITLE
refactor(prescription): 컨벤션 위반 수정 + MedicineMatchService 테스트 추가

### DIFF
--- a/src/main/java/com/ppiyaki/prescription/ImageOrientationCorrector.java
+++ b/src/main/java/com/ppiyaki/prescription/ImageOrientationCorrector.java
@@ -9,14 +9,12 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import javax.imageio.ImageIO;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class ImageOrientationCorrector {
-
-    private static final Logger log = LoggerFactory.getLogger(ImageOrientationCorrector.class);
 
     public byte[] correctOrientation(final byte[] imageBytes, final String format) {
         try {
@@ -29,9 +27,9 @@ public class ImageOrientationCorrector {
             final BufferedImage original = ImageIO.read(new ByteArrayInputStream(imageBytes));
             final BufferedImage corrected = applyOrientation(original, orientation);
 
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ImageIO.write(corrected, format.equalsIgnoreCase("png") ? "png" : "jpg", baos);
-            return baos.toByteArray();
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            ImageIO.write(corrected, format.equalsIgnoreCase("png") ? "png" : "jpg", outputStream);
+            return outputStream.toByteArray();
 
         } catch (final Exception e) {
             log.warn("EXIF orientation correction failed, using original: {}", e.getMessage());
@@ -54,43 +52,43 @@ public class ImageOrientationCorrector {
     }
 
     private BufferedImage applyOrientation(final BufferedImage image, final int orientation) {
-        final int w = image.getWidth();
-        final int h = image.getHeight();
+        final int width = image.getWidth();
+        final int height = image.getHeight();
 
         final AffineTransform transform = new AffineTransform();
-        int newWidth = w;
-        int newHeight = h;
+        int resultWidth = width;
+        int resultHeight = height;
 
         switch (orientation) {
             case 2 -> transform.scale(-1, 1);
             case 3 -> {
-                transform.translate(w, h);
+                transform.translate(width, height);
                 transform.rotate(Math.PI);
             }
             case 4 -> transform.scale(1, -1);
             case 5 -> {
-                newWidth = h;
-                newHeight = w;
+                resultWidth = height;
+                resultHeight = width;
                 transform.scale(-1, 1);
                 transform.rotate(Math.PI / 2);
             }
             case 6 -> {
-                newWidth = h;
-                newHeight = w;
-                transform.translate(h, 0);
+                resultWidth = height;
+                resultHeight = width;
+                transform.translate(height, 0);
                 transform.rotate(Math.PI / 2);
             }
             case 7 -> {
-                newWidth = h;
-                newHeight = w;
+                resultWidth = height;
+                resultHeight = width;
                 transform.scale(-1, 1);
-                transform.translate(0, -w);
+                transform.translate(0, -width);
                 transform.rotate(-Math.PI / 2);
             }
             case 8 -> {
-                newWidth = h;
-                newHeight = w;
-                transform.translate(0, w);
+                resultWidth = height;
+                resultHeight = width;
+                transform.translate(0, width);
                 transform.rotate(-Math.PI / 2);
             }
             default -> {
@@ -98,10 +96,10 @@ public class ImageOrientationCorrector {
             }
         }
 
-        final BufferedImage result = new BufferedImage(newWidth, newHeight, image.getType());
-        final Graphics2D g = result.createGraphics();
-        g.drawImage(image, transform, null);
-        g.dispose();
+        final BufferedImage result = new BufferedImage(resultWidth, resultHeight, image.getType());
+        final Graphics2D graphics = result.createGraphics();
+        graphics.drawImage(image, transform, null);
+        graphics.dispose();
         return result;
     }
 }

--- a/src/main/java/com/ppiyaki/prescription/PiiMaskingService.java
+++ b/src/main/java/com/ppiyaki/prescription/PiiMaskingService.java
@@ -44,13 +44,7 @@ public class PiiMaskingService {
                 continue;
             }
 
-            boolean isKeyword = false;
-            for (final String keyword : PII_KEYWORDS) {
-                if (text.contains(keyword)) {
-                    isKeyword = true;
-                    break;
-                }
-            }
+            final boolean isKeyword = PII_KEYWORDS.stream().anyMatch(text::contains);
 
             if (isKeyword) {
                 final int keywordLineY = token.y();
@@ -58,8 +52,6 @@ public class PiiMaskingService {
                     final OcrToken next = tokens.get(j);
                     if (isSameLine(keywordLineY, next.y(), token.height())) {
                         piiTokens.add(next);
-                    } else {
-                        break;
                     }
                 }
             }
@@ -84,15 +76,15 @@ public class PiiMaskingService {
     public BufferedImage maskImage(final BufferedImage original, final List<OcrToken> piiTokens) {
         final BufferedImage masked = new BufferedImage(
                 original.getWidth(), original.getHeight(), original.getType());
-        final Graphics2D g = masked.createGraphics();
-        g.drawImage(original, 0, 0, null);
-        g.setColor(Color.BLACK);
+        final Graphics2D graphics = masked.createGraphics();
+        graphics.drawImage(original, 0, 0, null);
+        graphics.setColor(Color.BLACK);
 
         for (final OcrToken token : piiTokens) {
-            g.fillRect(token.x(), token.y(), token.width(), token.height());
+            graphics.fillRect(token.x(), token.y(), token.width(), token.height());
         }
 
-        g.dispose();
+        graphics.dispose();
         return masked;
     }
 }

--- a/src/test/java/com/ppiyaki/medicine/service/MedicineMatchServiceTest.java
+++ b/src/test/java/com/ppiyaki/medicine/service/MedicineMatchServiceTest.java
@@ -1,0 +1,113 @@
+package com.ppiyaki.medicine.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.medicine.controller.dto.MedicineCandidate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MedicineMatchServiceTest {
+
+    private MedicineSearchService searchService;
+    private MedicineMatchService matchService;
+
+    @BeforeEach
+    void setUp() {
+        searchService = mock(MedicineSearchService.class);
+        matchService = new MedicineMatchService(searchService);
+    }
+
+    @Test
+    @DisplayName("이름이 정확히 일치하면 EXACT를 반환한다")
+    void match_exactMatch_returnsExact() {
+        // given
+        final MedicineCandidate candidate = new MedicineCandidate(
+                "200001", "타이레놀정500밀리그램", "한국존슨앤드존슨",
+                "아세트아미노펜", "정제", "일반", "해열진통소염제");
+        when(searchService.search(anyString(), anyInt())).thenReturn(List.of(candidate));
+
+        // when
+        final MatchResult result = matchService.match("타이레놀정500밀리그램", Optional.empty());
+
+        // then
+        assertThat(result.matchType()).isEqualTo(MatchType.EXACT);
+        assertThat(result.recommended()).isPresent();
+        assertThat(result.recommended().get().itemName()).isEqualTo("타이레놀정500밀리그램");
+    }
+
+    @Test
+    @DisplayName("이름이 일치하지 않으면 CANDIDATES를 반환한다")
+    void match_noExactMatch_returnsCandidates() {
+        // given
+        final MedicineCandidate candidate = new MedicineCandidate(
+                "200001", "타이레놀이알서방정", "한국존슨앤드존슨",
+                "아세트아미노펜", "정제", "일반", "해열진통소염제");
+        when(searchService.search(anyString(), anyInt())).thenReturn(List.of(candidate));
+
+        // when
+        final MatchResult result = matchService.match("타이레놀정500mg", Optional.empty());
+
+        // then
+        assertThat(result.matchType()).isEqualTo(MatchType.CANDIDATES);
+        assertThat(result.recommended()).isEmpty();
+        assertThat(result.candidates()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("검색 결과가 없고 성분명으로도 없으면 NO_MATCH를 반환한다")
+    void match_noResults_returnsNoMatch() {
+        // given
+        when(searchService.search(anyString(), anyInt())).thenReturn(List.of());
+
+        // when
+        final MatchResult result = matchService.match("존재하지않는약", Optional.empty());
+
+        // then
+        assertThat(result.matchType()).isEqualTo(MatchType.NO_MATCH);
+        assertThat(result.recommended()).isEmpty();
+        assertThat(result.candidates()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("이름 검색 실패 시 성분명으로 재검색하여 CANDIDATES를 반환한다")
+    void match_ingredientFallback_returnsCandidates() {
+        // given
+        final MedicineCandidate ingredientCandidate = new MedicineCandidate(
+                "300001", "아스피린장용정100mg", "바이엘코리아",
+                "아세틸살리실산", "장용정", "일반", "해열진통소염제");
+        when(searchService.search(anyString(), anyInt()))
+                .thenReturn(List.of())
+                .thenReturn(List.of(ingredientCandidate));
+
+        // when
+        final MatchResult result = matchService.match("알수없는약", Optional.of("아세틸살리실산"));
+
+        // then
+        assertThat(result.matchType()).isEqualTo(MatchType.CANDIDATES);
+        assertThat(result.candidates()).hasSize(1);
+        assertThat(result.candidates().get(0).mainIngr()).isEqualTo("아세틸살리실산");
+    }
+
+    @Test
+    @DisplayName("괄호가 포함된 약명도 정규화하여 정확히 매칭한다")
+    void match_nameWithParentheses_normalizesAndMatches() {
+        // given
+        final MedicineCandidate candidate = new MedicineCandidate(
+                "400001", "아목시실린캡슐500mg", "종근당",
+                "아목시실린", "캡슐", "전문", "항생제");
+        when(searchService.search(anyString(), anyInt())).thenReturn(List.of(candidate));
+
+        // when
+        final MatchResult result = matchService.match("아목시실린캡슐500mg(종근당)", Optional.empty());
+
+        // then
+        assertThat(result.matchType()).isEqualTo(MatchType.EXACT);
+    }
+}


### PR DESCRIPTION
## AS-IS
- ImageOrientationCorrector: 수동 Logger, 변수명 약어 (w/h/baos/g)
- PiiMaskingService: isKeyword 비-final, Y좌표 비정렬 시 같은 줄 마스킹 누락 (break로 중단)
- MedicineMatchService: 테스트 0건

## TO-BE
- @Slf4j 전환, 변수명 풀네임 (width/height/outputStream/graphics)
- anyMatch로 final화, break 제거하여 전체 후속 토큰 검사
- match() 5개 케이스 테스트: EXACT, CANDIDATES, NO_MATCH, 성분명 fallback, 괄호 정규화

🤖 Generated with [Claude Code](https://claude.com/claude-code)