### PR TITLE
docs(chat): 텍스트 메시지 응답 SSE 전환 반영 + 단발 채팅 명세 정정

### DIFF
--- a/docs/features/chat-session.md
+++ b/docs/features/chat-session.md
@@ -77,8 +77,8 @@ last_reviewed: 2026-04-10
 
 | Method | Path | 설명 | 인증 | Req | Res |
 |---|---|---|---|---|---|
-| POST | /api/v1/chat/sessions | 세션 생성 | 없음 | 없음 | `ChatSessionResponse` |
-| POST | /api/v1/chat/sessions/{sessionId}/messages | 메시지 전송 | 없음 | `ChatMessageRequest` | `ChatMessageResponse` |
+| POST | /api/v1/chat/sessions | 세션 생성 | 필수 | 없음 | `ChatSessionResponse` (JSON, 201) |
+| POST | /api/v1/chat/sessions/{sessionId}/messages | 메시지 전송 | 필수 | `ChatMessageRequest` | SSE 스트림 (`text/event-stream`, 토큰 chunk + `[DONE]`). 형식은 `chat-streaming.md §5-1` |
 
 **ChatSessionResponse**
 ```json

--- a/docs/features/voice-chat.md
+++ b/docs/features/voice-chat.md
@@ -50,8 +50,8 @@ last_reviewed: 2026-04-14
 
 | Method | Path | 설명 | 인증 | Req | Res |
 |---|---|---|---|---|---|
-| POST | /api/v1/chat/sessions/{sessionId}/messages | 텍스트 대화 (기존) | 필수 | `ChatMessageRequest` (JSON) | `ChatMessageResponse` (JSON) |
-| POST | /api/v1/chat/sessions/{sessionId}/voice-messages | 음성 대화 (신규) | 필수 | `MultipartFile` (form-data) | SSE 스트림 (text/event-stream, base64 audio 청크) |
+| POST | /api/v1/chat/sessions/{sessionId}/messages | 텍스트 대화 | 필수 | `ChatMessageRequest` (JSON) | SSE 스트림 (`text/event-stream`, 토큰 chunk + `[DONE]`. `chat-streaming.md §5-1`로 전환됨) |
+| POST | /api/v1/chat/sessions/{sessionId}/voice-messages | 음성 대화 | 필수 | `MultipartFile` (form-data, file + language) | SSE 스트림 (`text/event-stream`, `{text, audio: base64 mp3}` chunk + `[DONE]`. `chat-streaming.md §5-2`) |
 
 ### 5-2) 데이터 흐름
 


### PR DESCRIPTION
## AS-IS
사용자가 채팅 명세 정합성 점검 요청 — 코드와 노션 명세, feature spec 사이 불일치 발견.

### 발견 1: feature spec stale (chat-streaming.md 머지 이후 미반영)
- `ChatSessionController.sendMessage`는 `SseEmitter` 반환 (코드)
- 그런데 `chat-session.md` §5-2 / `voice-chat.md` §5-1 API 표는 `ChatMessageResponse` (JSON)으로 표기 → stale.
- chat-streaming.md(#110)로 SSE 전환된 이후 표 정정 누락.

### 발견 2: Notion 단발 채팅 spec 모호
- `POST /api/v1/chat/quick` (텍스트), `POST /api/v1/chat/quick/voice` (음성) 미구현 placeholder
- URI에 형용사 "quick" 사용 — 도메인 용어 아니고 RESTful 부적절
- Details에 "SSE 스트리밍" 명시인데 Response Body 예시는 단일 JSON — 모순
- 음성 단발에 Request Body 정의 누락 (multipart 추정)

## TO-BE

### 본 PR (코드 정합성 — feature spec)
- `chat-session.md` §5-2: 메시지 전송 응답 → "SSE 스트림 (chat-streaming.md §5-1)" 정정
- `voice-chat.md` §5-1: 텍스트 대화 응답 동일 정정
- 인증 컬럼 "없음" → "필수" (JWT 필수)

### Notion API 명세 DB (별도 작업, 본 PR scope 외)
- 단발 텍스트 URI: `/api/v1/chat/quick` → `/api/v1/chat/messages`
- 단발 음성 URI: `/api/v1/chat/quick/voice` → `/api/v1/chat/voice-messages`
- 두 페이지 본문에 "📝 정정 (2026-04-30)" 섹션 추가 — SSE 응답 예시, multipart Request, 에러 응답 표

미구현 placeholder는 spec 파일에 추가하지 않고 Notion DB에서 관리.

## 관련
- 코드: `ChatSessionController.java:45,53` (SseEmitter 반환)
- 정합성 기준: `chat-streaming.md` §5-1 (텍스트 SSE), §5-2 (음성 SSE)
- 미구현 이슈: #120 단발 채팅 API 추가

## 라벨 부여 확인
- [x] `type:docs`
- [x] `scope:chat`
- [x] `ai-generated`
- [x] `needs-human-review` — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 회귀 가능: 없음 (docs only)
- [x] 롤백: revert 1 커밋

## 보안/민감정보 체크
- [x] 시크릿/의료정보 노출 없음

## AI 작업 기록
- 사용한 프롬프트/지시 요약: chat API 명세 정합성 점검 + 정정
- AI 직접 수정: chat-session.md L80-81, voice-chat.md L53-54
- 사람 검증: 단발 URI 명명 결정 (/chat/quick → /chat/messages)

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 채팅 기능에 인증 필수 요구사항 추가
  * 메시지 전송 응답을 스트리밍 형식으로 업데이트
  * 음성 채팅 API 요청/응답 형식 명확화
  * SSE(Server-Sent Events) 스트리밍 응답 문서화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->