### PR TITLE
docs(prescription): 보호자 승인 모드 (관리형/자율형) 도입 명세

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -68,6 +68,7 @@
 | 복약 기록 | Medication Log | 실제 복용 이행 여부 기록 (`status`, `ai_status`) |
 | 복약 이행률 | Adherence Rate | 기간 내 성공 복약 / 예정 복약 |
 | 대리 처리 | Proxy Confirmation | 보호자가 시니어 대신 복용 상태를 확정 (`is_proxy=true`, `confirmed_by_user_id != senior_id`) |
+| 보호자 승인 모드 | Care Mode | 시니어의 처방전 변경 권한 정책. `MANAGED`(보호자 검증 강제, 0~72h 보호자 전용 + 72h 후 시니어 fallback) / `AUTONOMOUS`(시니어 즉시 변경 허용). `users.care_mode`에 저장. 변경은 보호자만 가능 |
 | DUR 점검 | Drug Utilization Review | 약물 상호작용/중복/금기 검증. 결과는 `dur_checks`에 immutable 로그로 저장 |
 | 약 개수 인식 | Pill Count Recognition | 복약 확인용 비전 기반 약 개수 판정. 세부 구현 보류 |
 | 삐약이 | Ppiyaki / Pet Character | 복약 성공 시 성장하는 게이미피케이션 캐릭터 |
@@ -98,6 +99,7 @@
 | gender | varchar | DB는 varchar, Java는 `Gender` enum(`MALE`/`FEMALE`/`OTHER`/`UNKNOWN`) |
 | dob | date | 생년월일 |
 | pet | bigint | `pets.id` PK 참조 (FK 제약 선언 여부는 §7-12) |
+| care_mode | varchar | DB는 varchar, Java는 `CareMode` enum(`MANAGED` default / `AUTONOMOUS`). 시니어 회원에 적용. 보호자 회원도 컬럼은 갖지만 처방전 흐름에서는 `prescription.owner_id`로 참조하는 시니어 측 값만 사용 |
 | created_at / updated_at | timestamp | `BaseTimeEntity` |
 
 > **코드 갭(현재 HEAD 기준)**: 코드의 `User.java`는 `nickname`, `gender`, `dob`가 없고 `pet` 대신 `ppiyaki bigint` 컬럼명을 사용하며 `password`가 non-null. 이 문서는 **타깃 스키마**를 기술하며, 코드 갱신은 별도 PR로 진행한다. 추적: §7-16.
@@ -368,6 +370,7 @@ erDiagram
         varchar gender
         date dob
         bigint pet FK
+        varchar care_mode "MANAGED default / AUTONOMOUS"
         timestamp created_at
         timestamp updated_at
     }

--- a/docs/features/prescription-ocr.md
+++ b/docs/features/prescription-ocr.md
@@ -3,10 +3,10 @@ feature: 처방전 OCR + 보호자 확인 통합 파이프라인
 slug: prescription-ocr
 owner: @goohong
 scope: prescription
-related_issues: []
-related_prs: []
+related_issues: [187, 189]
+related_prs: [188]
 status: draft
-last_reviewed: 2026-04-16
+last_reviewed: 2026-04-30
 ---
 
 # 처방전 OCR + 보호자 확인 통합 파이프라인
@@ -30,7 +30,8 @@ last_reviewed: 2026-04-16
   - 잘못된 항목 삭제 가능
   - 처방전에 누락된 약물 수동 추가 가능
 - "전체 확인 완료" 버튼을 누르면 약물·복약 일정 등록 화면으로 자동 이동.
-- 보호자가 72h 내 미확인 시 시니어 본인 확인 가능 (보호자 부재 fallback).
+- **보호자 승인 모드 (관리형/자율형)** 에 따라 시니어 본인 확정 권한이 달라진다 (§3-3 참조).
+- `MANAGED` 모드에서 보호자가 72h 내 미확인 시 시니어 본인 fallback 확정 가능.
 
 ## 3) 요구사항
 
