### PR TITLE
feat(user): 시니어 보호자 승인 모드 변경 API 구현

### DIFF
--- a/src/main/java/com/ppiyaki/user/controller/UserController.java
+++ b/src/main/java/com/ppiyaki/user/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.ppiyaki.user.controller;
+
+import com.ppiyaki.user.controller.dto.CareModeResponse;
+import com.ppiyaki.user.controller.dto.CareModeUpdateRequest;
+import com.ppiyaki.user.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(final UserService userService) {
+        this.userService = userService;
+    }
+
+    @PutMapping("/{seniorId}/care-mode")
+    public ResponseEntity<CareModeResponse> updateCareMode(
+            @AuthenticationPrincipal final Long requesterId,
+            @PathVariable final Long seniorId,
+            @Valid @RequestBody final CareModeUpdateRequest request
+    ) {
+        return ResponseEntity.ok(userService.updateCareMode(requesterId, seniorId, request.careMode()));
+    }
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/CareModeResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/CareModeResponse.java
@@ -1,0 +1,9 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.ppiyaki.user.CareMode;
+
+public record CareModeResponse(
+        Long userId,
+        CareMode careMode
+) {
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/CareModeUpdateRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/CareModeUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.ppiyaki.user.CareMode;
+import jakarta.validation.constraints.NotNull;
+
+public record CareModeUpdateRequest(
+        @NotNull CareMode careMode
+) {
+}

--- a/src/main/java/com/ppiyaki/user/service/UserService.java
+++ b/src/main/java/com/ppiyaki/user/service/UserService.java
@@ -1,0 +1,42 @@
+package com.ppiyaki.user.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.controller.dto.CareModeResponse;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final CareRelationRepository careRelationRepository;
+
+    public UserService(
+            final UserRepository userRepository,
+            final CareRelationRepository careRelationRepository
+    ) {
+        this.userRepository = userRepository;
+        this.careRelationRepository = careRelationRepository;
+    }
+
+    @Transactional
+    public CareModeResponse updateCareMode(
+            final Long requesterId,
+            final Long seniorId,
+            final CareMode careMode
+    ) {
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(requesterId, seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+
+        senior.changeCareMode(careMode);
+        return new CareModeResponse(senior.getId(), senior.getCareMode());
+    }
+}

--- a/src/test/java/com/ppiyaki/user/service/UserServiceCareModeTest.java
+++ b/src/test/java/com/ppiyaki/user/service/UserServiceCareModeTest.java
@@ -1,0 +1,124 @@
+package com.ppiyaki.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.Gender;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
+import com.ppiyaki.user.controller.dto.CareModeResponse;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService.updateCareMode")
+class UserServiceCareModeTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CareRelationRepository careRelationRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("활성 보호자가 시니어 careMode를 AUTONOMOUS로 변경하면 성공")
+    void 보호자_변경_성공() throws Exception {
+        // given
+        final Long seniorId = 100L;
+        final Long caregiverId = 200L;
+        final User senior = givenSenior(seniorId);
+        when(userRepository.findById(seniorId)).thenReturn(Optional.of(senior));
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(caregiverId, seniorId))
+                .thenReturn(Optional.of(new CareRelation(seniorId, caregiverId, "INVITE")));
+
+        // when
+        final CareModeResponse response = userService.updateCareMode(caregiverId, seniorId, CareMode.AUTONOMOUS);
+
+        // then
+        assertThat(response.userId()).isEqualTo(seniorId);
+        assertThat(response.careMode()).isEqualTo(CareMode.AUTONOMOUS);
+        assertThat(senior.getCareMode()).isEqualTo(CareMode.AUTONOMOUS);
+    }
+
+    @Test
+    @DisplayName("시니어 본인이 셀프 변경 시도하면 CARE_RELATION_NOT_FOUND")
+    void 시니어_셀프_변경_실패() throws Exception {
+        // given
+        final Long seniorId = 100L;
+        final User senior = givenSenior(seniorId);
+        when(userRepository.findById(seniorId)).thenReturn(Optional.of(senior));
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(seniorId, seniorId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateCareMode(seniorId, seniorId, CareMode.AUTONOMOUS))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_NOT_FOUND);
+        assertThat(senior.getCareMode()).isEqualTo(CareMode.MANAGED);
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자가 호출하면 CARE_RELATION_NOT_FOUND")
+    void 관계_없음_실패() throws Exception {
+        // given
+        final Long seniorId = 100L;
+        final Long otherUserId = 999L;
+        final User senior = givenSenior(seniorId);
+        when(userRepository.findById(seniorId)).thenReturn(Optional.of(senior));
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(otherUserId, seniorId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateCareMode(otherUserId, seniorId, CareMode.AUTONOMOUS))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("seniorId 미존재 시 USER_NOT_FOUND")
+    void 시니어_미존재_실패() {
+        // given
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateCareMode(200L, 999L, CareMode.AUTONOMOUS))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    private User givenSenior(final Long id) throws Exception {
+        final User user = new User(
+                "loginid",
+                "password",
+                UserRole.SENIOR,
+                "시니어",
+                Gender.UNKNOWN,
+                LocalDate.of(1950, 1, 1),
+                null
+        );
+        final Field idField = user.getClass().getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(user, id);
+        return user;
+    }
+}


