### PR TITLE
fix(chat): SSE 엔드포인트 produces 제거

### DIFF
--- a/src/main/java/com/ppiyaki/chat/controller/ChatSessionController.java
+++ b/src/main/java/com/ppiyaki/chat/controller/ChatSessionController.java
@@ -42,7 +42,7 @@ public class ChatSessionController {
                 .body(new ChatSessionResponse(chatSession.getId()));
     }
 
-    @PostMapping(value = "/{sessionId}/messages", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @PostMapping("/{sessionId}/messages")
     public SseEmitter sendMessage(
             @AuthenticationPrincipal final Long userId,
             @PathVariable final Long sessionId,
@@ -50,8 +50,7 @@ public class ChatSessionController {
         return chatSessionService.sendMessageStream(userId, sessionId, chatMessageRequest.message());
     }
 
-    @PostMapping(value = "/{sessionId}/voice-messages", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = {
-            MediaType.TEXT_EVENT_STREAM_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    @PostMapping(value = "/{sessionId}/voice-messages", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public SseEmitter sendVoiceMessage(
             @AuthenticationPrincipal final Long userId,
             @PathVariable final Long sessionId,


### PR DESCRIPTION
## AS-IS
- sendMessage, sendVoiceMessage에 `produces = TEXT_EVENT_STREAM_VALUE` 명시
- 스트림 시작 전 BusinessException 발생 시 GlobalExceptionHandler가 JSON 반환 불가 → 500

## TO-BE
- produces 제거, SseEmitter 반환 시 Spring 자동 content negotiation
- 정상: SseEmitter → text/event-stream (자동)
- 에러: GlobalExceptionHandler → application/json (자동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기술 개선**
  * 채팅 메시지 전송 및 음성 메시지 처리 엔드포인트의 내부 구성을 최적화했습니다. 요청 처리 방식이 개선되었으며 사용자 기능에는 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->