@@ -59,8 +60,16 @@ last_reviewed: 2026-04-16
 - [ ] `POST /api/v1/prescriptions/{id}/medicines` — 처방전에 누락된 약물 수동 추가.
 - [ ] `POST /api/v1/prescriptions/{id}/confirm` — 전체 확인. 모든 후보의 `caregiver_decision != PENDING` 검증 후 `Prescription.status = CONFIRMED`로 전이. 활성화된 후보들로 `Medicine` row 생성·연결.
 - [ ] `POST /api/v1/prescriptions/{id}/reject` — 처방전 폐기 (재촬영 요청). 마스킹본 + 후보들 모두 삭제. `Prescription.status = REJECTED`.
-- [ ] **72h 미확인 처방전**: 시니어 본인이 확인 가능 (별도 권한 부여 로직).
 - [ ] 모든 변경 audit log: 누가 언제 어떤 결정을 내렸는지 기록.
+
+### 기능 요구사항 — 보호자 승인 모드 (§3-3)
+- [ ] `User.careMode` enum 컬럼 신설 — `MANAGED` (관리형, default) / `AUTONOMOUS` (자율형).
+- [ ] `PUT /api/v1/users/{seniorId}/care-mode` — **보호자만 호출 가능**. 활성 `care_relations` 관계 검증. 시니어 본인 셀프 변경 엔드포인트는 두지 않는다.
+- [ ] 처방전 흐름의 모든 변경 엔드포인트(`PATCH /medicines/{candidateId}`, `POST /medicines`, `POST /confirm`, `POST /reject`)에 모드 분기 적용:
+  - `AUTONOMOUS`: 시니어/보호자 모두 가능.
+  - `MANAGED`: 보호자만 가능. 처방전 `created_at + 72h` 경과 시 시니어 본인 fallback 가능.
+- [ ] 권한 검증 실패 시 `CARE_RELATION_NOT_FOUND`(403) 반환 — 정확한 거부 사유는 응답 body로 명시.
+- [ ] 보호자 미연동 시니어는 본 spec 범위 외 (§9 보호자 연동 전제).
 
 ### 비기능 요구사항
 - **응답 시간**: 등록 API는 동기. 전체 처리(OCR+AI+매칭) 5초 이내 p95 목표.
