### PR TITLE
fix(chat): Reactor 스레드 간 SecurityContext 자동 전파 활성화

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     name: ppiyaki-backend
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:default}
+  reactor:
+    context-propagation: auto
   ai:
     openai:
       api-key: ${OPENAI_API_KEY:sk-placeholder}

--- a/src/test/java/com/ppiyaki/chat/ReactorSecurityContextPropagationTest.java
+++ b/src/test/java/com/ppiyaki/chat/ReactorSecurityContextPropagationTest.java
@@ -1,0 +1,42 @@
+package com.ppiyaki.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.TestPropertySource;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@SpringBootTest
+@TestPropertySource(properties = "spring.ai.openai.api-key=test-dummy-key")
+@DisplayName("Reactor 스케줄러 경계를 넘어 SecurityContext가 전파된다")
+class ReactorSecurityContextPropagationTest {
+
+    @AfterEach
+    void cleanup() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("spring.reactor.context-propagation=auto 설정 시, Flux 오퍼레이터가 다른 스케줄러에서 실행돼도 SecurityContext가 유지된다")
+    void securityContextPropagatesAcrossSchedulerBoundary() {
+        final Long expectedPrincipal = 42L;
+        final Authentication authentication = new TestingAuthenticationToken(expectedPrincipal, null);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        final Object principalSeenByAsyncTask = Mono.fromCallable(() -> {
+            final Authentication current = SecurityContextHolder.getContext().getAuthentication();
+            return current == null ? null : current.getPrincipal();
+        })
+                .subscribeOn(Schedulers.boundedElastic())
+                .block();
+
+        assertThat(principalSeenByAsyncTask).isEqualTo(expectedPrincipal);
+    }
+}


### PR DESCRIPTION
## AS-IS
- 채팅 스트리밍 중 MCP 도구(`@Tool` 메서드)가 Reactor 스케줄러 스레드에서 실행될 때 `SecurityContextHolder`가 비어 있어 `userId` 조회 시 NPE 발생.
- `DelegatingSecurityContextAsyncTaskExecutor`로 executor 스레드까지는 전파했으나, Spring AI 내부 Reactor Flux 파이프라인이 다른 스레드(Reactor Netty 등)로 넘기는 순간 ThreadLocal 기반 SecurityContext가 유실됨.
- Spring Boot 3.5 기본값 `spring.reactor.context-propagation=LIMITED` 때문에 Reactor 오퍼레이터 경계에서 ThreadLocal이 자동 복원되지 않음.

## TO-BE
- `application.yml`에 `spring.reactor.context-propagation: auto` 설정 추가.
- Spring Boot `ReactorAutoConfiguration`이 기동 시 `Hooks.enableAutomaticContextPropagation()` 호출 → 모든 Reactor 오퍼레이터 경계에서 ThreadLocal 자동 캡처/복원.
- Spring Security 6.5가 `SecurityContextHolderThreadLocalAccessor`를 `META-INF/services`로 이미 자동 등록해 두었으므로 추가 코드 없이 동작.
- Reactor 스케줄러 경계에서 SecurityContext가 유지되는지 검증하는 회귀 테스트 추가.

## 관련 이슈
- closes #181

## 리뷰어 참고 포인트
- `application.yml`은 보호 영역 → `needs-human-review` 라벨 부여 예정.
- `AUTO`는 JVM 전역 훅이므로 모든 Reactor 체인에 영향을 줌. 현재 Reactor 사용처는 `ChatSessionService`의 스트리밍 2개뿐이므로 부작용 가능성은 낮다고 판단.
- `ChatStreamConfig`의 `DelegatingSecurityContextAsyncTaskExecutor`는 MVC → executor 경계에서 여전히 필요해 유지.
- 회귀 테스트는 실제로 `context-propagation: auto`를 제거하면 `AssertionFailedError`로 실패하는 것을 수동 검증함.

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료 (`type:fix`)
- [x] `scope:*` 라벨 1개 부여 완료 (`scope:chat`)
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [x] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 변경 범위의 회귀 가능 구간을 확인했다. (설정 제거 → 테스트 fail 재현 확인)
- [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다.

### 롤백 절차
- `application.yml`의 `spring.reactor.context-propagation: auto` 라인 제거하면 즉시 롤백. 단, 롤백 시 채팅 MCP 도구 호출은 다시 동작 불가 상태로 회귀됨.

## DDD/OOP 준수 체크
- [x] 도메인 용어가 기존 컨텍스트와 일치한다.
- [x] 계층 침범(Controller -> Repository 직접 호출 등)이 없다.
- [x] 객체 역할/책임이 명확하며, 과도한 God Object를 만들지 않았다.

## 보안/민감정보 체크
- [x] 시크릿(API 키/토큰/비밀번호) 하드코딩이 없다.
- [x] 복약 기록/건강 프로필 등 의료정보를 로그/스크린샷에 노출하지 않았다.
- [x] 민감정보가 필요한 경우 마스킹 처리했다.

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 채팅 도구 호출이 실제로 동작하도록 재현·분석·수정 요청.
- AI가 직접 수정한 파일/범위:
  - `src/main/resources/application.yml` — `spring.reactor.context-propagation: auto` 1줄 추가
  - `src/test/java/com/ppiyaki/chat/ReactorSecurityContextPropagationTest.java` — 신규 회귀 테스트
- 사람이 수동 검증한 항목: (리뷰 필요) `application.yml` 설정 변경의 전역 영향, 실제 로컬/스테이지에서 채팅 MCP 도구 end-to-end 동작 여부.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 비동기 작업 간 보안 컨텍스트 전파 기능을 활성화하여 시스템 안정성 강화

* **테스트**
  * 보안 컨텍스트 전파 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->