### PR TITLE
feat(prescription): 처방전 변경 권한 분기 + 72h fallback

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -65,6 +65,7 @@
 | `CARE_001` | 403 | No active care relation | 보호자-시니어 연동 관계 없음 |
 | `CARE_002` | 403 | Caregiver must specify seniorId | 보호자는 seniorId 필수 |
 | `CARE_003` | 403 | Only caregivers can specify seniorId | 시니어는 seniorId 지정 불가 |
+| `CARE_004` | 403 | Senior cannot mutate prescription before caregiver review window | MANAGED 모드 0~72h 사이 시니어 본인이 처방전 변경 시도. 보호자 검토 대기 중. 72h 경과 시 fallback 통과 |
 
 ## 프론트엔드 처리 가이드
 
@@ -86,7 +87,8 @@ if (!response.ok) {
     case 'CARE_001':
     case 'CARE_002':
     case 'CARE_003':
-      // 권한 없음 안내
+    case 'CARE_004':
+      // 권한 없음 안내 (CARE_004는 "보호자 검토를 기다리고 있어요" 메시지 권장)
       break;
     default:
       // body.error.message로 일반 에러 표시

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {
     CARE_RELATION_NOT_FOUND(HttpStatus.FORBIDDEN, "CARE_001", "No active care relation"),
     CARE_RELATION_REQUIRED(HttpStatus.FORBIDDEN, "CARE_002", "Caregiver must specify seniorId"),
     CARE_RELATION_NOT_CAREGIVER(HttpStatus.FORBIDDEN, "CARE_003", "Only caregivers can specify seniorId"),
+    CARE_MODE_RESTRICTED(HttpStatus.FORBIDDEN, "CARE_004",
+            "Senior cannot mutate prescription before caregiver review window"),
 
     // Chat
     CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_001", "Chat session not found"),

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -25,10 +25,15 @@ import com.ppiyaki.prescription.controller.dto.PrescriptionListResponse;
 import com.ppiyaki.prescription.controller.dto.PrescriptionMedicineAddRequest;
 import com.ppiyaki.prescription.repository.PrescriptionMedicineCandidateRepository;
 import com.ppiyaki.prescription.repository.PrescriptionRepository;
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -49,10 +54,13 @@ public class PrescriptionService {
 
     private static final Logger log = LoggerFactory.getLogger(PrescriptionService.class);
 
+    private static final Duration MANAGED_FALLBACK_AFTER = Duration.ofHours(72);
+
     private final PrescriptionRepository prescriptionRepository;
     private final PrescriptionMedicineCandidateRepository candidateRepository;
     private final MedicineRepository medicineRepository;
     private final CareRelationRepository careRelationRepository;
+    private final UserRepository userRepository;
     private final ClovaOcrClient clovaOcrClient;
     private final OpenAiClient openAiClient;
     private final MedicineMatchService medicineMatchService;
@@ -66,6 +74,7 @@ public class PrescriptionService {
             final PrescriptionMedicineCandidateRepository candidateRepository,
             final MedicineRepository medicineRepository,
             final CareRelationRepository careRelationRepository,
+            final UserRepository userRepository,
             final ClovaOcrClient clovaOcrClient,
             final OpenAiClient openAiClient,
             final MedicineMatchService medicineMatchService,
@@ -78,6 +87,7 @@ public class PrescriptionService {
         this.candidateRepository = candidateRepository;
         this.medicineRepository = medicineRepository;
         this.careRelationRepository = careRelationRepository;
+        this.userRepository = userRepository;
         this.clovaOcrClient = clovaOcrClient;
         this.openAiClient = openAiClient;
         this.medicineMatchService = medicineMatchService;
@@ -153,7 +163,7 @@ public class PrescriptionService {
     @Transactional(readOnly = true)
     public PrescriptionDetailResponse getDetail(final Long userId, final Long prescriptionId) {
         final Prescription prescription = findPrescription(prescriptionId);
-        validateAccess(userId, prescription.getOwnerId());
+        validateReadAccess(userId, prescription);
         final List<PrescriptionMedicineCandidate> candidates = candidateRepository.findByPrescriptionId(prescriptionId);
         return PrescriptionDetailResponse.from(prescription, candidates);
     }
@@ -177,7 +187,7 @@ public class PrescriptionService {
             final CandidateDecisionRequest request
     ) {
         final Prescription prescription = findPrescription(prescriptionId);
-        validateAccess(userId, prescription.getOwnerId());
+        validateMutationAccess(userId, prescription);
 
         final PrescriptionMedicineCandidate candidate = candidateRepository.findById(candidateId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEDICINE_NOT_FOUND));
@@ -197,7 +207,7 @@ public class PrescriptionService {
             final PrescriptionMedicineAddRequest request
     ) {
         final Prescription prescription = findPrescription(prescriptionId);
-        validateAccess(userId, prescription.getOwnerId());
+        validateMutationAccess(userId, prescription);
 
         if (prescription.getStatus() != PrescriptionStatus.PENDING_REVIEW) {
             throw new BusinessException(ErrorCode.INVALID_INPUT,
@@ -219,7 +229,7 @@ public class PrescriptionService {
     @Transactional
     public PrescriptionDetailResponse confirm(final Long userId, final Long prescriptionId) {
         final Prescription prescription = findPrescription(prescriptionId);
-        validateAccess(userId, prescription.getOwnerId());
+        validateMutationAccess(userId, prescription);
 
         final List<PrescriptionMedicineCandidate> candidates = candidateRepository.findByPrescriptionId(prescriptionId);
 
@@ -256,7 +266,7 @@ public class PrescriptionService {
     @Transactional
     public void reject(final Long userId, final Long prescriptionId) {
         final Prescription prescription = findPrescription(prescriptionId);
-        validateAccess(userId, prescription.getOwnerId());
+        validateMutationAccess(userId, prescription);
         prescription.reject();
     }
 
@@ -320,9 +330,38 @@ public class PrescriptionService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEDICINE_NOT_FOUND));
     }
 
-    private void validateAccess(final Long userId, final Long ownerId) {
+    /**
+     * 처방전 조회 권한 검증 (모드 무관). 시니어 본인 또는 활성 보호자만 통과.
+     */
+    private void validateReadAccess(final Long userId, final Prescription prescription) {
+        final Long ownerId = prescription.getOwnerId();
         if (userId.equals(ownerId)) {
             return;
+        }
+        careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(userId, ownerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+    }
+
+    /**
+     * 처방전 변경 권한 검증 (모드별 분기, spec §5-2-1).
+     * - AUTONOMOUS 시니어/보호자: 즉시 통과
+     * - MANAGED 시니어 0~72h: CARE_MODE_RESTRICTED
+     * - MANAGED 시니어 72h+: fallback 통과
+     * - 활성 보호자: 모드 무관 통과
+     */
+    private void validateMutationAccess(final Long userId, final Prescription prescription) {
+        final Long ownerId = prescription.getOwnerId();
+        if (userId.equals(ownerId)) {
+            final User senior = userRepository.findById(ownerId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+            if (senior.getCareMode() == CareMode.AUTONOMOUS) {
+                return;
+            }
+            final Duration elapsed = Duration.between(prescription.getCreatedAt(), LocalDateTime.now());
+            if (elapsed.compareTo(MANAGED_FALLBACK_AFTER) >= 0) {
+                return;
+            }
+            throw new BusinessException(ErrorCode.CARE_MODE_RESTRICTED);
         }
         careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(userId, ownerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));

--- a/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
+++ b/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
@@ -24,9 +24,15 @@ import com.ppiyaki.prescription.PrescriptionStatus;
 import com.ppiyaki.prescription.controller.dto.PrescriptionMedicineAddRequest;
 import com.ppiyaki.prescription.repository.PrescriptionMedicineCandidateRepository;
 import com.ppiyaki.prescription.repository.PrescriptionRepository;
+import com.ppiyaki.user.CareMode;
 import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.Gender;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
 import java.lang.reflect.Field;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -51,6 +57,8 @@ class PrescriptionServiceManualAddTest {
     @Mock
     private CareRelationRepository careRelationRepository;
     @Mock
+    private UserRepository userRepository;
+    @Mock
     private ClovaOcrClient clovaOcrClient;
     @Mock
     private OpenAiClient openAiClient;
@@ -69,13 +77,14 @@ class PrescriptionServiceManualAddTest {
     private PrescriptionService prescriptionService;
 
     @Test
-    @DisplayName("PENDING_REVIEW 상태 처방전에 보호자가 약물을 수동 추가하면 ACCEPTED 후보가 생성된다")
-    void 보호자_수동_추가_성공() throws Exception {
+    @DisplayName("AUTONOMOUS 시니어 본인이 약물을 수동 추가하면 ACCEPTED 후보가 생성된다")
+    void 자율형_시니어_수동_추가_성공() throws Exception {
         // given
         final Long ownerId = 100L;
         final Long prescriptionId = 1L;
         final Prescription prescription = givenPrescription(prescriptionId, ownerId, PrescriptionStatus.PENDING_REVIEW);
         when(prescriptionRepository.findById(prescriptionId)).thenReturn(Optional.of(prescription));
+        when(userRepository.findById(ownerId)).thenReturn(Optional.of(givenSenior(ownerId, CareMode.AUTONOMOUS)));
         when(candidateRepository.findByPrescriptionId(prescriptionId)).thenReturn(List.of());
 
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
@@ -154,6 +163,7 @@ class PrescriptionServiceManualAddTest {
         final Long prescriptionId = 1L;
         final Prescription prescription = givenPrescription(prescriptionId, ownerId, PrescriptionStatus.CONFIRMED);
         when(prescriptionRepository.findById(prescriptionId)).thenReturn(Optional.of(prescription));
+        when(userRepository.findById(ownerId)).thenReturn(Optional.of(givenSenior(ownerId, CareMode.AUTONOMOUS)));
 
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
                 "199500096", "타이레놀정 500mg", null, null);
@@ -189,6 +199,15 @@ class PrescriptionServiceManualAddTest {
         setField(prescription, "id", id);
         setField(prescription, "status", targetStatus);
         return prescription;
+    }
+
+    private User givenSenior(final Long id, final CareMode careMode) throws Exception {
+        final User user = new User(
+                "loginid" + id, "password", UserRole.SENIOR, "시니어",
+                Gender.UNKNOWN, LocalDate.of(1950, 1, 1), null);
+        setField(user, "id", id);
+        user.changeCareMode(careMode);
+        return user;
     }
 
     private static void setField(final Object target, final String fieldName, final Object value) throws Exception {

--- a/src/test/java/com/ppiyaki/prescription/service/PrescriptionServicePermissionTest.java
+++ b/src/test/java/com/ppiyaki/prescription/service/PrescriptionServicePermissionTest.java
@@ -1,0 +1,215 @@
+package com.ppiyaki.prescription.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.common.ai.OpenAiClient;
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.ocr.ClovaOcrClient;
+import com.ppiyaki.common.storage.NcpStorageProperties;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.medicine.service.MedicineMatchService;
+import com.ppiyaki.prescription.ImageOrientationCorrector;
+import com.ppiyaki.prescription.PiiMaskingService;
+import com.ppiyaki.prescription.Prescription;
+import com.ppiyaki.prescription.PrescriptionStatus;
+import com.ppiyaki.prescription.controller.dto.PrescriptionMedicineAddRequest;
+import com.ppiyaki.prescription.repository.PrescriptionMedicineCandidateRepository;
+import com.ppiyaki.prescription.repository.PrescriptionRepository;
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.Gender;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PrescriptionService 권한 분기 (모드별 + 72h fallback)")
+class PrescriptionServicePermissionTest {
+
+    @Mock
+    private PrescriptionRepository prescriptionRepository;
+    @Mock
+    private PrescriptionMedicineCandidateRepository candidateRepository;
+    @Mock
+    private MedicineRepository medicineRepository;
+    @Mock
+    private CareRelationRepository careRelationRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ClovaOcrClient clovaOcrClient;
+    @Mock
+    private OpenAiClient openAiClient;
+    @Mock
+    private MedicineMatchService medicineMatchService;
+    @Mock
+    private PiiMaskingService piiMaskingService;
+    @Mock
+    private ImageOrientationCorrector orientationCorrector;
+    @Mock
+    private NcpStorageProperties storageProperties;
+    @Mock
+    private S3Client s3Client;
+
+    @InjectMocks
+    private PrescriptionService prescriptionService;
+
+    private static final Long SENIOR_ID = 100L;
+    private static final Long CAREGIVER_ID = 200L;
+    private static final Long OTHER_ID = 999L;
+    private static final Long PRESCRIPTION_ID = 1L;
+
+    @Test
+    @DisplayName("[변경] AUTONOMOUS 모드: 시니어 본인은 즉시 통과한다")
+    void 자율형_시니어_변경_성공() throws Exception {
+        // given
+        final Prescription prescription = givenPrescription(LocalDateTime.now());
+        when(prescriptionRepository.findById(PRESCRIPTION_ID)).thenReturn(Optional.of(prescription));
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(givenSenior(CareMode.AUTONOMOUS)));
+        when(candidateRepository.findByPrescriptionId(PRESCRIPTION_ID)).thenReturn(List.of());
+
+        // when & then
+        assertThatCode(() -> prescriptionService.addManualMedicine(SENIOR_ID, PRESCRIPTION_ID, validRequest()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("[변경] AUTONOMOUS 모드: 활성 보호자도 통과한다")
+    void 자율형_보호자_변경_성공() throws Exception {
+        // given
+        final Prescription prescription = givenPrescription(LocalDateTime.now());
+        when(prescriptionRepository.findById(PRESCRIPTION_ID)).thenReturn(Optional.of(prescription));
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(CAREGIVER_ID, SENIOR_ID))
+                .thenReturn(Optional.of(new CareRelation(SENIOR_ID, CAREGIVER_ID, "INVITE")));
+        when(candidateRepository.findByPrescriptionId(PRESCRIPTION_ID)).thenReturn(List.of());
+
+        // when & then
+        assertThatCode(() -> prescriptionService.addManualMedicine(CAREGIVER_ID, PRESCRIPTION_ID, validRequest()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("[변경] MANAGED 모드 + 72h 미경과: 시니어 본인은 CARE_MODE_RESTRICTED")
+    void 관리형_시니어_72h_미경과_차단() throws Exception {
+        // given — 1시간 전 생성된 처방전
+        final Prescription prescription = givenPrescription(LocalDateTime.now().minusHours(1));
+        when(prescriptionRepository.findById(PRESCRIPTION_ID)).thenReturn(Optional.of(prescription));
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(givenSenior(CareMode.MANAGED)));
+
+        // when & then
+        assertThatThrownBy(() -> prescriptionService.addManualMedicine(SENIOR_ID, PRESCRIPTION_ID, validRequest()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_MODE_RESTRICTED);
+    }
+
+    @Test
+    @DisplayName("[변경] MANAGED 모드 + 72h 경과: 시니어 본인 fallback 통과")
+    void 관리형_시니어_72h_경과_fallback() throws Exception {
+        // given — 73시간 전 생성된 처방전
+        final Prescription prescription = givenPrescription(LocalDateTime.now().minusHours(73));
+        when(prescriptionRepository.findById(PRESCRIPTION_ID)).thenReturn(Optional.of(prescription));
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(givenSenior(CareMode.MANAGED)));
+        when(candidateRepository.findByPrescriptionId(PRESCRIPTION_ID)).thenReturn(List.of());
+
+        // when & then
+        assertThatCode(() -> prescriptionService.addManualMedicine(SENIOR_ID, PRESCRIPTION_ID, validRequest()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("[변경] MANAGED 모드: 활성 보호자는 모드 무관 통과 (72h 미경과 처방전)")
+    void 관리형_보호자_72h_미경과_통과() throws Exception {
+        // given
+        final Prescription prescription = givenPrescription(LocalDateTime.now());
+        when(prescriptionRepository.findById(PRESCRIPTION_ID)).thenReturn(Optional.of(prescription));
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(CAREGIVER_ID, SENIOR_ID))
+                .thenReturn(Optional.of(new CareRelation(SENIOR_ID, CAREGIVER_ID, "INVITE")));
+        when(candidateRepository.findByPrescriptionId(PRESCRIPTION_ID)).thenReturn(List.of());
+
+        // when & then
+        assertThatCode(() -> prescriptionService.addManualMedicine(CAREGIVER_ID, PRESCRIPTION_ID, validRequest()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("[변경] 관계 없는 사용자: CARE_RELATION_NOT_FOUND")
+    void 관계없는_사용자_차단() throws Exception {
+        // given
+        final Prescription prescription = givenPrescription(LocalDateTime.now());
+        when(prescriptionRepository.findById(PRESCRIPTION_ID)).thenReturn(Optional.of(prescription));
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(OTHER_ID, SENIOR_ID))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> prescriptionService.addManualMedicine(OTHER_ID, PRESCRIPTION_ID, validRequest()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("[조회] getDetail은 모드 무관 — MANAGED + 시니어 + 0h 처방전도 통과")
+    void 조회_모드_무관_통과() throws Exception {
+        // given — MANAGED 모드 + 방금 생성된 처방전 (변경 시점이라면 차단됨)
+        final Prescription prescription = givenPrescription(LocalDateTime.now());
+        when(prescriptionRepository.findById(PRESCRIPTION_ID)).thenReturn(Optional.of(prescription));
+        when(candidateRepository.findByPrescriptionId(PRESCRIPTION_ID)).thenReturn(List.of());
+
+        // when & then — userRepository 호출 없이 바로 통과 (read access는 시니어 본인 자동 통과)
+        assertThatCode(() -> prescriptionService.getDetail(SENIOR_ID, PRESCRIPTION_ID))
+                .doesNotThrowAnyException();
+    }
+
+    private PrescriptionMedicineAddRequest validRequest() {
+        return new PrescriptionMedicineAddRequest("199500096", "타이레놀정 500mg", null, null);
+    }
+
+    private Prescription givenPrescription(final LocalDateTime createdAt) throws Exception {
+        final Prescription prescription = new Prescription(SENIOR_ID);
+        setField(prescription, "id", PRESCRIPTION_ID);
+        setField(prescription, "status", PrescriptionStatus.PENDING_REVIEW);
+        setField(prescription, "createdAt", createdAt);
+        return prescription;
+    }
+
+    private User givenSenior(final CareMode careMode) throws Exception {
+        final User user = new User(
+                "senior", "password", UserRole.SENIOR, "시니어",
+                Gender.UNKNOWN, LocalDate.of(1950, 1, 1), null);
+        setField(user, "id", SENIOR_ID);
+        user.changeCareMode(careMode);
+        return user;
+    }
+
+    private static void setField(final Object target, final String fieldName, final Object value) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}


### PR DESCRIPTION
## AS-IS
- spec(`prescription-ocr.md` §3-3, §5-2-1)이 정의한 모드별 권한 분기 미구현.
- 현재 `PrescriptionService.validateAccess`는 owner(시니어)를 항상 통과시켜 보호자 검증 강제 의도가 사실상 동작 안 함.
- 72h fallback도 우연히 동작 (시니어 항상 통과로 인해).

## TO-BE
- `validateAccess` → `validateReadAccess` (모드 무관) + `validateMutationAccess` (모드별 분기)로 분리.
- spec §5-2-1 의사코드를 그대로 옮긴 5케이스 권한 분기.
- `CARE_MODE_RESTRICTED` (CARE_004, 403) ErrorCode 신규로 "관계 없음" vs "MANAGED 차단" 구분.
- 7건 신규 단위 테스트 (`PrescriptionServicePermissionTest`).

## 관련 이슈
- closes #195
- 선행 머지: #190 spec, #191 User.careMode, #194 PUT /care-mode

## 리뷰어 참고 포인트
- **`validateMutationAccess` 호출 시 UserRepository.findById(ownerId)** — 시니어가 아닌 user_id가 owner_id로 들어올 수 없음 (`Prescription.owner_id`는 처방전 등록자 = 시니어). 그러나 안전장치로 `USER_NOT_FOUND` 처리.
- **시간 계산**: `Duration.between(prescription.getCreatedAt(), LocalDateTime.now())` 요청 시점 계산. `@Scheduled` 미사용 (단순화).
- **`MANAGED_FALLBACK_AFTER = Duration.ofHours(72)`**: 상수로 분리. 향후 모드별 가변 fallback 도입 시 확장 가능.
- **getDetail은 `validateReadAccess`** — 조회는 모드 무관(spec §5-2 표). 보호자가 모드 변경 전에도 처방전 내용을 미리 볼 수 있어야 UX 자연스러움.
- **테스트 격리**: 권한 테스트는 `addManualMedicine` 경로 한 번으로 5케이스 모두 검증 (각 변경 엔드포인트별 반복 안 함). `validateMutationAccess`가 단일 메서드라 행위 일관성 검증 충분.

## 하네스 정합성 체크리스트 (push 직전 자체 점검)
- Step 1 엔티티 변경: N/A
- Step 2 API 변경: ✅ Notion API DB 처방전 수동추가 행에 CARE_MODE_RESTRICTED 보강 paragraph 추가
- Step 3 새 ErrorCode: ✅ `CARE_MODE_RESTRICTED` + `error-codes.md` 갱신
- Step 4 인덱스: N/A
- Step 5 Spec 1:1: §3-3 + §5-2-1 의사코드 그대로 구현
- Step 6 라벨: type:feat / scope:prescription / ai-generated. needs-human-review N/A

## 라벨 부여 확인
- [x] `type:feat` 라벨 부여
- [x] `scope:prescription` 라벨 부여
- [x] `ai-generated` 라벨 부여
- [x] `needs-human-review` — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 회귀 가능 구간: 기존 ManualAddTest 5건 — UserRepository mock 추가하여 정상 통과. 다른 컨트롤러 변경 없음.
- [x] 롤백: revert 1 커밋. ErrorCode enum에 새 값 추가만 했고 기존 코드 깨지 않음.

## DDD/OOP 준수 체크
- [x] 도메인 용어 일치 (CareMode, Prescription, CareRelation)
- [x] 계층 침범 없음 (Service만 변경)
- [x] God Object 없음 — 권한 분기 메서드 분리

## 보안/민감정보 체크
- [x] 시크릿 하드코딩 없음
- [x] 의료정보 원문 노출 없음 — 시간 계산만 로깅 없음
- [x] 마스킹 — 해당 없음

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: spec PR 12 — validateAccess 모드 분기 + 72h fallback + CARE_MODE_RESTRICTED 도입.
- AI가 직접 수정한 파일: ErrorCode, error-codes.md, PrescriptionService, ManualAddTest, PermissionTest(신규)
- 사람이 수동 검증한 항목: enum 값 명명, 의사코드 동치 여부.
- 잔여 리스크: 시간 의존 테스트 1건 (73h 경과 fallback) — 시스템 시계에 의존하지만 LocalDateTime.now() 기반이라 결정론적.

</details>