@@ -131,17 +140,44 @@ created_medicine_id         bigint nullable FK to medicines
 created_at
 ```
 
+**확장 — `User`** (시니어 회원에 적용)
+```
+care_mode    enum NOT NULL DEFAULT 'MANAGED'   // MANAGED / AUTONOMOUS
+```
+- `MANAGED`: 보호자 검증 강제. 0~72h 보호자만 변경 가능, 72h 후 시니어 본인 fallback.
+- `AUTONOMOUS`: 시니어/보호자 모두 즉시 변경 가능.
+- 보호자 회원도 같은 컬럼을 가지지만 처방전 흐름에서는 사용하지 않는다 (사용하는 모든 곳은 `prescription.owner_id`로 참조하는 시니어 측 값).
+
 ### 5-2) API 엔드포인트
 
-| Method | Path | 설명 | 인증 |
+| Method | Path | 설명 | 인증 / 권한 |
 |---|---|---|---|
 | POST | `/api/v1/prescriptions` | 처방전 등록 (objectKey 입력, 동기 처리) | 필수 |
-| GET | `/api/v1/prescriptions/{id}` | 추출 결과 + 후보 + matchType별 메모 + 마스킹본 presigned URL | 필수 (소유자/보호자) |
+| GET | `/api/v1/prescriptions/{id}` | 추출 결과 + 후보 + matchType별 메모 + 마스킹본 presigned URL | 필수 (소유자/보호자, 모드 무관) |
 | GET | `/api/v1/prescriptions?status=...` | 내가 확인할/확인한 처방전 리스트 | 필수 |
-| PATCH | `/api/v1/prescriptions/{id}/medicines/{candidateId}` | 후보별 보호자 결정 | 필수 |
-| POST | `/api/v1/prescriptions/{id}/medicines` | 누락 약물 수동 추가 | 필수 |
-| POST | `/api/v1/prescriptions/{id}/confirm` | 전체 확인 → CONFIRMED, Medicine 생성 | 필수 |
-| POST | `/api/v1/prescriptions/{id}/reject` | 폐기 | 필수 |
+| PATCH | `/api/v1/prescriptions/{id}/medicines/{candidateId}` | 후보별 결정 | 모드별 분기 (§3-3) |
+| POST | `/api/v1/prescriptions/{id}/medicines` | 누락 약물 수동 추가 | 모드별 분기 (§3-3) |
+| POST | `/api/v1/prescriptions/{id}/confirm` | 전체 확인 → CONFIRMED, Medicine 생성 | 모드별 분기 (§3-3) |
+| POST | `/api/v1/prescriptions/{id}/reject` | 폐기 | 모드별 분기 (§3-3) |
+| PUT | `/api/v1/users/{seniorId}/care-mode` | 시니어의 careMode 변경 | 보호자만 (활성 `care_relations` 검증). 시니어 본인 셀프 엔드포인트 없음 |
+
+### 5-2-1) 권한 분기 의사코드
+
+```
+function checkPrescriptionMutation(requesterId, prescription):
+    seniorId = prescription.owner_id
+    seniorMode = users[seniorId].care_mode
+
+    if requesterId == seniorId:
+        if seniorMode == AUTONOMOUS: allow
+        if seniorMode == MANAGED:
+            elapsed = now() - prescription.created_at
+            if elapsed >= 72h: allow (fallback)
+            else: deny (보호자 검토 대기 중)
+    else:
+        if exists active care_relations(caregiver=requesterId, senior=seniorId): allow
+        else: deny (CARE_RELATION_NOT_FOUND)
+```
 
 ### 5-3) 외부 연동
 
@@ -255,6 +291,7 @@ created_at
   action enum (ACCEPT/REJECT/CORRECT/ADD/CONFIRM/REJECT_PRESCRIPTION),
   before_value text nullable, after_value text nullable, created_at
   ```
+- `users` 테이블에 `care_mode` 컬럼 추가 (varchar, NOT NULL DEFAULT 'MANAGED'). 기존 시니어 row는 default로 backfill.
 
 ## 6) 작업 분할 (예상 PR 리스트)
 
@@ -276,10 +313,12 @@ created_at
 - [ ] PR 7 `feat(prescription)`: `PrescriptionProcessingService` 통합 + `PrescriptionController`. 동기 처리. E2E 테스트.
 - [ ] PR 8 `feat(prescription)`: 후보별 PATCH·삭제·추가 API + Service. `caregiver_decision` 전이 검증.
 - [ ] PR 9 `feat(prescription)`: confirm/reject API + Medicine 생성 연동. 권한(소유자/보호자) 검증.