### PR DESCRIPTION
## AS-IS
- spec(`prescription-ocr.md` §3-3, §5-2)이 정의한 `PUT /api/v1/users/{seniorId}/care-mode` 엔드포인트가 미구현.
- PR #191에서 `User.careMode` 컬럼은 추가됐지만 변경할 수단이 없음.

## TO-BE
- 신규 `UserController` + `UserService`로 PUT 엔드포인트 제공.
- 권한: 활성 `care_relations` 보호자만 (시니어 본인이 호출해도 거부 — spec 의도).
- 입력: `{ "careMode": "MANAGED" | "AUTONOMOUS" }`. 응답: `{ "userId", "careMode" }`.
- 단위 테스트 4건.

## 관련 이슈
- closes #192
- 선행 의존: PR #191 (User.careMode 컬럼) 머지
- 선행 의존: PR #190 (care-mode spec) 합의

## 리뷰어 참고 포인트
- **base 브랜치**: 본 PR은 `feat/user-care-mode-column-#189`(PR #191)를 base로 함. #191 머지 후 자동으로 `develop` base로 재타겟됨.
- **시니어 본인 셀프 변경 차단** 동작: `validateAccess`처럼 `if (requesterId == seniorId) return;` 패턴을 쓰지 **않음**. spec이 보호자만 호출하도록 의도해서 일관 처리: `careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(requesterId, seniorId)` 검증 — 시니어 본인이 호출하면 (caregiver=senior, senior=senior) 행이 없어 자연스럽게 `CARE_RELATION_NOT_FOUND`.
- **에러코드 분리는 후속 PR**: `CARE_MODE_RESTRICTED`는 본 PR scope 외. 다음 PR(`PrescriptionService.validateAccess` 분기)에서 ErrorCode enum + error-codes.md 동시 추가 예정.
- **E2E 테스트 부재**: `src/test/.../user/` 디렉토리에 기존 controller E2E 인프라가 일부 있지만, prescription처럼 수동 add 케이스와 같은 이유로 본 PR은 단위 테스트 우선. care-mode 통합 E2E는 prescription E2E 인프라 PR과 함께 묶을 예정.

## 하네스 정합성 체크리스트 (push 직전 자체 점검)
- Step 1 엔티티 변경: N/A — `User.careMode`는 #191에서 이미 추가됨
- Step 2 API 변경: ✅ Notion API 명세 DB 행 존재 (PR #190에서 추가). 본 PR 머지 후 status `시작 전` → `완료`로 전환 필요
- Step 3 새 ErrorCode: N/A — 기존 `USER_NOT_FOUND` / `CARE_RELATION_NOT_FOUND` 재사용
- Step 4 인덱스 정합성: N/A — 새 문서 없음
- Step 5 Spec 1:1 대응: ✅ — `prescription-ocr.md` §6 PR 11과 정확히 일치
- Step 6 라벨: type:feat / scope:user / ai-generated. needs-human-review N/A

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료
- [x] `scope:*` 라벨 1개 부여 완료
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [x] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트 (해당 시 작성)</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크 (AI 작성 시)
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 회귀 가능 구간: 신규 컨트롤러/서비스 추가만, 기존 흐름 영향 없음
- [x] 롤백: revert 1 커밋

## DDD/OOP 준수 체크 (AI 작성 시)
- [x] 도메인 용어 일치 (`CareMode`, `User.changeCareMode`, `CareRelation`)
- [x] 계층 침범 없음 (Controller → Service → Repository)
- [x] God Object 없음 — UserService 신규, 단일 책임

## 보안/민감정보 체크 (AI 작성 시)
- [x] 시크릿 하드코딩 없음
- [x] 의료정보 원문 노출 없음
- [x] 마스킹 — 해당 없음

## 예외 머지 여부 (AI 작성 시)
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: spec PR #190 합의 후 PR 11 구현 — PUT /care-mode API.
- AI가 직접 수정한 파일/범위:
  - 신규: `UserController`, `UserService`, `CareModeUpdateRequest`, `CareModeResponse`, `UserServiceCareModeTest`
- 사람이 수동 검증한 항목: 권한 모델(보호자만 + 시니어 셀프 거부), DTO 형태, base 브랜치 선택.
- 잔여 리스크/추가 확인 필요사항: 시니어 본인 셀프 호출 거부 로직이 `CARE_RELATION_NOT_FOUND`로 묶여 의미가 모호할 수 있음. 향후 클라이언트 UX에서 "이 작업은 보호자에게 요청하세요" 메시지로 가이드 권장.

</details>