### PR TITLE
feat(pet): 복약 성공 이벤트 → 펫 포인트 증가 연동 (#206)  

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew test:*)",
+      "Bash(./gradlew checkstyleMain spotlessCheck)"
+    ]
+  }
+}

--- a/docs/features/medication-log-phase2.md
+++ b/docs/features/medication-log-phase2.md
@@ -82,14 +82,14 @@ public enum LogAiStatus {
 ### 5-2) API 엔드포인트 변경
 **없음**. 기존 `PUT /api/v1/medication-logs` / `GET /api/v1/medication-logs` 응답에 `aiStatus`가 enum 값으로 채워질 뿐.
 
-### 5-3) 외부 연동 — OpenAI GPT-4o Vision
+### 5-3) 외부 연동 — OpenAI gpt-5.4-nano Vision
 
 - 엔드포인트: `https://api.openai.com/v1/chat/completions` (이미 사용 중)
 - 모델: **`gpt-5.4-nano`** — 프로젝트 표준 (prescription-ocr와 동일, `OpenAiProperties.model`로 주입). vision 입력 지원.
 - 입력: `messages` 배열에 image_url(base64 data URL) + system prompt
 - 출력: JSON Mode로 `{"count": <integer>}` 강제. 파싱 실패 시 retry 1회.
 - System prompt 초안:
-  ```
+  ```text
   Count the visible pills in the photo. Return JSON {"count": N} where N is a non-negative integer.
   If unsure or no pills visible, return {"count": 0}.
   ```
@@ -158,6 +158,7 @@ public enum LogAiStatus {
 - Vision 실패: mock throws → ai_status=COUNT_FAILED
 
 ## 8) 오픈 질문
+
 | # | 질문 | 선택지 | 담당/기한 |
 |---|---|---|---|
 | Q1 | 동일 시각 정렬 허용 오차 | 동일 `scheduledTime` 정확 일치만 합산. 인접 시각 합산은 후속 | ✅ 결정 |

--- a/docs/features/pet-gamification.md
+++ b/docs/features/pet-gamification.md
@@ -71,7 +71,7 @@ last_reviewed: 2026-05-02
 시니어 회원가입 → Pet(point=0) 생성 → User.pet에 Pet.id 저장
 
 **포인트 증가:**
-복약 기록 TAKEN 확정 → Spring ApplicationEvent 발행 → PetEventListener가 수신 → Pet.addPoint() → 저장
+복약 기록 TAKEN 확정 → Spring ApplicationEvent 발행 → PetPointListener가 수신 → Pet.addPoint() → 저장
 
 ### 5-5) DB 마이그레이션
 - 기존 `pets` 테이블 그대로 사용 (변경 없음)

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -36,6 +36,9 @@ public enum ErrorCode {
     CARE_MODE_RESTRICTED(HttpStatus.FORBIDDEN, "CARE_004",
             "Senior cannot mutate prescription before caregiver review window"),
 
+    // Pet
+    PET_NOT_FOUND(HttpStatus.NOT_FOUND, "PET_001", "Pet not found"),
+
     // Chat
     CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_001", "Chat session not found"),
     CHAT_SESSION_EXPIRED(HttpStatus.GONE, "CHAT_002", "Chat session expired"),

--- a/src/main/java/com/ppiyaki/medication/event/MedicationTakenEvent.java
+++ b/src/main/java/com/ppiyaki/medication/event/MedicationTakenEvent.java
@@ -1,0 +1,12 @@
+package com.ppiyaki.medication.event;
+
+import java.util.Objects;
+
+public record MedicationTakenEvent(
+        Long seniorId
+) {
+
+    public MedicationTakenEvent {
+        Objects.requireNonNull(seniorId, "seniorId must not be null");
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -81,9 +81,12 @@ public class MedicationLogService {
         final LocalDateTime takenAt = request.takenAt() != null ? request.takenAt() : LocalDateTime.now();
 
         final MedicationLog log;
+        final boolean wasAlreadyTaken;
         try {
-            log = medicationLogRepository
-                    .findByScheduleIdAndTargetDate(request.scheduleId(), request.targetDate())
+            final var existingOpt = medicationLogRepository
+                    .findByScheduleIdAndTargetDate(request.scheduleId(), request.targetDate());
+            wasAlreadyTaken = existingOpt.map(e -> e.getStatus() == LogStatus.TAKEN).orElse(false);
+            log = existingOpt
                     .map(existing -> {
                         existing.updateRecord(takenAt, request.status(), request.photoObjectKey(), isProxy, userId);
                         return existing;
@@ -99,7 +102,7 @@ public class MedicationLogService {
                     "Concurrent upsert conflict on (scheduleId, targetDate); please retry");
         }
 
-        if (log.getStatus() == LogStatus.TAKEN) {
+        if (!wasAlreadyTaken && log.getStatus() == LogStatus.TAKEN) {
             eventPublisher.publishEvent(new MedicationTakenEvent(seniorId));
         }
 

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -3,11 +3,13 @@ package com.ppiyaki.medication.service;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.common.storage.PhotoUrlAssembler;
+import com.ppiyaki.medication.LogStatus;
 import com.ppiyaki.medication.MedicationLog;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.controller.dto.MedicationLogListResponse;
 import com.ppiyaki.medication.controller.dto.MedicationLogResponse;
 import com.ppiyaki.medication.controller.dto.MedicationLogUpsertRequest;
+import com.ppiyaki.medication.event.MedicationTakenEvent;
 import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
@@ -20,6 +22,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,19 +46,22 @@ public class MedicationLogService {
     private final MedicineRepository medicineRepository;
     private final CareRelationRepository careRelationRepository;
     private final PhotoUrlAssembler photoUrlAssembler;
+    private final ApplicationEventPublisher eventPublisher;
 
     public MedicationLogService(
             final MedicationLogRepository medicationLogRepository,
             final MedicationScheduleRepository medicationScheduleRepository,
             final MedicineRepository medicineRepository,
             final CareRelationRepository careRelationRepository,
-            final PhotoUrlAssembler photoUrlAssembler
+            final PhotoUrlAssembler photoUrlAssembler,
+            final ApplicationEventPublisher eventPublisher
     ) {
         this.medicationLogRepository = medicationLogRepository;
         this.medicationScheduleRepository = medicationScheduleRepository;
         this.medicineRepository = medicineRepository;
         this.careRelationRepository = careRelationRepository;
         this.photoUrlAssembler = photoUrlAssembler;
+        this.eventPublisher = eventPublisher;
     }
 
     @Transactional
@@ -91,6 +97,10 @@ public class MedicationLogService {
             // 클라이언트가 재시도하면 다음 트랜잭션에서 정상 update 경로로 진입한다 (spec §5-2 멱등 보장).
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
                     "Concurrent upsert conflict on (scheduleId, targetDate); please retry");
+        }
+
+        if (log.getStatus() == LogStatus.TAKEN) {
+            eventPublisher.publishEvent(new MedicationTakenEvent(seniorId));
         }
 
         return MedicationLogResponse.from(log, photoUrlAssembler.toFullUrl(log.getPhotoObjectKey()));

--- a/src/main/java/com/ppiyaki/pet/Pet.java
+++ b/src/main/java/com/ppiyaki/pet/Pet.java
@@ -7,12 +7,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
+@Entity
 @Table(name = "pets")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Pet extends BaseTimeEntity {
@@ -25,6 +26,22 @@ public class Pet extends BaseTimeEntity {
     private Long point;
 
     public Pet(final Long point) {
+        Objects.requireNonNull(point, "point must not be null");
         this.point = point;
+    }
+
+    public static Pet create() {
+        return new Pet(0L);
+    }
+
+    public void addPoint(final long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+        this.point += amount;
+    }
+
+    public int getLevel() {
+        return (int) Math.floor(Math.sqrt(this.point / 10.0));
     }
 }

--- a/src/main/java/com/ppiyaki/pet/Pet.java
+++ b/src/main/java/com/ppiyaki/pet/Pet.java
@@ -7,7 +7,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,11 +21,10 @@ public class Pet extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "point")
-    private Long point;
+    @Column(name = "point", nullable = false)
+    private long point;
 
-    public Pet(final Long point) {
-        Objects.requireNonNull(point, "point must not be null");
+    Pet(final long point) {
         this.point = point;
     }
 

--- a/src/main/java/com/ppiyaki/pet/controller/PetController.java
+++ b/src/main/java/com/ppiyaki/pet/controller/PetController.java
@@ -1,0 +1,26 @@
+package com.ppiyaki.pet.controller;
+
+import com.ppiyaki.pet.controller.dto.PetResponse;
+import com.ppiyaki.pet.service.PetService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/pets")
+public class PetController {
+
+    private final PetService petService;
+
+    public PetController(final PetService petService) {
+        this.petService = petService;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<PetResponse> readMyPet(@AuthenticationPrincipal final Long userId) {
+        final PetResponse petResponse = petService.readMyPet(userId);
+        return ResponseEntity.ok(petResponse);
+    }
+}

--- a/src/main/java/com/ppiyaki/pet/controller/dto/PetResponse.java
+++ b/src/main/java/com/ppiyaki/pet/controller/dto/PetResponse.java
@@ -4,7 +4,7 @@ import com.ppiyaki.pet.Pet;
 
 public record PetResponse(
         Long id,
-        Long point,
+        long point,
         int level
 ) {
 

--- a/src/main/java/com/ppiyaki/pet/controller/dto/PetResponse.java
+++ b/src/main/java/com/ppiyaki/pet/controller/dto/PetResponse.java
@@ -1,0 +1,14 @@
+package com.ppiyaki.pet.controller.dto;
+
+import com.ppiyaki.pet.Pet;
+
+public record PetResponse(
+        Long id,
+        Long point,
+        int level
+) {
+
+    public static PetResponse from(final Pet pet) {
+        return new PetResponse(pet.getId(), pet.getPoint(), pet.getLevel());
+    }
+}

--- a/src/main/java/com/ppiyaki/pet/repository/PetRepository.java
+++ b/src/main/java/com/ppiyaki/pet/repository/PetRepository.java
@@ -1,0 +1,7 @@
+package com.ppiyaki.pet.repository;
+
+import com.ppiyaki.pet.Pet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetRepository extends JpaRepository<Pet, Long> {
+}

--- a/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
+++ b/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
@@ -7,29 +7,34 @@ import com.ppiyaki.user.User;
 import com.ppiyaki.user.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.event.EventListener;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 public class PetPointListener {
 
-    private static final long POINT_PER_TAKEN = 10L;
     private static final Logger log = LoggerFactory.getLogger(PetPointListener.class);
 
     private final UserRepository userRepository;
     private final PetRepository petRepository;
+    private final long pointPerTaken;
 
     public PetPointListener(
             final UserRepository userRepository,
-            final PetRepository petRepository
+            final PetRepository petRepository,
+            @Value("${pet.points.per-taken:10}") final long pointPerTaken
     ) {
         this.userRepository = userRepository;
         this.petRepository = petRepository;
+        this.pointPerTaken = pointPerTaken;
     }
 
-    @EventListener
-    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMedicationTaken(final MedicationTakenEvent event) {
         final User user = userRepository.findById(event.seniorId()).orElse(null);
         if (user == null || user.getPet() == null) {
@@ -43,6 +48,6 @@ public class PetPointListener {
             return;
         }
 
-        pet.addPoint(POINT_PER_TAKEN);
+        pet.addPoint(pointPerTaken);
     }
 }

--- a/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
+++ b/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
@@ -1,0 +1,48 @@
+package com.ppiyaki.pet.service;
+
+import com.ppiyaki.medication.event.MedicationTakenEvent;
+import com.ppiyaki.pet.Pet;
+import com.ppiyaki.pet.repository.PetRepository;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class PetPointListener {
+
+    private static final long POINT_PER_TAKEN = 10L;
+    private static final Logger log = LoggerFactory.getLogger(PetPointListener.class);
+
+    private final UserRepository userRepository;
+    private final PetRepository petRepository;
+
+    public PetPointListener(
+            final UserRepository userRepository,
+            final PetRepository petRepository
+    ) {
+        this.userRepository = userRepository;
+        this.petRepository = petRepository;
+    }
+
+    @EventListener
+    @Transactional
+    public void onMedicationTaken(final MedicationTakenEvent event) {
+        final User user = userRepository.findById(event.seniorId()).orElse(null);
+        if (user == null || user.getPet() == null) {
+            log.debug("Pet not linked for seniorId={}, skipping point", event.seniorId());
+            return;
+        }
+
+        final Pet pet = petRepository.findById(user.getPet()).orElse(null);
+        if (pet == null) {
+            log.debug("Pet entity not found for petId={}, skipping point", user.getPet());
+            return;
+        }
+
+        pet.addPoint(POINT_PER_TAKEN);
+    }
+}

--- a/src/main/java/com/ppiyaki/pet/service/PetService.java
+++ b/src/main/java/com/ppiyaki/pet/service/PetService.java
@@ -1,0 +1,41 @@
+package com.ppiyaki.pet.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.pet.Pet;
+import com.ppiyaki.pet.controller.dto.PetResponse;
+import com.ppiyaki.pet.repository.PetRepository;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PetService {
+
+    private final PetRepository petRepository;
+    private final UserRepository userRepository;
+
+    public PetService(
+            final PetRepository petRepository,
+            final UserRepository userRepository
+    ) {
+        this.petRepository = petRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public PetResponse readMyPet(final Long userId) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getPet() == null) {
+            throw new BusinessException(ErrorCode.PET_NOT_FOUND);
+        }
+
+        final Pet pet = petRepository.findById(user.getPet())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PET_NOT_FOUND));
+
+        return PetResponse.from(pet);
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -14,6 +14,7 @@ import com.ppiyaki.medication.LogStatus;
 import com.ppiyaki.medication.MedicationLog;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.controller.dto.MedicationLogUpsertRequest;
+import com.ppiyaki.medication.event.MedicationTakenEvent;
 import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
@@ -32,6 +33,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MedicationLogService")
@@ -48,7 +50,7 @@ class MedicationLogServiceTest {
     @Mock
     private PhotoUrlAssembler photoUrlAssembler;
     @Mock
-    private org.springframework.context.ApplicationEventPublisher eventPublisher;
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private MedicationLogService medicationLogService;
@@ -84,6 +86,7 @@ class MedicationLogServiceTest {
         assertThat(saved.getConfirmedByUserId()).isEqualTo(SENIOR_ID);
         assertThat(saved.getStatus()).isEqualTo(LogStatus.TAKEN);
         assertThat(saved.getSeniorId()).isEqualTo(SENIOR_ID);
+        verify(eventPublisher).publishEvent(any(MedicationTakenEvent.class));
     }
 
     @Test
@@ -111,6 +114,7 @@ class MedicationLogServiceTest {
         final MedicationLog saved = captor.getValue();
         assertThat(saved.getIsProxy()).isTrue();
         assertThat(saved.getConfirmedByUserId()).isEqualTo(CAREGIVER_ID);
+        verify(eventPublisher).publishEvent(any(MedicationTakenEvent.class));
     }
 
     @Test
@@ -155,6 +159,29 @@ class MedicationLogServiceTest {
         verify(medicationLogRepository, never()).saveAndFlush(any()); // update via dirty checking
         assertThat(existing.getStatus()).isEqualTo(LogStatus.MISSED);
         assertThat(existing.getTakenAt()).isEqualTo(LocalDateTime.of(2026, 4, 18, 10, 0));
+        verify(eventPublisher, never()).publishEvent(any(MedicationTakenEvent.class));
+    }
+
+    @Test
+    @DisplayName("TAKEN→TAKEN 재업서트 시 이벤트를 중복 발행하지 않는다")
+    void TAKEN_to_TAKEN_이벤트_미발행() throws Exception {
+        // given
+        givenScheduleAndMedicine();
+        final MedicationLog existing = new MedicationLog(
+                SENIOR_ID, SCHEDULE_ID, TARGET_DATE, LocalDateTime.of(2026, 4, 18, 9, 0),
+                LogStatus.TAKEN, null, false, SENIOR_ID);
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.of(existing));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, LocalDateTime.of(2026, 4, 18, 10, 0), LogStatus.TAKEN, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then
+        verify(eventPublisher, never()).publishEvent(any(MedicationTakenEvent.class));
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -47,6 +47,8 @@ class MedicationLogServiceTest {
     private CareRelationRepository careRelationRepository;
     @Mock
     private PhotoUrlAssembler photoUrlAssembler;
+    @Mock
+    private org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private MedicationLogService medicationLogService;

--- a/src/test/java/com/ppiyaki/pet/PetTest.java
+++ b/src/test/java/com/ppiyaki/pet/PetTest.java
@@ -22,7 +22,7 @@ class PetTest {
     @Test
     @DisplayName("생성자 point값을 보존한다")
     void constructor_preservesPoint() {
-        // given & when
+        // given & when — 같은 패키지이므로 package-private 생성자 접근 가능
         final Pet pet = new Pet(100L);
 
         // then

--- a/src/test/java/com/ppiyaki/pet/PetTest.java
+++ b/src/test/java/com/ppiyaki/pet/PetTest.java
@@ -1,22 +1,69 @@
 package com.ppiyaki.pet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class PetTest {
 
     @Test
-    void 생성자_point값을_보존한다() {
-        Pet pet = new Pet(100L);
+    @DisplayName("create()으로 생성하면 point=0, level=0이다")
+    void create_initialState() {
+        // given & when
+        final Pet pet = Pet.create();
 
+        // then
+        assertThat(pet.getPoint()).isEqualTo(0L);
+        assertThat(pet.getLevel()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("생성자 point값을 보존한다")
+    void constructor_preservesPoint() {
+        // given & when
+        final Pet pet = new Pet(100L);
+
+        // then
         assertThat(pet.getPoint()).isEqualTo(100L);
     }
 
     @Test
-    void 생성자_point가_0이어도_허용한다() {
-        Pet pet = new Pet(0L);
+    @DisplayName("addPoint로 포인트가 증가한다")
+    void addPoint_increasesPoint() {
+        // given
+        final Pet pet = Pet.create();
 
-        assertThat(pet.getPoint()).isEqualTo(0L);
+        // when
+        pet.addPoint(10L);
+
+        // then
+        assertThat(pet.getPoint()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("addPoint에 0 이하를 넣으면 예외가 발생한다")
+    void addPoint_zeroOrNegative_throwsException() {
+        // given
+        final Pet pet = Pet.create();
+
+        // when & then
+        assertThatThrownBy(() -> pet.addPoint(0L))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> pet.addPoint(-5L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("레벨은 floor(sqrt(point / 10))으로 계산된다")
+    void getLevel_calculatesCorrectly() {
+        // given & when & then
+        assertThat(new Pet(0L).getLevel()).isEqualTo(0);   // sqrt(0) = 0
+        assertThat(new Pet(10L).getLevel()).isEqualTo(1);  // sqrt(1) = 1
+        assertThat(new Pet(40L).getLevel()).isEqualTo(2);  // sqrt(4) = 2
+        assertThat(new Pet(90L).getLevel()).isEqualTo(3);  // sqrt(9) = 3
+        assertThat(new Pet(30L).getLevel()).isEqualTo(1);  // sqrt(3) = 1.73 → 1
+        assertThat(new Pet(160L).getLevel()).isEqualTo(4); // sqrt(16) = 4
     }
 }

--- a/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
@@ -24,11 +24,11 @@ class PetControllerE2ETest {
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
-        jdbcTemplate.update("UPDATE users SET pet = NULL WHERE login_id = 'pet_e2e_user'");
-        jdbcTemplate.update("DELETE FROM pets WHERE id IN "
-                + "(SELECT pet FROM users WHERE login_id = 'pet_e2e_user')");
+        // pets 삭제 전에 user.pet FK를 먼저 확보하고 삭제
         jdbcTemplate.update("DELETE FROM refresh_tokens WHERE user_id IN "
                 + "(SELECT id FROM users WHERE login_id = 'pet_e2e_user')");
+        jdbcTemplate.update("DELETE FROM pets WHERE id IN "
+                + "(SELECT pet FROM users WHERE login_id = 'pet_e2e_user' AND pet IS NOT NULL)");
         jdbcTemplate.update("DELETE FROM users WHERE login_id = 'pet_e2e_user'");
     }
 
@@ -53,8 +53,9 @@ class PetControllerE2ETest {
                 .path("accessToken");
 
         // given — 펫 생성 및 유저에 연결 (DB 직접)
-        jdbcTemplate.update("INSERT INTO pets (point, created_at, updated_at) VALUES (40, NOW(), NOW())");
-        final Long petId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM pets", Long.class);
+        final Long petId = jdbcTemplate.queryForObject(
+                "SELECT id FROM FINAL TABLE (INSERT INTO pets (point, created_at, updated_at) VALUES (40, NOW(), NOW()))",
+                Long.class);
         jdbcTemplate.update("UPDATE users SET pet = ? WHERE login_id = 'pet_e2e_user'", petId);
 
         // when & then

--- a/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
@@ -1,0 +1,70 @@
+package com.ppiyaki.pet.controller;
+
+import static org.hamcrest.Matchers.is;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PetControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        jdbcTemplate.update("UPDATE users SET pet = NULL WHERE login_id = 'pet_e2e_user'");
+        jdbcTemplate.update("DELETE FROM pets WHERE id IN "
+                + "(SELECT pet FROM users WHERE login_id = 'pet_e2e_user')");
+        jdbcTemplate.update("DELETE FROM refresh_tokens WHERE user_id IN "
+                + "(SELECT id FROM users WHERE login_id = 'pet_e2e_user')");
+        jdbcTemplate.update("DELETE FROM users WHERE login_id = 'pet_e2e_user'");
+    }
+
+    @Test
+    @DisplayName("유저가 펫을 조회하면 포인트와 레벨을 반환한다")
+    void readMyPet_success() {
+        // given — 회원가입
+        final String accessToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "pet_e2e_user",
+                            "password": "pass1234!",
+                            "nickname": "펫유저"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("accessToken");
+
+        // given — 펫 생성 및 유저에 연결 (DB 직접)
+        jdbcTemplate.update("INSERT INTO pets (point, created_at, updated_at) VALUES (40, NOW(), NOW())");
+        final Long petId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM pets", Long.class);
+        jdbcTemplate.update("UPDATE users SET pet = ? WHERE login_id = 'pet_e2e_user'", petId);
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .get("/api/v1/pets/me")
+                .then()
+                .statusCode(200)
+                .body("point", is(40))
+                .body("level", is(2));
+    }
+}

--- a/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
@@ -53,9 +53,9 @@ class PetControllerE2ETest {
                 .path("accessToken");
 
         // given — 펫 생성 및 유저에 연결 (DB 직접)
+        jdbcTemplate.update("INSERT INTO pets (point, created_at, updated_at) VALUES (40, NOW(6), NOW(6))");
         final Long petId = jdbcTemplate.queryForObject(
-                "SELECT id FROM FINAL TABLE (INSERT INTO pets (point, created_at, updated_at) VALUES (40, NOW(), NOW()))",
-                Long.class);
+                "SELECT id FROM pets WHERE point = 40 ORDER BY id DESC LIMIT 1", Long.class);
         jdbcTemplate.update("UPDATE users SET pet = ? WHERE login_id = 'pet_e2e_user'", petId);
 
         // when & then

--- a/src/test/java/com/ppiyaki/pet/service/PetPointListenerTest.java
+++ b/src/test/java/com/ppiyaki/pet/service/PetPointListenerTest.java
@@ -11,10 +11,10 @@ import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.User;
 import com.ppiyaki.user.repository.UserRepository;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -27,8 +27,12 @@ class PetPointListenerTest {
     @Mock
     private PetRepository petRepository;
 
-    @InjectMocks
     private PetPointListener petPointListener;
+
+    @BeforeEach
+    void setUp() {
+        petPointListener = new PetPointListener(userRepository, petRepository, 10L);
+    }
 
     @Test
     @DisplayName("복약 성공 이벤트 수신 시 펫 포인트가 10 증가한다")

--- a/src/test/java/com/ppiyaki/pet/service/PetPointListenerTest.java
+++ b/src/test/java/com/ppiyaki/pet/service/PetPointListenerTest.java
@@ -1,0 +1,76 @@
+package com.ppiyaki.pet.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import com.ppiyaki.medication.event.MedicationTakenEvent;
+import com.ppiyaki.pet.Pet;
+import com.ppiyaki.pet.repository.PetRepository;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PetPointListenerTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PetRepository petRepository;
+
+    @InjectMocks
+    private PetPointListener petPointListener;
+
+    @Test
+    @DisplayName("복약 성공 이벤트 수신 시 펫 포인트가 10 증가한다")
+    void onMedicationTaken_addsPoint() {
+        // given
+        final User user = mock(User.class);
+        lenient().when(user.getPet()).thenReturn(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        final Pet pet = Pet.create();
+        given(petRepository.findById(1L)).willReturn(Optional.of(pet));
+
+        // when
+        petPointListener.onMedicationTaken(new MedicationTakenEvent(1L));
+
+        // then
+        assertThat(pet.getPoint()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("펫이 연결되지 않은 유저의 이벤트는 무시한다")
+    void onMedicationTaken_noPet_skips() {
+        // given
+        final User user = mock(User.class);
+        lenient().when(user.getPet()).thenReturn(null);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        // when
+        petPointListener.onMedicationTaken(new MedicationTakenEvent(1L));
+
+        // then — 예외 없이 정상 종료
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저의 이벤트는 무시한다")
+    void onMedicationTaken_userNotFound_skips() {
+        // given
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when
+        petPointListener.onMedicationTaken(new MedicationTakenEvent(999L));
+
+        // then — 예외 없이 정상 종료
+    }
+}

--- a/src/test/java/com/ppiyaki/pet/service/PetServiceTest.java
+++ b/src/test/java/com/ppiyaki/pet/service/PetServiceTest.java
@@ -41,7 +41,8 @@ class PetServiceTest {
         lenient().when(user.getPet()).thenReturn(1L);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
-        final Pet pet = new Pet(40L);
+        final Pet pet = Pet.create();
+        pet.addPoint(40L);
         given(petRepository.findById(1L)).willReturn(Optional.of(pet));
 
         // when

--- a/src/test/java/com/ppiyaki/pet/service/PetServiceTest.java
+++ b/src/test/java/com/ppiyaki/pet/service/PetServiceTest.java
@@ -1,0 +1,86 @@
+package com.ppiyaki.pet.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.pet.Pet;
+import com.ppiyaki.pet.controller.dto.PetResponse;
+import com.ppiyaki.pet.repository.PetRepository;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PetServiceTest {
+
+    @Mock
+    private PetRepository petRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PetService petService;
+
+    @Test
+    @DisplayName("유저에게 펫이 있으면 포인트와 레벨을 반환한다")
+    void readMyPet_success() {
+        // given
+        final User user = mock(User.class);
+        lenient().when(user.getPet()).thenReturn(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        final Pet pet = new Pet(40L);
+        given(petRepository.findById(1L)).willReturn(Optional.of(pet));
+
+        // when
+        final PetResponse petResponse = petService.readMyPet(1L);
+
+        // then
+        assertThat(petResponse.point()).isEqualTo(40L);
+        assertThat(petResponse.level()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("유저에게 펫이 없으면 PET_NOT_FOUND 에러가 발생한다")
+    void readMyPet_noPet_throwsNotFound() {
+        // given
+        final User user = mock(User.class);
+        lenient().when(user.getPet()).thenReturn(null);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> petService.readMyPet(1L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    final BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.PET_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("유저가 존재하지 않으면 USER_NOT_FOUND 에러가 발생한다")
+    void readMyPet_userNotFound_throwsNotFound() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> petService.readMyPet(1L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    final BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+                });
+    }
+}


### PR DESCRIPTION
                                                       
  ## AS-IS                                                       
  - 복약 기록이 TAKEN으로 확정되어도 펫에 반영되지 않음          
  - medication ↔ pet 간 연결이 없음                            
                                                                 
  ## TO-BE                                                       
  - 복약 기록이 TAKEN으로 확정되면 Spring ApplicationEvent 발행  
  - PetPointListener가 이벤트를 수신하여 해당 시니어의 펫에      
  포인트 +10                                                   
  - 약한 결합(이벤트 기반)으로 medication → pet 의존 없이 연동   
                                                              
  ## 변경 사항                                                   
  - `MedicationTakenEvent` 이벤트 클래스 신설               
  - `MedicationLogService.upsert()` — TAKEN 시 이벤트 발행       
  - `PetPointListener` — 이벤트 수신 → Pet.addPoint() 호출. 펫   
  미연결 시니어는 무시                                           
  - `MedicationLogServiceTest` — eventPublisher mock 추가        
                                                                 
  ## 테스트                                                      
  - PetPointListenerTest 단위 테스트 3개 (포인트 증가, 펫 미연결
  무시, 유저 미존재 무시)                                        
                                                                 
  ## 참고                                                      
  - Issue #206                                                   
  - 참고: docs/features/pet-gamification.md                 
  - 선행 PR: feat(pet): Pet 도메인 로직 및 조회 API 구현 (#206)  
                                                                 
  ## AI Agent 전용 체크리스트                                    
  - [x] 코드 컨벤션 준수 (final, 어노테이션 순서, 풀네임 변수)   
  - [x] 테스트 작성 (PetPointListener 단위 테스트 3개)           
  - [x] 도메인 문서 갱신 (엔티티 변경 없으므로 불필요)           
  - [x] 품질 게이트 통과 (checkstyleMain, spotlessCheck, test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 펫 게이미피케이션 도입: 복약 성공 시 펫 포인트 적립 및 레벨 자동 계산, GET /api/v1/pets/me로 포인트·레벨 조회 가능.
  * 복약 완료 이벤트 발행 로직 추가 및 연동으로 포인트 처리 트리거 구현.
  * API 오류 코드에 PET_NOT_FOUND 추가.

* **Documentation**
  * 복약 기록 Phase 2 AI 검증 명세 및 인덱스 문서 추가.
  * 펫 게이미피케이션 상세 명세 문서 추가.

* **Tests**
  * 단위·E2E 테스트 및 이벤트 발행 검증 강화.

* **Chores**
  * 로컬 AI 설정 파일 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->