### PR TITLE
feat(prescription): 보호자 수동 약물 추가 API 구현

### DIFF
--- a/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
+++ b/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
@@ -67,6 +67,9 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
     @Column(name = "created_medicine_id")
     private Long createdMedicineId;
 
+    private static final String MANUAL_ADD_REASON = "보호자 수동 추가";
+    private static final String MANUAL_ADD_RAW_TEXT = "보호자 수동 추가";
+
     public PrescriptionMedicineCandidate(
             final Long prescriptionId,
             final String ocrRawText,
@@ -88,6 +91,32 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
         this.matchType = matchType;
         this.matchReason = matchReason;
         this.caregiverDecision = CaregiverDecision.PENDING;
+    }
+
+    public static PrescriptionMedicineCandidate manualAdd(
+            final Long prescriptionId,
+            final String itemSeq,
+            final String itemName,
+            final String dosage,
+            final String schedule
+    ) {
+        Objects.requireNonNull(itemSeq, "itemSeq must not be null");
+        Objects.requireNonNull(itemName, "itemName must not be null");
+        final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                prescriptionId,
+                MANUAL_ADD_RAW_TEXT,
+                itemName,
+                dosage,
+                schedule,
+                itemSeq,
+                itemName,
+                MatchType.EXACT,
+                MANUAL_ADD_REASON
+        );
+        candidate.caregiverDecision = CaregiverDecision.ACCEPTED;
+        candidate.caregiverChosenItemSeq = itemSeq;
+        candidate.reviewedAt = LocalDateTime.now();
+        return candidate;
     }
 
     public void accept() {

--- a/src/main/java/com/ppiyaki/prescription/controller/PrescriptionController.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/PrescriptionController.java
@@ -5,6 +5,7 @@ import com.ppiyaki.prescription.controller.dto.CandidateDecisionRequest;
 import com.ppiyaki.prescription.controller.dto.PrescriptionCreateRequest;
 import com.ppiyaki.prescription.controller.dto.PrescriptionDetailResponse;
 import com.ppiyaki.prescription.controller.dto.PrescriptionListResponse;
+import com.ppiyaki.prescription.controller.dto.PrescriptionMedicineAddRequest;
 import com.ppiyaki.prescription.service.PrescriptionService;
 import jakarta.validation.Valid;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -65,6 +66,16 @@ public class PrescriptionController {
     ) {
         prescriptionService.updateCandidateDecision(userId, prescriptionId, candidateId, request);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{prescriptionId}/medicines")
+    public ResponseEntity<PrescriptionDetailResponse> addManualMedicine(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long prescriptionId,
+            @Valid @RequestBody final PrescriptionMedicineAddRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(prescriptionService.addManualMedicine(userId, prescriptionId, request));
     }
 
     @PostMapping("/{prescriptionId}/confirm")

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineAddRequest.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineAddRequest.java
@@ -1,0 +1,11 @@
+package com.ppiyaki.prescription.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PrescriptionMedicineAddRequest(
+        @NotBlank String itemSeq,
+        @NotBlank String itemName,
+        String dosage,
+        String schedule
+) {
+}

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -22,6 +22,7 @@ import com.ppiyaki.prescription.PrescriptionStatus;
 import com.ppiyaki.prescription.controller.dto.CandidateDecisionRequest;
 import com.ppiyaki.prescription.controller.dto.PrescriptionDetailResponse;
 import com.ppiyaki.prescription.controller.dto.PrescriptionListResponse;
+import com.ppiyaki.prescription.controller.dto.PrescriptionMedicineAddRequest;
 import com.ppiyaki.prescription.repository.PrescriptionMedicineCandidateRepository;
 import com.ppiyaki.prescription.repository.PrescriptionRepository;
 import com.ppiyaki.user.repository.CareRelationRepository;
@@ -187,6 +188,32 @@ public class PrescriptionService {
             case MANUALLY_CORRECTED -> candidate.correctManually(request.chosenItemSeq());
             default -> throw new BusinessException(ErrorCode.INVALID_INPUT, "Invalid decision: " + request.decision());
         }
+    }
+
+    @Transactional
+    public PrescriptionDetailResponse addManualMedicine(
+            final Long userId,
+            final Long prescriptionId,
+            final PrescriptionMedicineAddRequest request
+    ) {
+        final Prescription prescription = findPrescription(prescriptionId);
+        validateAccess(userId, prescription.getOwnerId());
+
+        if (prescription.getStatus() != PrescriptionStatus.PENDING_REVIEW) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
+                    "Prescription must be in PENDING_REVIEW to add medicines.");
+        }
+
+        candidateRepository.save(PrescriptionMedicineCandidate.manualAdd(
+                prescription.getId(),
+                request.itemSeq(),
+                request.itemName(),
+                request.dosage(),
+                request.schedule()
+        ));
+
+        final List<PrescriptionMedicineCandidate> candidates = candidateRepository.findByPrescriptionId(prescriptionId);
+        return PrescriptionDetailResponse.from(prescription, candidates);
     }
 
     @Transactional