-- [ ] PR 10 `feat(prescription)`: 72h fallback — 시니어 본인 확인 권한 활성화 로직 (`@Scheduled` 배치 또는 요청 시점 계산).
-- [ ] PR 11 `feat(prescription)`: audit log (선택, MVP에서는 candidate row의 변경 시각만 활용 후 후속 PR로 분리 가능).
-- [ ] PR 12 `test(prescription)`: E2E — 보호자 확인 / 시니어 자동 fallback / 권한 실패 / 잘못된 상태 전이.
-- [ ] PR 13 `chore(infra)`: NCP Object Storage Lifecycle Policy `upload/prescription/` prefix에 24h 만료 규칙 설정 (NCP 콘솔 작업)
+- [ ] PR 10 `feat(user)`: `User.careMode` enum 컬럼 추가 (default `MANAGED`) + 마이그레이션. 보호 영역 — `needs-human-review`.
+- [ ] PR 11 `feat(user)`: `PUT /api/v1/users/{seniorId}/care-mode` API. 보호자만 호출 가능, 활성 `care_relations` 검증.
+- [ ] PR 12 `feat(prescription)`: 처방전 변경 엔드포인트(`PATCH/POST/POST/POST`) 4건의 권한 분기 로직 — `validateAccess`에 모드별 분기 + 72h fallback (요청 시점 계산, `@Scheduled` 배치 미사용).
+- [ ] PR 13 `feat(prescription)`: audit log (선택, MVP에서는 candidate row의 변경 시각만 활용 후 후속 PR로 분리 가능).
+- [ ] PR 14 `test(prescription)`: E2E — 모드별 보호자 확인 / 시니어 자동 fallback / 권한 실패 / 잘못된 상태 전이.
+- [ ] PR 15 `chore(infra)`: NCP Object Storage Lifecycle Policy `upload/prescription/` prefix에 24h 만료 규칙 설정 (NCP 콘솔 작업)
 
 ## 7) 테스트 전략
 
@@ -289,7 +328,8 @@ created_at
 - `PiiMaskingService` — 정규식 정확도(주민번호/휴대전화), bbox 계산
 - `ImageMaskingService` — 박스 좌표 합성 정확도
 - 상태 머신 전이 검증 (잘못된 전이 reject)
-- 권한 검증 (소유자/보호자/72h fallback)
+- 권한 검증 — 모드별 분기 5케이스: AUTONOMOUS+시니어, AUTONOMOUS+보호자, MANAGED+보호자, MANAGED+시니어 0~72h(차단), MANAGED+시니어 72h+(통과)
+- `User.careMode` 변경 권한 — 보호자만, 활성 care_relations 검증
 - candidate.caregiver_decision 변경 감사
 
 ### 통합 (E2E)
@@ -301,8 +341,12 @@ created_at
 - 정상 흐름: OCR → PENDING_REVIEW → 보호자 confirm → CONFIRMED → Medicine 생성 확인
 - MANUALLY_CORRECTED: 보호자가 다른 itemSeq 선택 → Medicine.itemSeq에 chosen 값 반영
 - 누락 약물 추가: 보호자가 수동으로 약물 1개 추가 → Medicine 생성 확인
-- 72h 후 시니어 확인: 보호자 미확인 상태에서 시니어 confirm 시도 → 성공
+- AUTONOMOUS 모드: 시니어가 즉시 confirm → 성공
+- MANAGED 모드 + 0~72h: 시니어 confirm 시도 → 403 (보호자 검토 대기)
+- MANAGED 모드 + 72h 경과: 시니어 fallback confirm → 성공
 - 권한 실패: 다른 사용자가 confirm 시도 → 403
+- careMode 변경: 시니어 본인이 자기 모드 변경 시도 → 403 (보호자만 가능)
+- careMode 변경: 보호자가 시니어 모드 MANAGED→AUTONOMOUS 변경 → 성공 후 시니어 즉시 confirm 가능
 
 ## 8) 오픈 질문
 
@@ -310,8 +354,9 @@ created_at
 |---|---|---|---|
 | Q-OCR-2 | OpenAI 모델 확정 | gpt-5.4-nano 잠정 확정. OpenAI 라인업 변경 시 재검토 | @goohong / PR 5 전 |
 | Q-OCR-3 | 마스킹본 보존 기간 | **영구 보존** (결정됨 — §9 참조) | ✅ 결정 |
