### PR TITLE
feat(medication): 복약 사진 약 개수 AI 검증 Phase 2 구현

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -67,6 +67,7 @@
 | 복약 일정 | Medication Schedule | 특정 약물을 언제 복용할지(`scheduled_time`, `dosage`) |
 | 복약 기록 | Medication Log | 실제 복용 이행 여부 기록 (`status`, `ai_status`) |
 | 복약 상태 | Log Status | 복약 기록의 사용자 확정 상태. `TAKEN` / `MISSED` / `PENDING`. `medication_logs.status`에 enum 매핑 |
+| AI 검증 상태 | Log AI Status | 복약 인증 사진 약 개수 AI 검증 결과. `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED`. `medication_logs.ai_status`에 enum 매핑 (Phase 2). 사진 + status=TAKEN일 때만 채워짐 |
 | 복약 이행률 | Adherence Rate | 기간 내 성공 복약 / 예정 복약 |
 | 대리 처리 | Proxy Confirmation | 보호자가 시니어 대신 복용 상태를 확정 (`is_proxy=true`, `confirmed_by_user_id != senior_id`) |
 | 보호자 승인 모드 | Care Mode | 시니어의 처방전 변경 권한 정책. `MANAGED`(보호자 검증 강제, 0~72h 보호자 전용 + 72h 후 시니어 fallback) / `AUTONOMOUS`(시니어 즉시 변경 허용). `users.care_mode`에 저장. 변경은 보호자만 가능 |

