### PR TITLE
test(prescription): care-mode + 처방전 변경 권한 E2E 추가

### DIFF
--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionMutationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionMutationControllerE2ETest.java
@@ -1,0 +1,252 @@
+package com.ppiyaki.prescription.controller;
+
+import static org.hamcrest.Matchers.is;
+
+import com.ppiyaki.prescription.Prescription;
+import com.ppiyaki.prescription.PrescriptionStatus;
+import com.ppiyaki.prescription.repository.PrescriptionRepository;
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("처방전 변경 엔드포인트 권한 분기 E2E")
+class PrescriptionMutationControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CareRelationRepository careRelationRepository;
+
+    @Autowired
+    private PrescriptionRepository prescriptionRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private static long userSequence = 800000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("AUTONOMOUS 시니어 본인이 POST /medicines 호출하면 201")
+    void autonomous_senior_can_add_medicine() {
+        // given
+        final SignupResult senior = signup("자율형시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        final Long prescriptionId = seedPrescription(senior.userId(), LocalDateTime.now());
+
+        // when & then
+        addMedicine(senior.accessToken(), prescriptionId)
+                .then()
+                .statusCode(201);
+    }
+
+    @Test
+    @DisplayName("MANAGED 시니어 본인이 0~72h 사이에 POST /medicines 호출하면 403 CARE_004")
+    void managed_senior_blocked_within_72h() {
+        // given
+        final SignupResult senior = signup("관리형시니어A");
+        // default = MANAGED
+        final Long prescriptionId = seedPrescription(senior.userId(), LocalDateTime.now().minusHours(1));
+
+        // when & then
+        addMedicine(senior.accessToken(), prescriptionId)
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_004"));
+    }
+
+    @Test
+    @DisplayName("MANAGED 시니어 본인이 72h 경과 후 POST /medicines 호출하면 fallback 통과")
+    void managed_senior_fallback_after_72h() {
+        // given
+        final SignupResult senior = signup("관리형시니어B");
+        // default = MANAGED
+        final Long prescriptionId = seedPrescription(senior.userId(), LocalDateTime.now().minusHours(73));
+
+        // when & then
+        addMedicine(senior.accessToken(), prescriptionId)
+                .then()
+                .statusCode(201);
+    }
+
+    @Test
+    @DisplayName("활성 보호자가 MANAGED 모드 시니어의 처방전에 POST /medicines 호출하면 201")
+    void caregiver_can_add_medicine_under_managed() {
+        // given
+        final SignupResult senior = signup("관리형시니어C");
+        final SignupResult caregiver = signup("보호자G");
+        seedCareRelation(senior.userId(), caregiver.userId());
+        final Long prescriptionId = seedPrescription(senior.userId(), LocalDateTime.now());
+
+        // when & then
+        addMedicine(caregiver.accessToken(), prescriptionId)
+                .then()
+                .statusCode(201);
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자가 POST /medicines 호출하면 403 CARE_001")
+    void unrelated_user_rejected() {
+        // given
+        final SignupResult senior = signup("관리형시니어D");
+        final SignupResult stranger = signup("타인H");
+        final Long prescriptionId = seedPrescription(senior.userId(), LocalDateTime.now());
+
+        // when & then
+        addMedicine(stranger.accessToken(), prescriptionId)
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    @Test
+    @DisplayName("AUTONOMOUS로 모드 전환 후 시니어가 즉시 변경 가능 — 모드 효과 통합 검증")
+    void mode_change_effect_integration() {
+        // given — MANAGED 상태에서 시니어 차단 확인
+        final SignupResult senior = signup("통합시니어");
+        final SignupResult caregiver = signup("통합보호자");
+        seedCareRelation(senior.userId(), caregiver.userId());
+        final Long prescriptionId = seedPrescription(senior.userId(), LocalDateTime.now());
+
+        addMedicine(senior.accessToken(), prescriptionId).then().statusCode(403);
+
+        // when — 보호자가 AUTONOMOUS로 전환
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .body("""
+                        {"careMode": "AUTONOMOUS"}
+                        """)
+                .when()
+                .put("/api/v1/users/" + senior.userId() + "/care-mode")
+                .then()
+                .statusCode(200);
+
+        // then — 시니어가 즉시 변경 가능
+        addMedicine(senior.accessToken(), prescriptionId).then().statusCode(201);
+    }
+
+    private io.restassured.response.Response addMedicine(final String token, final Long prescriptionId) {
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body("""
+                        {
+                            "itemSeq": "199500096",
+                            "itemName": "타이레놀정 500mg",
+                            "dosage": "1정",
+                            "schedule": "1일 3회"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/medicines");
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "presmut" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    @Transactional
+    void setSeniorMode(final Long seniorId, final CareMode mode) {
+        transactionTemplate.executeWithoutResult(status -> {
+            final User user = userRepository.findById(seniorId).orElseThrow();
+            user.changeCareMode(mode);
+            userRepository.save(user);
+        });
+    }
+
+    private void seedCareRelation(final Long seniorId, final Long caregiverId) {
+        careRelationRepository.save(new CareRelation(seniorId, caregiverId, "INV-" + seniorId + "-" + caregiverId));
+    }
+
+    private Long seedPrescription(final Long seniorId, final LocalDateTime createdAt) {
+        final Long id = transactionTemplate.execute(status -> {
+            final Prescription prescription = new Prescription(seniorId);
+            setHierarchicalField(prescription, "status", PrescriptionStatus.PENDING_REVIEW);
+            return prescriptionRepository.save(prescription).getId();
+        });
+        // created_at은 @CreatedDate + updatable=false라 JPA로는 갱신 불가 → 직접 SQL 실행
+        jdbcTemplate.update("UPDATE prescriptions SET created_at = ? WHERE id = ?",
+                java.sql.Timestamp.valueOf(createdAt), id);
+        return id;
+    }
+
+    private static void setHierarchicalField(final Object target, final String fieldName, final Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Field not found: " + fieldName);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}

--- a/src/test/java/com/ppiyaki/user/controller/CareModeControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/CareModeControllerE2ETest.java
@@ -1,0 +1,174 @@
+package com.ppiyaki.user.controller;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("PUT /api/v1/users/{seniorId}/care-mode E2E")
+class CareModeControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CareRelationRepository careRelationRepository;
+
+    private static long userSequence = 700000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("활성 보호자가 시니어 careMode를 AUTONOMOUS로 변경하면 200 + 새 모드 반환")
+    void caregiver_updates_senior_careMode_success() {
+        // given
+        final SignupResult senior = signup("시니어A");
+        final SignupResult caregiver = signup("보호자A");
+        seedCareRelation(senior.userId(), caregiver.userId());
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .body("""
+                        {"careMode": "AUTONOMOUS"}
+                        """)
+                .when()
+                .put("/api/v1/users/" + senior.userId() + "/care-mode")
+                .then()
+                .statusCode(200)
+                .body("userId", equalTo(senior.userId().intValue()))
+                .body("careMode", is("AUTONOMOUS"));
+
+        final User updated = userRepository.findById(senior.userId()).orElseThrow();
+        assert updated.getCareMode() == CareMode.AUTONOMOUS;
+    }
+
+    @Test
+    @DisplayName("시니어 본인이 자기 careMode 변경 시도하면 403 CARE_001")
+    void senior_self_update_rejected() {
+        // given
+        final SignupResult senior = signup("시니어B");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {"careMode": "AUTONOMOUS"}
+                        """)
+                .when()
+                .put("/api/v1/users/" + senior.userId() + "/care-mode")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자가 변경 시도하면 403 CARE_001")
+    void unrelated_user_rejected() {
+        // given
+        final SignupResult senior = signup("시니어C");
+        final SignupResult stranger = signup("타인D");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + stranger.accessToken())
+                .body("""
+                        {"careMode": "AUTONOMOUS"}
+                        """)
+                .when()
+                .put("/api/v1/users/" + senior.userId() + "/care-mode")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    @Test
+    @DisplayName("seniorId 미존재 시 404 USER_001")
+    void senior_not_found() {
+        // given
+        final SignupResult caregiver = signup("보호자E");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .body("""
+                        {"careMode": "AUTONOMOUS"}
+                        """)
+                .when()
+                .put("/api/v1/users/9999999/care-mode")
+                .then()
+                .statusCode(404)
+                .body("error.code", is("USER_001"));
+    }
+
+    @Test
+    @DisplayName("careMode가 null이면 400 COMMON_001")
+    void invalid_payload_rejected() {
+        // given
+        final SignupResult caregiver = signup("보호자F");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .body("""
+                        {"careMode": null}
+                        """)
+                .when()
+                .put("/api/v1/users/" + caregiver.userId() + "/care-mode")
+                .then()
+                .statusCode(400);
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "caremode" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private void seedCareRelation(final Long seniorId, final Long caregiverId) {
+        careRelationRepository.save(new CareRelation(seniorId, caregiverId, "INVITE-" + seniorId + "-" + caregiverId));
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}


### PR DESCRIPTION
## AS-IS
- spec(`prescription-ocr.md` §6 PR 14)이 정의한 권한 분기 E2E 시나리오 미구현.
- 권한 분기 로직은 PR #196에서 단위 테스트(7건)로 검증됐지만 RestAssured 통합 흐름이 없음.
- prescription 모듈 controller E2E 인프라 0건 — `src/test/.../prescription/` 디렉토리에 controller 테스트 없음.

## TO-BE
- `CareModeControllerE2ETest` 5건 + `PrescriptionMutationControllerE2ETest` 6건 추가.
- @SpringBootTest 프로퍼티로 ConditionalOnProperty 빈(clova.ocr/openai/mfds.api/ncp.storage) 활성화하는 패턴 정립.
- POST /prescriptions OCR 파이프라인 E2E는 외부 의존성이 커 본 PR scope 외.

## 관련 이슈
- closes #197
- spec PR 14 (§6)

## 리뷰어 참고 포인트
- **테스트 인프라 핵심**: `@SpringBootTest(properties = {...})`로 ConditionalOnProperty 활성화. ClovaOcrClient/OpenAiClient/MedicineMatchService/S3Client 모두 실제 빈으로 생성되지만 본 PR 테스트 경로(PUT /care-mode, POST /medicines)에서는 호출되지 않아 실제 외부 통신 없음.
- **created_at 시뮬레이션**: `@CreatedDate updatable=false`라 JPA로 갱신 불가 → JdbcTemplate으로 직접 SQL 실행. 73h 경과 fallback 시뮬레이션의 핵심 트릭.
- **모드 효과 통합 검증**: `mode_change_effect_integration` 테스트 — MANAGED → 시니어 차단 → 보호자가 AUTONOMOUS 전환 → 시니어 즉시 변경 가능. 두 PR(#194 + #196)의 상호작용을 한 번에 검증.
- **POST /prescriptions OCR 파이프라인 E2E 미포함**: ClovaOcr/OpenAI/S3 mock 빈 주입이 필요해 별도 PR로 분리 권장. 본 PR은 권한 분기와 모드 효과에 집중.

## 하네스 정합성 체크리스트 (push 직전 자체 점검)
- Step 1 엔티티 변경: N/A
- Step 2 API 변경: N/A (테스트만 추가)
- Step 3 새 ErrorCode: N/A
- Step 4 인덱스: N/A
- Step 5 Spec 1:1: ✅ §6 PR 14와 일치
- Step 6 라벨: type:test / scope:prescription / scope:user / ai-generated. needs-human-review N/A

## 라벨 부여 확인
- [x] `type:test` 라벨 부여
- [x] `scope:prescription`, `scope:user` 라벨 부여
- [x] `ai-generated` 라벨 부여
- [x] `needs-human-review` — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 회귀 가능 구간: 본 PR은 테스트 추가만, 프로덕션 코드 변경 0
- [x] 롤백: revert 1 커밋

## DDD/OOP 준수 체크
- [x] 도메인 용어 일치
- [x] 계층 침범 없음 — 테스트 코드만
- [x] God Object 없음

## 보안/민감정보 체크
- [x] 시크릿 하드코딩 없음 (test-* placeholder만)
- [x] 의료정보 원문 노출 없음
- [x] 마스킹 — 해당 없음

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: spec PR 14 — care-mode + 처방전 권한 E2E 시나리오 작성
- AI가 직접 수정한 파일: CareModeControllerE2ETest 신규, PrescriptionMutationControllerE2ETest 신규
- 사람이 수동 검증한 항목: 테스트 시나리오 범위(POST OCR 제외 결정), JdbcTemplate created_at 우회
- 잔여 리스크: 시간 의존 테스트 1건 (LocalDateTime.now() 기반 73h fallback) — 결정론적이라 리스크 낮음

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 처방전 의약품 추가 기능에 대한 통합 테스트 스위트 추가
  * 치료 모드 변경 기능에 대한 통합 테스트 스위트 추가

**주요 검증 범위**: 자율적 사용자의 의약품 추가 권한, 관리 대상 사용자의 시간 기반 제한(72시간), 보호자 권한 확인, 권한 없는 사용자 차단, 치료 모드 변경에 따른 권한 즉시 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->