### PR TITLE
feat(chat): ChatClient에 MCP tool 등록 — 약물 검색/DUR 점검 연동

### DIFF
--- a/src/main/java/com/ppiyaki/chat/ChatClientConfig.java
+++ b/src/main/java/com/ppiyaki/chat/ChatClientConfig.java
@@ -1,6 +1,8 @@
 package com.ppiyaki.chat;
 
+import java.util.List;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.tool.ToolCallback;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -8,14 +10,23 @@ import org.springframework.context.annotation.Configuration;
 public class ChatClientConfig {
 
     @Bean
-    public ChatClient chatClient(final ChatClient.Builder builder) {
-        return builder
+    public ChatClient chatClient(
+            final ChatClient.Builder builder,
+            final List<ToolCallback> toolCallbacks
+    ) {
+        final ChatClient.Builder clientBuilder = builder
                 .defaultSystem("당신은 복약 관리 서비스 '삐약이'의 AI 도우미입니다.\n"
                         + "사용자는 어르신(시니어)입니다.\n"
                         + "- 최대한 쉽고 간결한 용어를 사용하세요.\n"
                         + "- 답변은 짧고 핵심만 전달하세요.\n"
                         + "- 의학 전문 용어 대신 일상 표현을 사용하세요.\n"
-                        + "- 복약 관련 질문에 친절하고 정확하게 답변해 주세요.")
-                .build();
+                        + "- 복약 관련 질문에 친절하고 정확하게 답변해 주세요.\n"
+                        + "- 약물 검색이나 DUR 점검이 필요하면 제공된 도구를 사용하세요.");
+
+        if (!toolCallbacks.isEmpty()) {
+            clientBuilder.defaultToolCallbacks(toolCallbacks.toArray(ToolCallback[]::new));
+        }
+
+        return clientBuilder.build();
     }
 }

--- a/src/main/java/com/ppiyaki/chat/ChatToolCallbackConfig.java
+++ b/src/main/java/com/ppiyaki/chat/ChatToolCallbackConfig.java
@@ -1,0 +1,30 @@
+package com.ppiyaki.chat;
+
+import com.ppiyaki.common.mcp.DurMcpTools;
+import com.ppiyaki.common.mcp.MedicineMcpTools;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.ai.support.ToolCallbacks;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ChatToolCallbackConfig {
+
+    @Bean
+    public List<ToolCallback> toolCallbacks(
+            final ObjectProvider<MedicineMcpTools> medicineMcpTools,
+            final ObjectProvider<DurMcpTools> durMcpTools
+    ) {
+        final List<ToolCallback> callbacks = new ArrayList<>();
+
+        medicineMcpTools.ifAvailable(
+                tools -> callbacks.addAll(List.of(ToolCallbacks.from(tools))));
+        durMcpTools.ifAvailable(
+                tools -> callbacks.addAll(List.of(ToolCallbacks.from(tools))));
+
+        return callbacks;
+    }
+}


### PR DESCRIPTION
## AS-IS
- ChatClient에 tool 미등록 → LLM이 기본 지식으로만 답변
- MCP tool 빈(MedicineMcpTools, DurMcpTools)은 등록되지만 ChatClient와 연결 안 됨

## TO-BE
- ChatToolCallbackConfig: MCP tool 빈을 ToolCallback으로 변환 (ObjectProvider로 optional 주입)
- ChatClientConfig: defaultToolCallbacks()로 tool 등록
- 약물 검색 질문 시 MFDS API 실제 데이터 기반 답변 확인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)