--- a/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
+++ b/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
@@ -1,0 +1,199 @@
+package com.ppiyaki.prescription.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.common.ai.OpenAiClient;
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.ocr.ClovaOcrClient;
+import com.ppiyaki.common.storage.NcpStorageProperties;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.medicine.service.MatchType;
+import com.ppiyaki.medicine.service.MedicineMatchService;
+import com.ppiyaki.prescription.CaregiverDecision;
+import com.ppiyaki.prescription.ImageOrientationCorrector;
+import com.ppiyaki.prescription.PiiMaskingService;
+import com.ppiyaki.prescription.Prescription;
+import com.ppiyaki.prescription.PrescriptionMedicineCandidate;
+import com.ppiyaki.prescription.PrescriptionStatus;
+import com.ppiyaki.prescription.controller.dto.PrescriptionMedicineAddRequest;
+import com.ppiyaki.prescription.repository.PrescriptionMedicineCandidateRepository;
+import com.ppiyaki.prescription.repository.PrescriptionRepository;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PrescriptionService.addManualMedicine")
+class PrescriptionServiceManualAddTest {
+
+    @Mock
+    private PrescriptionRepository prescriptionRepository;
+    @Mock
+    private PrescriptionMedicineCandidateRepository candidateRepository;
+    @Mock
+    private MedicineRepository medicineRepository;
+    @Mock
+    private CareRelationRepository careRelationRepository;
+    @Mock
+    private ClovaOcrClient clovaOcrClient;
+    @Mock
+    private OpenAiClient openAiClient;
+    @Mock
+    private MedicineMatchService medicineMatchService;
+    @Mock
+    private PiiMaskingService piiMaskingService;
+    @Mock
+    private ImageOrientationCorrector orientationCorrector;
+    @Mock
+    private NcpStorageProperties storageProperties;
+    @Mock
+    private S3Client s3Client;
+
+    @InjectMocks
+    private PrescriptionService prescriptionService;
+
+    @Test
+    @DisplayName("PENDING_REVIEW 상태 처방전에 보호자가 약물을 수동 추가하면 ACCEPTED 후보가 생성된다")
+    void 보호자_수동_추가_성공() throws Exception {
+        // given
+        final Long ownerId = 100L;
+        final Long prescriptionId = 1L;
+        final Prescription prescription = givenPrescription(prescriptionId, ownerId, PrescriptionStatus.PENDING_REVIEW);
+        when(prescriptionRepository.findById(prescriptionId)).thenReturn(Optional.of(prescription));
+        when(candidateRepository.findByPrescriptionId(prescriptionId)).thenReturn(List.of());
+
+        final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
+                "199500096", "타이레놀정 500mg", "1정", "1일 3회 식후");
+
+        // when
+        prescriptionService.addManualMedicine(ownerId, prescriptionId, request);
+
+        // then
+        final ArgumentCaptor<PrescriptionMedicineCandidate> captor = ArgumentCaptor.forClass(
+                PrescriptionMedicineCandidate.class);
+        verify(candidateRepository).save(captor.capture());
+        final PrescriptionMedicineCandidate saved = captor.getValue();
+        assertThat(saved.getMatchedItemSeq()).isEqualTo("199500096");
+        assertThat(saved.getMatchedItemName()).isEqualTo("타이레놀정 500mg");
+        assertThat(saved.getExtractedDosage()).isEqualTo("1정");
+        assertThat(saved.getExtractedSchedule()).isEqualTo("1일 3회 식후");
+        assertThat(saved.getMatchType()).isEqualTo(MatchType.EXACT);
+        assertThat(saved.getCaregiverDecision()).isEqualTo(CaregiverDecision.ACCEPTED);
+        assertThat(saved.getCaregiverChosenItemSeq()).isEqualTo("199500096");
+        assertThat(saved.getReviewedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("활성 care_relations 보호자도 수동 추가 가능하다")
+    void 보호자_권한_수동_추가() throws Exception {
+        // given
+        final Long seniorId = 100L;
+        final Long caregiverId = 200L;
+        final Long prescriptionId = 1L;
+        final Prescription prescription = givenPrescription(prescriptionId, seniorId,
+                PrescriptionStatus.PENDING_REVIEW);
+        when(prescriptionRepository.findById(prescriptionId)).thenReturn(Optional.of(prescription));
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(caregiverId, seniorId))
+                .thenReturn(Optional.of(new CareRelation(seniorId, caregiverId, "INVITE")));
+        when(candidateRepository.findByPrescriptionId(prescriptionId)).thenReturn(List.of());
+
+        final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
+                "199500096", "타이레놀정 500mg", null, null);
+
+        // when
+        prescriptionService.addManualMedicine(caregiverId, prescriptionId, request);
+
+        // then
+        verify(candidateRepository).save(any(PrescriptionMedicineCandidate.class));
+    }
+
+    @Test
+    @DisplayName("권한 없는 사용자 요청 시 CARE_RELATION_NOT_FOUND 예외")
+    void 권한없는_사용자_요청_실패() throws Exception {
+        // given
+        final Long ownerId = 100L;
+        final Long otherUserId = 999L;
+        final Long prescriptionId = 1L;
+        final Prescription prescription = givenPrescription(prescriptionId, ownerId, PrescriptionStatus.PENDING_REVIEW);
+        when(prescriptionRepository.findById(prescriptionId)).thenReturn(Optional.of(prescription));
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(otherUserId, ownerId))
+                .thenReturn(Optional.empty());
+
+        final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
+                "199500096", "타이레놀정 500mg", null, null);
+
+        // when & then
+        assertThatThrownBy(() -> prescriptionService.addManualMedicine(otherUserId, prescriptionId, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_NOT_FOUND);
+        verify(candidateRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("PENDING_REVIEW가 아닌 상태에서 추가 시 INVALID_INPUT 예외")
+    void 잘못된_상태_요청_실패() throws Exception {
+        // given
+        final Long ownerId = 100L;
+        final Long prescriptionId = 1L;
+        final Prescription prescription = givenPrescription(prescriptionId, ownerId, PrescriptionStatus.CONFIRMED);
+        when(prescriptionRepository.findById(prescriptionId)).thenReturn(Optional.of(prescription));
+
+        final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
+                "199500096", "타이레놀정 500mg", null, null);
+
+        // when & then
+        assertThatThrownBy(() -> prescriptionService.addManualMedicine(ownerId, prescriptionId, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+        verify(candidateRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("처방전 미존재 시 MEDICINE_NOT_FOUND 예외")
+    void 처방전_미존재_실패() {
+        // given
+        when(prescriptionRepository.findById(999L)).thenReturn(Optional.empty());
+        final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
+                "199500096", "타이레놀정 500mg", null, null);
+
+        // when & then
+        assertThatThrownBy(() -> prescriptionService.addManualMedicine(100L, 999L, request))
+                .isInstanceOf(BusinessException.class);
+        verify(candidateRepository, never()).save(any());
+    }
+
+    private Prescription givenPrescription(
+            final Long id,
+            final Long ownerId,
+            final PrescriptionStatus targetStatus
+    ) throws Exception {
+        final Prescription prescription = new Prescription(ownerId);
+        setField(prescription, "id", id);
+        setField(prescription, "status", targetStatus);
+        return prescription;
+    }
+
+    private static void setField(final Object target, final String fieldName, final Object value) throws Exception {
+        final Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
## AS-IS
- `docs/features/prescription-ocr.md` §3 보호자 워크플로우에 명시된 `POST /api/v1/prescriptions/{id}/medicines` 엔드포인트 미구현.
- OCR이 처방전에서 누락한 약물을 보호자가 직접 추가할 방법이 없어, 빠진 약은 confirm 후 별도 medicine CRUD를 거쳐야 했음.

## TO-BE
- `POST /api/v1/prescriptions/{prescriptionId}/medicines` 엔드포인트 추가.
- 보호자(또는 시니어 본인)가 의약품 검색 결과에서 고른 itemSeq+itemName을 처방전에 후보로 등록 → confirm 시 다른 ACCEPTED 후보들과 함께 `Medicine` 일괄 생성.
- `PrescriptionMedicineCandidate.manualAdd` 정적 팩토리로 의도 명시.

## 관련 이슈
- closes #187
- spec: `docs/features/prescription-ocr.md` §3, §5-2, Q-CONF-3 (a)안 채택

## 리뷰어 참고 포인트
- **itemSeq + itemName 둘 다 클라이언트에서 받음**: MFDS DUR API(`getDurPrdlstInfoList03`)와 e약은요 API(`DrugInfoClient`) 모두 itemName 검색만 지원하여 서버측 itemSeq → itemName 단건 조회가 불가. 클라이언트는 어차피 검색 결과에서 둘 다 갖고 있으므로 자연스러움. 후속 PR에서 audit/검증 추가 가능.
- **`matchType=EXACT` 재사용**: 신규 enum 값 추가 없이 `matchReason`("보호자 수동 추가")로 구분. 클라이언트는 reason 텍스트로 분기 가능.
- **`caregiverDecision=ACCEPTED` 자동 세팅**: 보호자가 능동적으로 추가했으므로 PENDING 거치지 않음. confirm 시 바로 Medicine 생성.
- **E2E 테스트 부재**: `src/test/java/com/ppiyaki/prescription/` 디렉토리가 비어있어 prescription 모듈 E2E 인프라가 없음. 별도 트래커 항목(처방전 OCR + 보호자 확인 E2E 테스트)에서 인프라 일괄 구축 후 추가할 예정. 본 PR은 단위 테스트 5건으로 보강.

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료
- [x] `scope:*` 라벨 1개 부여 완료
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [x] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트 (해당 시 작성)</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크 (AI 작성 시)
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 변경 범위의 회귀 가능 구간 확인 — 기존 엔드포인트 영향 없음(신규 엔드포인트 추가만)
- [x] 롤백: revert 1 커밋

## DDD/OOP 준수 체크 (AI 작성 시)
- [x] 도메인 용어 일치 (`PrescriptionMedicineCandidate`, `CaregiverDecision`, `MatchType`)
- [x] 계층 침범 없음 (Controller → Service → Repository)
- [x] God Object 없음 — 정적 팩토리로 책임 분리

## 보안/민감정보 체크 (AI 작성 시)
- [x] 시크릿 하드코딩 없음
- [x] 의료정보 원문 노출 없음
- [x] 마스킹 — 해당 없음

## 예외 머지 여부 (AI 작성 시)
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 처방전 OCR 후속 미구현 항목 중 1번 — POST /medicines (보호자 수동 추가) 구현. 디자인 결정(itemSeq+itemName/EXACT/ACCEPTED)은 사용자 확인 완료.
- AI가 직접 수정한 파일/범위:
  - 신규: `PrescriptionMedicineAddRequest`, `PrescriptionServiceManualAddTest`
  - 수정: `PrescriptionMedicineCandidate` (manualAdd 팩토리), `PrescriptionService` (addManualMedicine 메서드), `PrescriptionController` (POST 엔드포인트)
- 사람이 수동 검증한 항목: 디자인 결정(클라이언트가 itemName 함께 보내는 것), spec Q-CONF-3 결정.
- 잔여 리스크/추가 확인 필요사항: itemSeq/itemName 미스매치 가능성 (MVP 신뢰 기반). 후속 audit/검증 가능.

</details>