-| Q-CONF-3 | 보호자가 약물을 수동 추가하는 권한 범위 | (a) 후보에 추가만 / (b) Medicine 직접 생성 | @goohong / PR 9 전 |
+| Q-CONF-3 | 보호자가 약물을 수동 추가하는 권한 범위 | ✅ 해소됨 — (a) 후보에 추가만 (PR #188 머지). | ✅ 결정 |
 | Q-CONF-4 | confirm 후 DUR 자동 점검 | (a) 자동 트리거 / (b) 별도 사용자 액션 | @goohong / DUR 후속 |
+| Q-CONF-5 | 보호자 승인 모드 | ✅ 해소됨 — `MANAGED` (default) / `AUTONOMOUS` 두 모드. `User.careMode`. 보호자만 변경 가능. MANAGED 모드 0~72h는 보호자만, 72h 후 시니어 fallback. | ✅ 결정 |
 | Q-OCR-5 | 회전된 처방전 이미지 대응 | ✅ 해소됨 — `ImageOrientationCorrector` 구현. metadata-extractor 라이브러리로 EXIF orientation 태그를 읽어 이미지 로드 시 자동 회전 보정. 바운딩박스 좌표와 픽셀 정렬 문제 해결. | ✅ 결정 |
 | Q-OCR-6 | PII 키워드 마스킹 범위 | ✅ 해소됨 — 패턴 기반 마스킹만 유지(주민번호, 휴대전화). 키워드 기반 마스킹(환자명/처방의 다음 토큰 등) 전면 제거. 오탐 리스크 없는 최소 범위로 단순화. | ✅ 결정 |
 
@@ -343,3 +388,5 @@ created_at
 - 2026-04-16: **GPT 프롬프트 필드 확장** — `manufacturer`(제조사), `ingredientName`(주성분명) 추가. `ExtractedMedicine` record 반영. 성분명은 약물명 검색 실패 시 fallback 검색에 활용.
 - 2026-04-16: **MatchType 단순화** — `EXACT`/`FUZZY_AUTO`/`MANUAL_REQUIRED`/`NO_MATCH` → `EXACT`/`CANDIDATES`/`NO_MATCH`. Levenshtein 유사도 기반 자동 보정 제거. `MatchResult`에서 `similarity` 필드 제거, `matched`→`recommended`, `alternatives`→`candidates` 리네임.
 - 2026-04-16: **검색 전략 변경** — 약물명 검색 실패 시 prefix 축소 fallback 제거, `ingredientName` fallback 검색으로 대체. 성분명 동일 약물 후보군 반환 → `CANDIDATES` 결과로 처리.
+- 2026-04-30: **보호자 수동 약물 추가 정책 확정** (Q-CONF-3 해소) — (a) 후보에 추가만, confirm 시점에 Medicine 일괄 생성. itemSeq + itemName 둘 다 클라이언트 전송 (서버측 itemSeq → itemName 조회 인프라 부재). PR #188로 머지.
+- 2026-04-30: **보호자 승인 모드 도입** (Q-CONF-5 해소) — `User.careMode` enum 컬럼 (`MANAGED` default / `AUTONOMOUS`). 모드 변경은 `PUT /api/v1/users/{seniorId}/care-mode` — **보호자만 호출 가능**, 시니어 본인 셀프 변경 엔드포인트 두지 않음. 처방전 변경 엔드포인트 4건(`PATCH /medicines/{candidateId}`, `POST /medicines`, `POST /confirm`, `POST /reject`)에 모드 분기 적용. AUTONOMOUS는 시니어/보호자 모두 즉시 가능, MANAGED는 0~72h 보호자만 + 72h 후 시니어 fallback. 보호자 미연동 시니어는 spec 범위 외 (보호자 연동 전제 유지). 의도: spec의 "보호자 검증 강제"가 코드에서 사실상 동작하지 않던 상태를 명시적 권한 모델로 끌어올림.

--- a/docs/features/prescription-ocr.md
+++ b/docs/features/prescription-ocr.md
@@ -30,8 +30,8 @@ last_reviewed: 2026-04-30
   - 잘못된 항목 삭제 가능
   - 처방전에 누락된 약물 수동 추가 가능
 - "전체 확인 완료" 버튼을 누르면 약물·복약 일정 등록 화면으로 자동 이동.
-- **보호자 승인 모드 (관리형/자율형)** 에 따라 시니어 본인 확정 권한이 달라진다 (§3-3 참조).
-- `MANAGED` 모드에서 보호자가 72h 내 미확인 시 시니어 본인 fallback 확정 가능.
+- **보호자 승인 모드 (관리형/자율형)** 에 따라 시니어 본인 변경 권한이 달라진다 (§3-3 참조).
+- `MANAGED` 모드에서 보호자가 72h 내 미확인 시 시니어 본인 fallback 변경 권한 활성 (§3-3에 정의된 4개 변경 엔드포인트 전체에 동일 적용).
 
 ## 3) 요구사항
 
@@ -68,7 +68,9 @@ last_reviewed: 2026-04-30
 - [ ] 처방전 흐름의 모든 변경 엔드포인트(`PATCH /medicines/{candidateId}`, `POST /medicines`, `POST /confirm`, `POST /reject`)에 모드 분기 적용:
   - `AUTONOMOUS`: 시니어/보호자 모두 가능.
   - `MANAGED`: 보호자만 가능. 처방전 `created_at + 72h` 경과 시 시니어 본인 fallback 가능.
-- [ ] 권한 검증 실패 시 `CARE_RELATION_NOT_FOUND`(403) 반환 — 정확한 거부 사유는 응답 body로 명시.
+- [ ] 권한 검증 실패 시 원인별 403 에러코드를 분리해 반환:
+  - `CARE_RELATION_NOT_FOUND`: 요청자가 시니어 본인도 아니고 활성 `care_relations` 관계도 없음
+  - `CARE_MODE_RESTRICTED`: MANAGED 모드 0~72h 사이 시니어 본인이 변경 시도 (보호자 검토 대기 중)
 - [ ] 보호자 미연동 시니어는 본 spec 범위 외 (§9 보호자 연동 전제).
 
 ### 비기능 요구사항
@@ -141,8 +143,8 @@ created_at
 ```
 
 **확장 — `User`** (시니어 회원에 적용)
-```
-care_mode    enum NOT NULL DEFAULT 'MANAGED'   // MANAGED / AUTONOMOUS
+```sql
+care_mode    enum NOT NULL DEFAULT 'MANAGED'   -- MANAGED / AUTONOMOUS
 ```
 - `MANAGED`: 보호자 검증 강제. 0~72h 보호자만 변경 가능, 72h 후 시니어 본인 fallback.
 - `AUTONOMOUS`: 시니어/보호자 모두 즉시 변경 가능.
@@ -163,7 +165,7 @@ care_mode    enum NOT NULL DEFAULT 'MANAGED'   // MANAGED / AUTONOMOUS
 
 ### 5-2-1) 권한 분기 의사코드
 
-```
+```text
 function checkPrescriptionMutation(requesterId, prescription):
     seniorId = prescription.owner_id
     seniorMode = users[seniorId].care_mode
@@ -173,10 +175,10 @@ function checkPrescriptionMutation(requesterId, prescription):
         if seniorMode == MANAGED:
             elapsed = now() - prescription.created_at
             if elapsed >= 72h: allow (fallback)
-            else: deny (보호자 검토 대기 중)
+            else: deny → CARE_MODE_RESTRICTED (보호자 검토 대기 중)
     else:
         if exists active care_relations(caregiver=requesterId, senior=seniorId): allow
-        else: deny (CARE_RELATION_NOT_FOUND)
+        else: deny → CARE_RELATION_NOT_FOUND
 ```
 
 ### 5-3) 외부 연동


### PR DESCRIPTION
## AS-IS
- spec(`prescription-ocr.md`)이 정의한 "보호자 검증 강제" 흐름이 현재 코드에서 사실상 동작하지 않음. `PrescriptionService.validateAccess`가 owner(시니어)를 항상 통과시켜 시니어 본인이 처음부터 confirm/reject/PATCH 가능.
- spec의 72h fallback도 별도 권한 분기 로직 없이 자연 동작 — 의도된 안전장치가 아닌 우연한 통과.
- 시니어 자율성 vs 보호자 검증 강제의 product 정책 자체가 코드/spec에서 모호함.

## TO-BE
- 명시적인 **보호자 승인 모드(관리형/자율형)** 시스템 도입.
- `User.careMode` enum 컬럼 (`MANAGED` default / `AUTONOMOUS`).
- 모드 변경 API: `PUT /api/v1/users/{seniorId}/care-mode` — **보호자만 호출 가능** (활성 `care_relations` 검증). 시니어 본인 셀프 변경 엔드포인트 두지 않음.
- 처방전 변경 엔드포인트 4건(`PATCH /medicines/{candidateId}`, `POST /medicines`, `POST /confirm`, `POST /reject`)에 모드 분기:
  - `AUTONOMOUS`: 시니어/보호자 모두 즉시 가능
  - `MANAGED`: 0~72h 보호자만, 72h 후 시니어 본인 fallback
- 본 PR은 spec 갱신만. 구현은 후속 PR 5건으로 분할 (§6).

## 관련 이슈
- closes #189
- refs #188 (수동 추가 API — Q-CONF-3 해소 반영)

## 리뷰어 참고 포인트
- **§3-3 보호자 승인 모드** 섹션이 핵심. 권한 분기 의사코드(§5-2-1)로 구현 시 사실상 그대로 옮길 수 있게 작성.
- **보호자만 모드 변경**: 시니어가 본인 자율성을 직접 강화하지 못하게 막음 → 시니어 단독 자율 선택 방지. UX 의도와 보안 측면 검토 부탁.
- **72h 시간 계산은 요청 시점에서**: `@Scheduled` 배치 미사용 (단순화). prescription.created_at + 72h vs now 비교만으로 fallback 판정.
- **보호자 미연동 시니어 범위 외** (§9 보호자 연동 전제 유지). 단독 시니어가 처방전 등록 시 모든 변경이 72h 대기되는 부작용은 의도된 nudge.

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료
- [x] `scope:*` 라벨 (다중) 부여 완료 — prescription, user
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [x] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 — 해당 없음 (docs only)

<details>
<summary>AI Agent 전용 체크리스트 (해당 시 작성)</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용 (spec 초안 작성)

## 품질 게이트 체크 (AI 작성 시)
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 회귀 가능 구간: 없음 (docs only)
- [x] 롤백: revert 1 커밋

## DDD/OOP 준수 체크 (AI 작성 시)
- [x] 도메인 용어 일치 (`User`, `CareRelation`, `PrescriptionMedicineCandidate`)
- [x] 계층 침범 없음 (코드 변경 없음)
- [x] God Object 없음 (코드 변경 없음)

## 보안/민감정보 체크 (AI 작성 시)
- [x] 시크릿 하드코딩 없음
- [x] 의료정보 원문 노출 없음
- [x] 마스킹 — 해당 없음

## 예외 머지 여부 (AI 작성 시)
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 사용자가 "관리형/자율형 모드를 옵션으로 도입, 보호자만 모드 변경 가능, 처방전 흐름 전체 적용"으로 결정. spec 갱신.
- AI가 직접 수정한 파일/범위: `docs/features/prescription-ocr.md` 단일 파일.
- 사람이 수동 검증한 항목: enum 명명, API 권한 분기, default 모드, 적용 범위, 시니어 셀프 변경 미허용 결정.
- 잔여 리스크/추가 확인 필요사항: 보호자 미연동 시니어가 default MANAGED로 인해 72h 대기 부작용 — 본 spec에서는 "보호자 연동 전제"로 범위 외 처리. 향후 product 데이터 보고 재검토 필요.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 사용자 관리 모드 설정 추가 (관리형/자율형)
- 케어기버의 관리 모드 설정 권한 추가

## 변경사항
- **자율형 모드**: 시니어와 케어기버 모두 처방 즉시 승인 가능
- **관리형 모드**: 케어기버만 처방 처리, 72시간 이후 시니어 확인 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->