### PR TITLE
feat(user): 시니어 보호자 승인 모드 변경 API 구현

### DIFF
--- a/src/main/java/com/ppiyaki/user/controller/UserController.java
+++ b/src/main/java/com/ppiyaki/user/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.ppiyaki.user.controller;
+
+import com.ppiyaki.user.controller.dto.CareModeResponse;
+import com.ppiyaki.user.controller.dto.CareModeUpdateRequest;
+import com.ppiyaki.user.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(final UserService userService) {
+        this.userService = userService;
+    }
+
+    @PutMapping("/{seniorId}/care-mode")
+    public ResponseEntity<CareModeResponse> updateCareMode(
+            @AuthenticationPrincipal final Long requesterId,
+            @PathVariable final Long seniorId,
+            @Valid @RequestBody final CareModeUpdateRequest request
+    ) {
+        return ResponseEntity.ok(userService.updateCareMode(requesterId, seniorId, request.careMode()));
+    }
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/CareModeResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/CareModeResponse.java
@@ -1,0 +1,9 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.ppiyaki.user.CareMode;
+
+public record CareModeResponse(
+        Long userId,
+        CareMode careMode
+) {
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/CareModeUpdateRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/CareModeUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.ppiyaki.user.CareMode;
+import jakarta.validation.constraints.NotNull;
+
+public record CareModeUpdateRequest(
+        @NotNull CareMode careMode
+) {
+}

--- a/src/main/java/com/ppiyaki/user/service/UserService.java
+++ b/src/main/java/com/ppiyaki/user/service/UserService.java
@@ -1,0 +1,42 @@
+package com.ppiyaki.user.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.controller.dto.CareModeResponse;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final CareRelationRepository careRelationRepository;
+
+    public UserService(
+            final UserRepository userRepository,
+            final CareRelationRepository careRelationRepository
+    ) {
+        this.userRepository = userRepository;
+        this.careRelationRepository = careRelationRepository;
+    }
+
+    @Transactional
+    public CareModeResponse updateCareMode(
+            final Long requesterId,
+            final Long seniorId,
+            final CareMode careMode
+    ) {
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(requesterId, seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+
+        senior.changeCareMode(careMode);
+        return new CareModeResponse(senior.getId(), senior.getCareMode());
+    }
+}

--- a/src/test/java/com/ppiyaki/user/service/UserServiceCareModeTest.java
+++ b/src/test/java/com/ppiyaki/user/service/UserServiceCareModeTest.java
@@ -1,0 +1,124 @@
+package com.ppiyaki.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.Gender;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
+import com.ppiyaki.user.controller.dto.CareModeResponse;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService.updateCareMode")
+class UserServiceCareModeTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CareRelationRepository careRelationRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("활성 보호자가 시니어 careMode를 AUTONOMOUS로 변경하면 성공")
+    void 보호자_변경_성공() throws Exception {
+        // given
+        final Long seniorId = 100L;
+        final Long caregiverId = 200L;
+        final User senior = givenSenior(seniorId);
+        when(userRepository.findById(seniorId)).thenReturn(Optional.of(senior));
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(caregiverId, seniorId))
+                .thenReturn(Optional.of(new CareRelation(seniorId, caregiverId, "INVITE")));
+
+        // when
+        final CareModeResponse response = userService.updateCareMode(caregiverId, seniorId, CareMode.AUTONOMOUS);
+
+        // then
+        assertThat(response.userId()).isEqualTo(seniorId);
+        assertThat(response.careMode()).isEqualTo(CareMode.AUTONOMOUS);
+        assertThat(senior.getCareMode()).isEqualTo(CareMode.AUTONOMOUS);
+    }
+
+    @Test
+    @DisplayName("시니어 본인이 셀프 변경 시도하면 CARE_RELATION_NOT_FOUND")
+    void 시니어_셀프_변경_실패() throws Exception {
+        // given
+        final Long seniorId = 100L;
+        final User senior = givenSenior(seniorId);
+        when(userRepository.findById(seniorId)).thenReturn(Optional.of(senior));
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(seniorId, seniorId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateCareMode(seniorId, seniorId, CareMode.AUTONOMOUS))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_NOT_FOUND);
+        assertThat(senior.getCareMode()).isEqualTo(CareMode.MANAGED);
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자가 호출하면 CARE_RELATION_NOT_FOUND")
+    void 관계_없음_실패() throws Exception {
+        // given
+        final Long seniorId = 100L;
+        final Long otherUserId = 999L;
+        final User senior = givenSenior(seniorId);
+        when(userRepository.findById(seniorId)).thenReturn(Optional.of(senior));
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(otherUserId, seniorId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateCareMode(otherUserId, seniorId, CareMode.AUTONOMOUS))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("seniorId 미존재 시 USER_NOT_FOUND")
+    void 시니어_미존재_실패() {
+        // given
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateCareMode(200L, 999L, CareMode.AUTONOMOUS))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    private User givenSenior(final Long id) throws Exception {
+        final User user = new User(
+                "loginid",
+                "password",
+                UserRole.SENIOR,
+                "시니어",
+                Gender.UNKNOWN,
+                LocalDate.of(1950, 1, 1),
+                null
+        );
+        final Field idField = user.getClass().getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(user, id);
+        return user;
+    }
+}


### PR DESCRIPTION
> 본 PR은 #193 재오픈입니다. #191 머지 시 base 브랜치 자동 삭제로 #193이 닫혀, develop 기반 새 브랜치로 cherry-pick 후 재생성.

## AS-IS
- spec(`prescription-ocr.md` §3-3, §5-2)이 정의한 `PUT /api/v1/users/{seniorId}/care-mode` 엔드포인트가 미구현.
- PR #191(머지 완료)에서 `User.careMode` 컬럼은 추가됐지만 변경할 수단이 없음.

## TO-BE
- 신규 `UserController` + `UserService`로 PUT 엔드포인트 제공.
- 권한: 활성 `care_relations` 보호자만 (시니어 본인이 호출해도 거부).
- 입력: `{ "careMode": "MANAGED" | "AUTONOMOUS" }`. 응답: `{ "userId", "careMode" }`.
- 단위 테스트 4건.

## 관련 이슈
- closes #192
- 후속: PrescriptionService.validateAccess 모드 분기 + 72h fallback (`CARE_MODE_RESTRICTED` 도입 동반)

## 라벨 부여 확인
- [x] `type:feat`, `scope:user`, `ai-generated`
- [x] needs-human-review — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트</summary>

- [x] AI 보조/생성 사용
- [x] checkstyleMain spotlessCheck test 통과
- [x] 회귀 가능 구간: 신규 컨트롤러/서비스만 추가
- [x] DDD/계층 침범 없음
- [x] 시크릿/의료정보 노출 없음

</details>