### PR TITLE
feat(user): User.careMode 컬럼 추가

### DIFF
--- a/src/main/java/com/ppiyaki/user/CareMode.java
+++ b/src/main/java/com/ppiyaki/user/CareMode.java
@@ -1,0 +1,7 @@
+package com.ppiyaki.user;
+
+public enum CareMode {
+
+    MANAGED,
+    AUTONOMOUS
+}

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -47,6 +47,10 @@ public class User extends BaseTimeEntity {
     @Column(name = "pet")
     private Long pet;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "care_mode", nullable = false)
+    private CareMode careMode = CareMode.MANAGED;
+
     public User(
             final String loginId,
             final String password,
@@ -63,5 +67,10 @@ public class User extends BaseTimeEntity {
         this.gender = gender;
         this.dob = dob;
         this.pet = pet;
+        this.careMode = CareMode.MANAGED;
+    }
+
+    public void changeCareMode(final CareMode careMode) {
+        this.careMode = careMode;
     }
 }

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -49,7 +50,7 @@ public class User extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "care_mode", nullable = false)
-    private CareMode careMode = CareMode.MANAGED;
+    private CareMode careMode;
 
     public User(
             final String loginId,
@@ -71,6 +72,6 @@ public class User extends BaseTimeEntity {
     }
 
     public void changeCareMode(final CareMode careMode) {
-        this.careMode = careMode;
+        this.careMode = Objects.requireNonNull(careMode, "careMode must not be null");
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -149,6 +149,7 @@
         login_id varchar(255),
         nickname varchar(255),
         password varchar(255),
+        care_mode enum ('AUTONOMOUS','MANAGED') not null,
         gender enum ('FEMALE','MALE','OTHER','UNKNOWN'),
         role enum ('CAREGIVER','SENIOR'),
         primary key (id)

--- a/src/test/java/com/ppiyaki/user/UserCareModeTest.java
+++ b/src/test/java/com/ppiyaki/user/UserCareModeTest.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +31,18 @@ class UserCareModeTest {
 
         // then
         assertThat(user.getCareMode()).isEqualTo(CareMode.AUTONOMOUS);
+    }
+
+    @Test
+    @DisplayName("changeCareMode에 null을 전달하면 NullPointerException")
+    void careMode_null_전달_실패() {
+        // given
+        final User user = newUser();
+
+        // when & then
+        assertThatThrownBy(() -> user.changeCareMode(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("careMode");
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/user/UserCareModeTest.java
+++ b/src/test/java/com/ppiyaki/user/UserCareModeTest.java
@@ -1,0 +1,60 @@
+package com.ppiyaki.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("User.careMode")
+class UserCareModeTest {
+
+    @Test
+    @DisplayName("신규 User는 careMode가 MANAGED로 초기화된다")
+    void 신규_유저_careMode_default_MANAGED() {
+        // when
+        final User user = newUser();
+
+        // then
+        assertThat(user.getCareMode()).isEqualTo(CareMode.MANAGED);
+    }
+
+    @Test
+    @DisplayName("changeCareMode로 모드를 AUTONOMOUS로 변경할 수 있다")
+    void careMode_변경_AUTONOMOUS() {
+        // given
+        final User user = newUser();
+
+        // when
+        user.changeCareMode(CareMode.AUTONOMOUS);
+
+        // then
+        assertThat(user.getCareMode()).isEqualTo(CareMode.AUTONOMOUS);
+    }
+
+    @Test
+    @DisplayName("AUTONOMOUS로 변경한 뒤 다시 MANAGED로 되돌릴 수 있다")
+    void careMode_변경_가역() {
+        // given
+        final User user = newUser();
+        user.changeCareMode(CareMode.AUTONOMOUS);
+
+        // when
+        user.changeCareMode(CareMode.MANAGED);
+
+        // then
+        assertThat(user.getCareMode()).isEqualTo(CareMode.MANAGED);
+    }
+
+    private User newUser() {
+        return new User(
+                "loginid",
+                "password",
+                UserRole.SENIOR,
+                "테스트유저",
+                Gender.UNKNOWN,
+                LocalDate.of(1950, 1, 1),
+                null
+        );
+    }
+}


### PR DESCRIPTION
## AS-IS
- 처방전 흐름에서 보호자 검증 강제/자율 옵션이 없음. `PrescriptionService.validateAccess`가 owner(시니어)를 항상 통과시켜 spec의 "보호자 검증" 의도와 어긋남.
- spec PR #190에서 `User.careMode` 도입을 결정.

## TO-BE
- `CareMode` enum (`MANAGED` default / `AUTONOMOUS`) 신설.
- `User` 엔티티에 `careMode` 컬럼 + `changeCareMode` 도메인 메서드 추가.
- `schema.sql` 갱신 (`care_mode enum NOT NULL`).
- 본 PR은 **데이터 모델 추가만**. 동작 변경 없음. 후속 PR로 모드 변경 API + validateAccess 분기 진행.

## 관련 이슈
- refs #189 (보호자 승인 모드 도입)
- 의존: #190 (spec PR) 머지 권장 — 본 PR이 #190의 첫 구현 단계이므로 spec 합의 후 진행이 안전.

## 리뷰어 참고 포인트
- **보호 영역 변경**: `src/main/resources/schema.sql` 수정으로 `needs-human-review` 라벨 부여.
- **prod 마이그레이션 필요**: prod DDL은 `validate` 모드라 자동 ALTER 불가. 다음 중 택일 필요:
  ```
  ALTER TABLE users ADD COLUMN care_mode VARCHAR(20) NOT NULL DEFAULT 'MANAGED';
  ```
  또는 1회 `JPA_DDL_AUTO=update` env로 배포 후 다시 `validate`로 복구.
- **기존 row backfill**: `NOT NULL DEFAULT 'MANAGED'`이므로 기존 시니어/보호자 row 모두 `MANAGED`로 자동 설정. 보호자도 같은 컬럼을 갖지만 처방전 흐름에서는 시니어 측 값만 참조 (spec §5-1 확장 메모).
- **enum 직렬화 위치 정렬**: schema.sql의 `enum ('AUTONOMOUS','MANAGED')`는 알파벳순 (Hibernate DDL 생성 관행).

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료
- [x] `scope:*` 라벨 1개 부여 완료
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [x] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 — schema.sql 변경

<details>
<summary>AI Agent 전용 체크리스트 (해당 시 작성)</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크 (AI 작성 시)
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 회귀 가능 구간: 기존 User 사용처는 새 필드 무시 가능 (default 동작). 위험 0.
- [x] 롤백: revert 1 커밋 + prod ALTER TABLE DROP COLUMN

## DDD/OOP 준수 체크 (AI 작성 시)
- [x] 도메인 용어 일치 (`CareMode`, `changeCareMode` — spec §5-1과 정합)
- [x] 계층 침범 없음
- [x] God Object 없음

## 보안/민감정보 체크 (AI 작성 시)
- [x] 시크릿 하드코딩 없음
- [x] 의료정보 원문 노출 없음
- [x] 마스킹 — 해당 없음

## 예외 머지 여부 (AI 작성 시)
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: spec PR #190 합의 후 첫 구현 PR — User.careMode 컬럼 추가.
- AI가 직접 수정한 파일/범위:
  - 신규: `CareMode`, `UserCareModeTest`
  - 수정: `User` (필드/생성자 초기화/changeCareMode 메서드), `schema.sql` (users 테이블)
- 사람이 수동 검증한 항목: enum 명명·default·setter 도메인 메서드 명, schema.sql 위치·NOT NULL 정책.
- 잔여 리스크/추가 확인 필요사항: prod 마이그레이션은 운영팀이 수동 실행 필요 (PR 본문 명시).

</details>