--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -6,8 +6,10 @@ import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -163,6 +165,92 @@ public class OpenAiClient {
         } catch (final Exception e) {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
                     "AI response parse failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 사진 속 알약 개수를 Vision LLM으로 추출.
+     * spec medication-log-phase2 §5-3.
+     *
+     * @param imageBytes 원본 이미지 바이트
+     * @param mediaType  예: "image/jpeg" / "image/png"
+     * @return 추출 개수. JSON 파싱 실패·API 실패 시 Optional.empty (1회 retry 후에도 실패).
+     */
+    public Optional<Integer> countPills(final byte[] imageBytes, final String mediaType) {
+        log.info("OpenAI countPills: imageSize={}bytes mediaType={}", imageBytes.length, mediaType);
+        for (int attempt = 1; attempt <= 2; attempt++) {
+            final long startTime = System.currentTimeMillis();
+            try {
+                final String model = properties.model() != null ? properties.model() : "gpt-5.4-nano";
+                final String requestBody = buildCountRequest(model, imageBytes, mediaType);
+
+                final String responseBody = restClient.post()
+                        .uri(API_URL)
+                        .header("Authorization", "Bearer " + properties.apiKey())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(requestBody)
+                        .retrieve()
+                        .body(String.class);
+
+                final long elapsed = System.currentTimeMillis() - startTime;
+                log.info("OpenAI countPills attempt={} elapsed={}ms", attempt, elapsed);
+
+                return parseCountResponse(responseBody);
+            } catch (final Exception e) {
+                final long elapsed = System.currentTimeMillis() - startTime;
+                log.warn("OpenAI countPills attempt={} failed elapsed={}ms error={}",
+                        attempt, elapsed, e.getMessage());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private String buildCountRequest(final String model, final byte[] imageBytes, final String mediaType) {
+        try {
+            final String dataUrl = "data:" + mediaType + ";base64,"
+                    + Base64.getEncoder().encodeToString(imageBytes);
+            final String systemPrompt = """
+                    Count the visible pills/capsules/tablets in the photo.
+                    Return JSON {"count": N} where N is a non-negative integer.
+                    If unsure or no pills visible, return {"count": 0}.
+                    Do not include any other text.
+                    """;
+
+            final Map<String, Object> textPart = Map.of("type", "text", "text", "How many pills are in this image?");
+            final Map<String, Object> imagePart = Map.of("type", "image_url", "image_url", Map.of("url", dataUrl));
+            final Map<String, Object> systemMessage = Map.of("role", "system", "content", systemPrompt);
+            final Map<String, Object> userMessage = Map.of("role", "user", "content", List.of(textPart, imagePart));
+
+            final Map<String, Object> request = Map.of(
+                    "model", model,
+                    "messages", List.of(systemMessage, userMessage),
+                    "temperature", 0.0,
+                    "response_format", Map.of("type", "json_object")
+            );
+            return objectMapper.writeValueAsString(request);
+        } catch (final Exception e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
+                    "AI countPills request build failed: " + e.getMessage());
+        }
+    }
+
+    private Optional<Integer> parseCountResponse(final String responseBody) {
+        try {
+            final JsonNode root = objectMapper.readTree(responseBody);
+            final String content = root.path("choices").get(0)
+                    .path("message").path("content").asText();
+            final JsonNode parsed = objectMapper.readTree(content);
+            if (!parsed.has("count") || !parsed.path("count").isNumber()) {
+                return Optional.empty();
+            }
+            final int count = parsed.path("count").asInt();
+            if (count < 0) {
+                return Optional.empty();
+            }
+            return Optional.of(count);
+        } catch (final Exception e) {
+            log.warn("OpenAI countPills parse failed: {}", e.getMessage());
+            return Optional.empty();
         }
     }
 

--- a/src/main/java/com/ppiyaki/medication/DosageParser.java
+++ b/src/main/java/com/ppiyaki/medication/DosageParser.java
@@ -1,0 +1,36 @@
+package com.ppiyaki.medication;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * dosage 자유 텍스트("1정", "2알", "1.5캡슐")에서 정수 알약 개수 추출.
+ * spec medication-log-phase2 §5-3.
+ */
+public final class DosageParser {
+
+    private static final Pattern PILL_COUNT_PATTERN = Pattern.compile("(\\d+)");
+
+    private DosageParser() {
+    }
+
+    /**
+     * dosage 문자열에서 첫 정수 매치를 반환한다.
+     * 매치 없거나 null/blank 입력은 Optional.empty.
+     */
+    public static Optional<Integer> parsePillCount(final String dosage) {
+        if (dosage == null || dosage.isBlank()) {
+            return Optional.empty();
+        }
+        final Matcher matcher = PILL_COUNT_PATTERN.matcher(dosage);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Integer.parseInt(matcher.group(1)));
+        } catch (final NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/LogAiStatus.java
+++ b/src/main/java/com/ppiyaki/medication/LogAiStatus.java
@@ -1,0 +1,16 @@
+package com.ppiyaki.medication;
+
+public enum LogAiStatus {
+
+    /** Vision 추출 개수 == dosage 합 */
+    COUNT_MATCH,
+
+    /** 추출 개수 != 합 */
+    COUNT_MISMATCH,
+
+    /** dosage 파싱 실패 등으로 검증 불가 */
+    COUNT_UNKNOWN,
+
+    /** Vision API 호출 실패 (timeout, 5xx 등) */
+    COUNT_FAILED
+}

--- a/src/main/java/com/ppiyaki/medication/MedicationLog.java
+++ b/src/main/java/com/ppiyaki/medication/MedicationLog.java
@@ -54,8 +54,9 @@ public class MedicationLog extends CreatedTimeEntity {
     @Column(name = "photo_url")
     private String photoObjectKey;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "ai_status")
-    private String aiStatus;
+    private LogAiStatus aiStatus;
 
     @Column(name = "is_proxy", nullable = false)
     private Boolean isProxy;
@@ -95,5 +96,9 @@ public class MedicationLog extends CreatedTimeEntity {
         this.confirmedByUserId = Objects.requireNonNull(confirmedByUserId, "confirmedByUserId must not be null");
         this.takenAt = takenAt;
         this.photoObjectKey = photoObjectKey;
+    }
+
+    public void updateAiStatus(final LogAiStatus aiStatus) {
+        this.aiStatus = aiStatus;
     }
 }

--- a/src/main/java/com/ppiyaki/medication/controller/dto/MedicationLogResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/MedicationLogResponse.java
@@ -1,5 +1,6 @@
 package com.ppiyaki.medication.controller.dto;
 
+import com.ppiyaki.medication.LogAiStatus;
 import com.ppiyaki.medication.LogStatus;
 import com.ppiyaki.medication.MedicationLog;
 import java.time.LocalDate;
@@ -13,7 +14,7 @@ public record MedicationLogResponse(
         LocalDateTime takenAt,
         LogStatus status,
         String photoUrl,
-        String aiStatus,
+        LogAiStatus aiStatus,
         Boolean isProxy,
         Long confirmedByUserId,
         LocalDateTime createdAt

--- a/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
@@ -1,12 +1,32 @@
 package com.ppiyaki.medication.repository;
 
 import com.ppiyaki.medication.MedicationSchedule;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MedicationScheduleRepository extends JpaRepository<MedicationSchedule, Long> {
 
     List<MedicationSchedule> findByMedicineId(final Long medicineId);
 
     int deleteByMedicineId(final Long medicineId);
+
+    /**
+     * 같은 시니어가 같은 시각에 복용 예정인 active schedule 전체.
+     * Phase 2 약 개수 검증의 기대 카운트 산출용 (medication-log-phase2 §5-4).
+     */
+    @Query("""
+            SELECT s FROM MedicationSchedule s
+            WHERE s.medicineId IN (SELECT m.id FROM Medicine m WHERE m.ownerId = :seniorId)
+              AND s.scheduledTime = :time
+              AND (s.startDate IS NULL OR s.startDate <= :date)
+              AND (s.endDate IS NULL OR s.endDate >= :date)
+            """)
+    List<MedicationSchedule> findActiveByOwnerAndScheduledTime(
+            @Param("seniorId") final Long seniorId,
+            @Param("date") final LocalDate date,
+            @Param("time") final LocalTime time);
 }

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -1,8 +1,13 @@
 package com.ppiyaki.medication.service;
 
+import com.ppiyaki.common.ai.OpenAiClient;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.storage.NcpStorageProperties;
 import com.ppiyaki.common.storage.PhotoUrlAssembler;
+import com.ppiyaki.medication.DosageParser;
+import com.ppiyaki.medication.LogAiStatus;
+import com.ppiyaki.medication.LogStatus;
 import com.ppiyaki.medication.MedicationLog;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.controller.dto.MedicationLogListResponse;
@@ -17,12 +22,15 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 
 @Service
 @ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")
@@ -43,19 +51,28 @@ public class MedicationLogService {
     private final MedicineRepository medicineRepository;
     private final CareRelationRepository careRelationRepository;
     private final PhotoUrlAssembler photoUrlAssembler;
+    private final OpenAiClient openAiClient;
+    private final NcpStorageProperties storageProperties;
+    private final S3Client s3Client;
 
     public MedicationLogService(
             final MedicationLogRepository medicationLogRepository,
             final MedicationScheduleRepository medicationScheduleRepository,
             final MedicineRepository medicineRepository,
             final CareRelationRepository careRelationRepository,
-            final PhotoUrlAssembler photoUrlAssembler
+            final PhotoUrlAssembler photoUrlAssembler,
+            final OpenAiClient openAiClient,
+            final NcpStorageProperties storageProperties,
+            final S3Client s3Client
     ) {
         this.medicationLogRepository = medicationLogRepository;
         this.medicationScheduleRepository = medicationScheduleRepository;
         this.medicineRepository = medicineRepository;
         this.careRelationRepository = careRelationRepository;
         this.photoUrlAssembler = photoUrlAssembler;
+        this.openAiClient = openAiClient;
+        this.storageProperties = storageProperties;
+        this.s3Client = s3Client;
     }
 
     @Transactional
@@ -93,7 +110,67 @@ public class MedicationLogService {
                     "Concurrent upsert conflict on (scheduleId, targetDate); please retry");
         }
 
+        // Phase 2: 사진 + status=TAKEN일 때 약 개수 AI 검증 (spec medication-log-phase2 §5-4)
+        if (request.status() == LogStatus.TAKEN
+                && request.photoObjectKey() != null && !request.photoObjectKey().isBlank()) {
+            final LogAiStatus aiStatus = verifyPillCount(seniorId, schedule, request);
+            log.updateAiStatus(aiStatus);
+        }
+
         return MedicationLogResponse.from(log, photoUrlAssembler.toFullUrl(log.getPhotoObjectKey()));
+    }
+
+    /**
+     * 동일 시각 schedule들의 dosage 합 vs Vision 추출 개수 비교.
+     * spec medication-log-phase2 §5-4.
+     */
+    private LogAiStatus verifyPillCount(
+            final Long seniorId,
+            final MedicationSchedule triggerSchedule,
+            final MedicationLogUpsertRequest request
+    ) {
+        final List<MedicationSchedule> schedules = medicationScheduleRepository
+                .findActiveByOwnerAndScheduledTime(
+                        seniorId, request.targetDate(), triggerSchedule.getScheduledTime());
+
+        int expected = 0;
+        for (final MedicationSchedule s : schedules) {
+            final Optional<Integer> parsed = DosageParser.parsePillCount(s.getDosage());
+            if (parsed.isEmpty()) {
+                return LogAiStatus.COUNT_UNKNOWN;
+            }
+            expected += parsed.get();
+        }
+        if (schedules.isEmpty()) {
+            return LogAiStatus.COUNT_UNKNOWN;
+        }
+
+        final byte[] imageBytes;
+        try {
+            imageBytes = s3Client.getObjectAsBytes(GetObjectRequest.builder()
+                    .bucket(storageProperties.bucketName())
+                    .key(request.photoObjectKey())
+                    .build()).asByteArray();
+        } catch (final Exception e) {
+            return LogAiStatus.COUNT_FAILED;
+        }
+        final String mediaType = guessMediaType(request.photoObjectKey());
+        final Optional<Integer> actual = openAiClient.countPills(imageBytes, mediaType);
+        if (actual.isEmpty()) {
+            return LogAiStatus.COUNT_FAILED;
+        }
+        return actual.get() == expected ? LogAiStatus.COUNT_MATCH : LogAiStatus.COUNT_MISMATCH;
+    }
+
+    private String guessMediaType(final String objectKey) {
+        final String lower = objectKey.toLowerCase();
+        if (lower.endsWith(".png")) {
+            return "image/png";
+        }
+        if (lower.endsWith(".webp")) {
+            return "image/webp";
+        }
+        return "image/jpeg";
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/ppiyaki/common/storage/UploadControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/common/storage/UploadControllerE2ETest.java
@@ -29,6 +29,8 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
         "ncp.storage.access-key=test-access-key",
         "ncp.storage.secret-key=test-secret-key",
         "ncp.storage.bucket-name=ppiyaki-test",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
         "spring.main.allow-bean-definition-overriding=true"
 })
 @Import(UploadControllerE2ETest.MockS3PresignerConfig.class)

--- a/src/test/java/com/ppiyaki/medication/DosageParserTest.java
+++ b/src/test/java/com/ppiyaki/medication/DosageParserTest.java
@@ -1,0 +1,52 @@
+package com.ppiyaki.medication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("DosageParser.parsePillCount")
+class DosageParserTest {
+
+    @Test
+    @DisplayName("\"1정\" → Optional.of(1)")
+    void single_pill() {
+        assertThat(DosageParser.parsePillCount("1정")).contains(1);
+    }
+
+    @Test
+    @DisplayName("\"2알\" → Optional.of(2)")
+    void two_pills() {
+        assertThat(DosageParser.parsePillCount("2알")).contains(2);
+    }
+
+    @Test
+    @DisplayName("\"1.5캡슐\" → Optional.of(1) (정수 첫 매치만)")
+    void decimal_truncated_to_first_int() {
+        assertThat(DosageParser.parsePillCount("1.5캡슐")).contains(1);
+    }
+
+    @Test
+    @DisplayName("\"반알\" → Optional.empty()")
+    void korean_no_digit() {
+        assertThat(DosageParser.parsePillCount("반알")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("null → Optional.empty()")
+    void null_input() {
+        assertThat(DosageParser.parsePillCount(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("blank → Optional.empty()")
+    void blank_input() {
+        assertThat(DosageParser.parsePillCount("   ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("\"3정 1일 2회\" → 3 (첫 매치)")
+    void multiple_numbers_uses_first() {
+        assertThat(DosageParser.parsePillCount("3정 1일 2회")).contains(3);
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
@@ -30,7 +30,9 @@ import org.springframework.boot.test.web.server.LocalServerPort;
         "ncp.storage.region=kr-standard",
         "ncp.storage.access-key=test-access-key",
         "ncp.storage.secret-key=test-secret-key",
-        "ncp.storage.bucket-name=ppiyaki-test"
+        "ncp.storage.bucket-name=ppiyaki-test",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test"
 })
 @DisplayName("PUT/GET /api/v1/medication-logs E2E")
 class MedicationLogControllerE2ETest {

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -1,0 +1,240 @@
+package com.ppiyaki.medication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.common.ai.OpenAiClient;
+import com.ppiyaki.common.storage.NcpStorageProperties;
+import com.ppiyaki.common.storage.PhotoUrlAssembler;
+import com.ppiyaki.medication.LogAiStatus;
+import com.ppiyaki.medication.LogStatus;
+import com.ppiyaki.medication.MedicationLog;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.controller.dto.MedicationLogUpsertRequest;
+import com.ppiyaki.medication.repository.MedicationLogRepository;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MedicationLogService Phase 2 약 개수 AI 검증")
+class MedicationLogServicePhase2Test {
+
+    @Mock
+    private MedicationLogRepository medicationLogRepository;
+    @Mock
+    private MedicationScheduleRepository medicationScheduleRepository;
+    @Mock
+    private MedicineRepository medicineRepository;
+    @Mock
+    private CareRelationRepository careRelationRepository;
+    @Mock
+    private PhotoUrlAssembler photoUrlAssembler;
+    @Mock
+    private OpenAiClient openAiClient;
+    @Mock
+    private NcpStorageProperties storageProperties;
+    @Mock
+    private S3Client s3Client;
+
+    @InjectMocks
+    private MedicationLogService service;
+
+    private static final Long SENIOR_ID = 100L;
+    private static final Long SCHEDULE_ID = 1L;
+    private static final Long MEDICINE_ID = 10L;
+    private static final LocalDate TARGET_DATE = LocalDate.of(2026, 4, 30);
+    private static final LocalTime SCHEDULED_TIME = LocalTime.of(8, 0);
+    private static final String VALID_OBJECT_KEY = "medication-log/100/9b3e7a1c-8d55-4f0a-b2e1-5f9a7b3d8c21.jpg";
+
+    @Test
+    @DisplayName("status=MISSED면 AI 검증 스킵, ai_status=null")
+    void status_missed_skip_verification() throws Exception {
+        givenScheduleAndMedicine();
+        givenUpsertSucceeds();
+        final MedicationLogUpsertRequest req = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.MISSED, VALID_OBJECT_KEY);
+
+        service.upsert(SENIOR_ID, req);
+
+        verify(openAiClient, never()).countPills(any(), any());
+    }
+
+    @Test
+    @DisplayName("photoObjectKey=null이면 AI 검증 스킵")
+    void no_photo_skip_verification() throws Exception {
+        givenScheduleAndMedicine();
+        givenUpsertSucceeds();
+        final MedicationLogUpsertRequest req = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        service.upsert(SENIOR_ID, req);
+
+        verify(openAiClient, never()).countPills(any(), any());
+    }
+
+    @Test
+    @DisplayName("단일 schedule(1정) + Vision=1 → COUNT_MATCH")
+    void count_match_single_schedule() throws Exception {
+        givenScheduleAndMedicine();
+        givenUpsertSucceeds();
+        givenSiblingSchedules(List.of(buildSchedule(SCHEDULE_ID, "1정")));
+        givenS3Returns(new byte[]{1, 2, 3});
+        when(openAiClient.countPills(any(), eq("image/jpeg"))).thenReturn(Optional.of(1));
+
+        final var saved = captureSavedLog();
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        assertThat(saved.get().getAiStatus()).isEqualTo(LogAiStatus.COUNT_MATCH);
+    }
+
+    @Test
+    @DisplayName("두 schedule(1정+1정) + Vision=1 → COUNT_MISMATCH")
+    void count_mismatch_two_schedules() throws Exception {
+        givenScheduleAndMedicine();
+        givenUpsertSucceeds();
+        givenSiblingSchedules(List.of(buildSchedule(SCHEDULE_ID, "1정"), buildSchedule(2L, "1정")));
+        givenS3Returns(new byte[]{1, 2, 3});
+        when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(1));
+
+        final var saved = captureSavedLog();
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        assertThat(saved.get().getAiStatus()).isEqualTo(LogAiStatus.COUNT_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("dosage=\"반알\" 포함 → COUNT_UNKNOWN, Vision 호출 안 됨")
+    void unparsable_dosage_unknown() throws Exception {
+        givenScheduleAndMedicine();
+        givenUpsertSucceeds();
+        givenSiblingSchedules(List.of(buildSchedule(SCHEDULE_ID, "1정"), buildSchedule(2L, "반알")));
+
+        final var saved = captureSavedLog();
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        assertThat(saved.get().getAiStatus()).isEqualTo(LogAiStatus.COUNT_UNKNOWN);
+        verify(openAiClient, never()).countPills(any(), any());
+    }
+
+    @Test
+    @DisplayName("Vision Optional.empty() → COUNT_FAILED")
+    void vision_empty_failed() throws Exception {
+        givenScheduleAndMedicine();
+        givenUpsertSucceeds();
+        givenSiblingSchedules(List.of(buildSchedule(SCHEDULE_ID, "1정")));
+        givenS3Returns(new byte[]{1});
+        when(openAiClient.countPills(any(), any())).thenReturn(Optional.empty());
+
+        final var saved = captureSavedLog();
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        assertThat(saved.get().getAiStatus()).isEqualTo(LogAiStatus.COUNT_FAILED);
+    }
+
+    @Test
+    @DisplayName("png objectKey면 mediaType=image/png 전달")
+    void png_media_type() throws Exception {
+        givenScheduleAndMedicine();
+        givenUpsertSucceeds();
+        givenSiblingSchedules(List.of(buildSchedule(SCHEDULE_ID, "1정")));
+        givenS3Returns(new byte[]{1});
+        when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(1));
+
+        final String pngKey = "medication-log/100/9b3e7a1c-8d55-4f0a-b2e1-5f9a7b3d8c21.png";
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, pngKey));
+
+        verify(openAiClient).countPills(any(), eq("image/png"));
+    }
+
+    // --- fixtures -----------------------------------------------------------
+
+    private void givenScheduleAndMedicine() throws Exception {
+        final MedicationSchedule schedule = buildSchedule(SCHEDULE_ID, "1정");
+        when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(schedule));
+        final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", 30, 30, "ITEM-1", null);
+        setField(medicine, "id", MEDICINE_ID);
+        when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(medicine));
+    }
+
+    private void givenSiblingSchedules(final List<MedicationSchedule> schedules) {
+        when(medicationScheduleRepository.findActiveByOwnerAndScheduledTime(
+                eq(SENIOR_ID), eq(TARGET_DATE), eq(SCHEDULED_TIME))).thenReturn(schedules);
+    }
+
+    private void givenUpsertSucceeds() {
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn("https://example.com/" + VALID_OBJECT_KEY);
+    }
+
+    private void givenS3Returns(final byte[] bytes) {
+        when(storageProperties.bucketName()).thenReturn("ppiyaki-test");
+        final ResponseBytes<GetObjectResponse> resp = ResponseBytes.fromByteArray(
+                GetObjectResponse.builder().build(), bytes);
+        when(s3Client.getObjectAsBytes(any(GetObjectRequest.class))).thenReturn(resp);
+    }
+
+    private java.util.function.Supplier<MedicationLog> captureSavedLog() {
+        final ArgumentCaptor<MedicationLog> captor = ArgumentCaptor.forClass(MedicationLog.class);
+        return () -> {
+            verify(medicationLogRepository).saveAndFlush(captor.capture());
+            return captor.getValue();
+        };
+    }
+
+    private MedicationSchedule buildSchedule(final Long id, final String dosage) throws Exception {
+        final java.lang.reflect.Constructor<MedicationSchedule> ctor = MedicationSchedule.class
+                .getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final MedicationSchedule s = ctor.newInstance();
+        setField(s, "id", id);
+        setField(s, "medicineId", MEDICINE_ID);
+        setField(s, "dosage", dosage);
+        setField(s, "scheduledTime", SCHEDULED_TIME);
+        return s;
+    }
+
+    private static void setField(final Object target, final String fieldName, final Object value) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}


### PR DESCRIPTION
## AS-IS
- Phase 1 (PR #200) 머지로 인증 사진 첨부는 가능하지만 검증 미구현.
- spec PR #202가 Phase 2 설계 정리하고 머지됨.

## TO-BE
- 동기 처리로 PUT 응답에 검증 결과(`ai_status`) 즉시 포함.
- gpt-5.4-nano Vision API로 사진 속 알약 개수 추출 → 동일 시각 schedule들의 dosage 합산과 비교.
- 결과 enum: `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED`.

## 관련 이슈
- closes #184
- 의존: spec PR #202 머지 완료, Phase 1 PR #200 머지 완료

## 리뷰어 참고 포인트

### 동기 처리 결정
- 실측 기반 응답시간 ~3-6s. 시니어가 응답 받기 전 화면 안 넘어가므로 부수적 차단 효과까지 확보.
- 비동기 전환은 운영 트래픽 데이터 보고 후속 결정 (spec §4 비범위).

### 트리거 조건
```
status == TAKEN && photoObjectKey != null && !photoObjectKey.isBlank()
```
이외엔 `ai_status=null` 유지.

### 동일 시각 schedule 합산
- `MedicationScheduleRepository.findActiveByOwnerAndScheduledTime` cross-table JPQL: `Medicine.ownerId == seniorId` AND `scheduledTime` 일치 AND `startDate/endDate` 활성.
- 합산 시 dosage 파싱 실패가 1개라도 있으면 `COUNT_UNKNOWN` (Vision 호출 안 함, 비용 절약).

### dosage 파싱
- 정규식 `(\d+)` 첫 매치만. "1정"→1, "1.5캡슐"→1, "반알"→empty.
- `DosageParserTest` 7건으로 케이스별 검증.

### Vision API 안전장치
- timeout: connect 5s / read 10s (기존 OpenAiClient 설정).
- retry 1회.
- JSON Mode `{"count": N}` 강제, 음수·파싱 실패 시 `Optional.empty`.
- `COUNT_FAILED`는 시스템 알림용이지 사용자 노출 메시지로는 부적절 — 클라이언트가 별도 UX 매핑 필요.

### `MedicationLog.ai_status` 타입 마이그레이션
- DB 컬럼 변경 없음 (`varchar` 유지, ADR 0006 원칙).
- Java 측만 `String` → `LogAiStatus` enum + `@Enumerated(EnumType.STRING)`.
- 기존 row의 `ai_status`가 `null`이라 호환성 영향 없음.

## 하네스 정합성 체크리스트 (push 직전 자체 점검)
- Step 1 엔티티 변경: ✅ `LogAiStatus` enum 신설 → 06-domain-model §4 유비쿼터스 랭귀지에 등재. `medication_logs.ai_status` 컬럼 매핑은 Phase 1 §5에서 이미 명시됨.
- Step 2 API 변경: N/A (응답 필드 의미만 채워짐, 스키마 변경 없음).
- Step 3 새 ErrorCode: N/A.
- Step 4 인덱스: N/A.
- Step 5 Spec 1:1: ✅ `medication-log-phase2.md` §3 모든 항목 구현.
- Step 6 라벨: type:feat / scope:medication / ai-generated. needs-human-review N/A.

## 라벨 부여 확인
- [x] `type:feat`
- [x] `scope:medication`
- [x] `ai-generated`
- [x] `needs-human-review` — 해당 없음 (DB 마이그레이션 없음)

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` (147 통과, 신규 14건 추가)
- [x] 회귀 가능 구간: ai_status 타입 변경 — 기존 null 데이터라 영향 없음. 다른 컨트롤러 영향 없음.
- [x] 롤백: revert + (운영 적용 시) ai_status 컬럼 NULL 유지

## DDD/OOP 준수 체크
- [x] 도메인 용어 일치 (LogAiStatus, DosageParser)
- [x] 계층 침범 없음 (Service에서 외부 OpenAI 호출, Domain에 비즈니스 로직 분리)
- [x] God Object 없음 — DosageParser 분리

## 보안/민감정보 체크
- [x] 시크릿 하드코딩 없음
- [x] 의료정보 로깅 안 함 (사진 size/mediaType만 로깅, dosage·objectKey 미로깅)
- [x] 마스킹 — 해당 없음

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: medication-log-phase2.md spec 합의 후 구현
- AI가 직접 수정한 파일: LogAiStatus/DosageParser/MedicationLog/Service/Repository/OpenAiClient/DTO + 테스트 3개
- 사람이 수동 검증한 항목: gpt-5.4-nano 모델 채택, 동기 결정, 트리거 조건, dosage 파싱 정책
- 잔여 리스크: 실제 폰 카메라 사진 정확도 미검증 (운영 데이터로 측정 필요). UploadControllerE2ETest에 openai props 추가는 트랜지티브 의존성 노출이라 향후 정리 권장

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- **AI 기반 약 알약 수 검증**: 복용 기록 사진 업로드 시 AI가 약의 개수를 자동으로 인식하여 예상 복용량과 비교합니다. 결과는 일치/불일치/미확인/검증 실패로 기록됩니다.

## 문서
- AI 검증 상태에 대한 도메인 모델 문서 확장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->