### PR TITLE
refactor(infra): Vision 모델 gpt-5.4-mini 업그레이드 + 텍스트/비전 모델 분리

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -77,6 +77,8 @@ jobs:
               -e CLOVA_OCR_SECRET='${{ secrets.CLOVA_OCR_SECRET }}' \
               -e CLOVA_OCR_INVOKE_URL='${{ secrets.CLOVA_OCR_INVOKE_URL }}' \
               -e OPENAI_API_KEY='${{ secrets.OPENAI_API_KEY }}' \
+              -e OPENAI_TEXT_MODEL='gpt-5.4-nano' \
+              -e OPENAI_VISION_MODEL='gpt-5.4-mini' \
               ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
             
             echo "Cleaning up old images..."

--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -568,7 +568,7 @@ erDiagram
 
 | # | 주제 | 현재 상태 |
 |---|---|---|
-| ~~7-9~~ | ~~약 개수 인식 세부~~ | ✅ **해소됨** (Phase 2, v0.8.0). gpt-5.4-nano Vision API 동기 검증으로 구현. 명세는 `docs/features/medication-log-phase2.md`. 알약 식별(Phase 3, #185)은 별도 spec에서 진행 |
+| ~~7-9~~ | ~~약 개수 인식 세부~~ | ✅ **해소됨** (Phase 2, v0.8.0). gpt-5.4-mini Vision API 동기 검증으로 구현 (2026-05-06 nano→mini 정확도 업그레이드). 명세는 `docs/features/medication-log-phase2.md`. 알약 식별(Phase 3, #185)은 별도 spec에서 진행 |
 | 7-23 | DB 마이그레이션 도구 도입 | **후순위.** 현재는 `src/main/resources/schema.sql`을 Hibernate metadata에서 추출해 운영 스키마를 관리. 운영 안정화 단계에서 Flyway/Liquibase 도입 검토. 도입 시 `application-prod.yml`의 `ddl-auto: validate` 정책과 부트스트랩 흐름(초기 schema.sql → migration baseline) 정리 필요 |
 
 ## 8) 외부 연동 인벤토리

--- a/docs/features/medication-log-phase2.md
+++ b/docs/features/medication-log-phase2.md
@@ -36,8 +36,8 @@ last_reviewed: 2026-04-30
 - [ ] 결과를 `ai_status` 컬럼에 저장. 응답 DTO에 노출 (이미 Phase 1 응답에 `aiStatus` 필드 있음).
 
 ### 비기능 요구사항
-- **응답 시간**: 동기 처리. **실측 기반(2026-04-30 prod 서버에서 OpenAI Vision API 직접 호출): gpt-5.4-nano 평균 ~3s (1x1 더미 이미지), 실제 폰 카메라 사진은 ~4-6s 예상.** p50 ~3s / p95 ~6s 목표. 클라이언트 timeout 30s 권장.
-- **비용**: gpt-5.4-nano 호출당 약 0.4~1원 수준 추정 (이미지 토큰 포함). 처방전 OCR 비용 대비 차수 동일. 일일 트래픽 모니터링 권장.
+- **응답 시간**: 동기 처리. **실측 기반(2026-05-06 prod 서버에서 OpenAI Vision API 직접 호출): gpt-5.4-mini 평균 ~1.7s (custom 사진 3장 × 3-run), 실제 폰 카메라 사진은 ~3-5s 예상.** p50 ~2s / p95 ~5s 목표. 클라이언트 timeout 30s 권장.
+- **비용**: gpt-5.4-mini 호출당 약 2원 수준 추정 (이미지 토큰 포함). gpt-5.4-nano 대비 약 4-5배. MVP 단계 트래픽 작아 절대값 부담 미미. 일일 트래픽 모니터링 권장.
 - **보안**: 사진은 메모리에서만 처리 (이미 NCP S3에 저장된 것을 fetch). Vision API에 사용자 ID/PII 전송 안 함.
 - **타임아웃**: 서버측 30초 (Vision LLM 처리 시간 여유). 클라이언트 측 타임아웃 30초 이상 권장.
 - **민감정보 로깅 금지**: dosage·objectKey·결과 카운트는 로그에 남기지 않음 (id/userId만).
@@ -82,10 +82,10 @@ public enum LogAiStatus {
 ### 5-2) API 엔드포인트 변경
 **없음**. 기존 `PUT /api/v1/medication-logs` / `GET /api/v1/medication-logs` 응답에 `aiStatus`가 enum 값으로 채워질 뿐.
 
-### 5-3) 외부 연동 — OpenAI GPT-4o Vision
+### 5-3) 외부 연동 — OpenAI Vision
 
 - 엔드포인트: `https://api.openai.com/v1/chat/completions` (이미 사용 중)
-- 모델: **`gpt-5.4-nano`** — 프로젝트 표준 (prescription-ocr와 동일, `OpenAiProperties.model`로 주입). vision 입력 지원.
+- 모델: **`gpt-5.4-mini`** — `OpenAiProperties.visionModel`로 주입 (`OPENAI_VISION_MODEL` env, default `gpt-5.4-mini`). 텍스트 모델(`textModel`)과 분리 구성. vision 입력 지원.
 - 입력: `messages` 배열에 image_url(base64 data URL) + system prompt
 - 출력: JSON Mode로 `{"count": <integer>}` 강제. 파싱 실패 시 retry 1회.
 - System prompt 초안:
@@ -161,11 +161,12 @@ public enum LogAiStatus {
 | # | 질문 | 선택지 | 담당/기한 |
 |---|---|---|---|
 | Q1 | 동일 시각 정렬 허용 오차 | 동일 `scheduledTime` 정확 일치만 합산. 인접 시각 합산은 후속 | ✅ 결정 |
-| Q2 | gpt-5.4-nano vision 정확도 | 운영 데이터로 측정 후 모델 변경 여부 결정 | 운영 모니터링 |
+| ~~Q2~~ | ~~gpt-5.4-nano vision 정확도~~ | ✅ **해소됨** (2026-05-06). custom 사진 3장 × 3-run 정확도 테스트에서 nano가 정답 11→8로 misread. mini로 분리 업그레이드 (11/11/11 정확). 결정 로그 §9 참조 |
 
 ## 9) 결정 로그
 - 2026-04-30: 초안 작성. Phase 1 머지 직후 진행.
-- 2026-04-30: **Vision LLM = OpenAI gpt-5.4-nano** — 프로젝트 표준 모델 사용 (prescription-ocr와 동일). 기존 `OpenAiClient` + `OpenAiProperties.model` 인프라 그대로 확장. Clova Vision 미채택.
+- 2026-04-30: **Vision LLM = OpenAI gpt-5.4-nano** — 프로젝트 표준 모델 사용 (prescription-ocr와 동일). 기존 `OpenAiClient` + `OpenAiProperties.model` 인프라 그대로 확장. Clova Vision 미채택. (→ 2026-05-06 mini 업그레이드, 하단 참조)
+- 2026-05-06: **Vision LLM gpt-5.4-mini 업그레이드 + 텍스트 모델 분리** — 사용자 제공 custom 사진 3장 × 3-run 정확도 테스트에서 gpt-5.4-nano가 정답 11→8로 misread (재현 가능). gpt-4o(11/11/11) 동등 정확도 + 5.x 패밀리 유지 + 응답시간 ~1.7s + gpt-4o 대비 비용↓ 이유로 **gpt-5.4-mini 채택**. 텍스트 모델은 OCR 속도/비용 우선 고려해 nano 유지하고 `OpenAiProperties.textModel` / `visionModel`로 분리. env: `OPENAI_TEXT_MODEL` (default nano) / `OPENAI_VISION_MODEL` (default mini).
 - 2026-04-30: **동기 처리** — UX 단순성 우선. 실측 기반 p50 ~3s / p95 ~6s 응답 시간 감수. 시니어가 응답 받기 전 화면이 안 넘어가는 자연 차단 효과까지 부수적으로 확보. 비동기는 운영 트래픽 데이터 보고 후속 결정.
 - 2026-04-30: **트리거 = `photoObjectKey != null && status == TAKEN`** — 미복용/사진 없음은 검증 무의미.
 - 2026-04-30: **동일 시각 schedule 합산** — 시니어가 같은 시각에 여러 약 한 번에 촬영하는 실제 행동 패턴 정합.

--- a/docs/features/medicine-dur.md
+++ b/docs/features/medicine-dur.md
@@ -335,4 +335,5 @@ DurCheckService
 - 2026-04-15: **Layer 1 저장 방식 — 인메모리 우선, Redis TODO**. 이유: Redis 인프라 부담 회피, 단일 인스턴스 운영 중, 인터페이스 추상화(`MfdsResponseCache`)로 후속 Redis 스왑 용이. 마이그레이션 트리거: 다중 인스턴스 배포 / 엔트리 1만+ / 콜드 캐시 운영 비용 가시화. **TODO는 spec §5-3-A에 명시 유지**.
 - 2026-04-15: **Layer 2 무효화 방식 — `combo_hash` 포함 키**. 시니어가 약물을 추가/제거할 때 자동으로 캐시 미스. 단순 TTL만으로는 부정확하다는 판단.
 - 2026-04-16: **OpenAI 모델 맥락 공유** — prescription-ocr spec의 AI 모델이 gpt-4o-mini에서 gpt-5.4-nano로 변경됨 (OpenAI 라인업 변경, 단가: 입력 $0.20/1M, 출력 $1.25/1M). 본 spec(DUR)은 OpenAI를 직접 호출하지 않으나, prescription-ocr 통합 파이프라인과의 연계 구현 시 참고.
+- 2026-05-06: **OpenAI 모델 분리 구성 (맥락 공유)** — `OpenAiProperties.model`이 `textModel`/`visionModel`로 분리. text(prescription-ocr)는 nano 유지, vision(medication-log-phase2)은 mini 업그레이드. 본 spec은 영향 없음.
 - 2026-04-16: **구현 순서 확정** — ① item_seq 컬럼 추가 → ② medicine-search (+ medicine-dur 병렬 가능) → ③ medicine-dur (현재 spec) → ④ prescription-ocr 통합본 → ⑤ mcp-server-foundation. medicine-search와 병렬 진행 가능.

--- a/docs/features/prescription-ocr.md
+++ b/docs/features/prescription-ocr.md
@@ -197,7 +197,7 @@ function checkPrescriptionMutation(requesterId, prescription):
 - 인증: `OPENAI_API_KEY` 환경변수
 - 입력: 시스템 prompt(약물 추출 지시) + 마스킹된 OCR 텍스트
 - 출력: JSON Mode 활성화로 약물 후보 리스트 강제
-- 모델: **gpt-5.4-nano** (잠정 확정). 단가: 입력 $0.20/1M, 출력 $1.25/1M → 건당 약 0.4원
+- 모델: **gpt-5.4-nano** (`OpenAiProperties.textModel`로 주입, env `OPENAI_TEXT_MODEL`). vision 모델(`visionModel`, gpt-5.4-mini)과 분리 구성. 단가: 입력 $0.20/1M, 출력 $1.25/1M → 건당 약 0.4원
 - 타임아웃: 10s (LLM은 5s보다 여유)
 - 실패 처리: 동일
 
@@ -392,3 +392,4 @@ function checkPrescriptionMutation(requesterId, prescription):
 - 2026-04-16: **검색 전략 변경** — 약물명 검색 실패 시 prefix 축소 fallback 제거, `ingredientName` fallback 검색으로 대체. 성분명 동일 약물 후보군 반환 → `CANDIDATES` 결과로 처리.
 - 2026-04-30: **보호자 수동 약물 추가 정책 확정** (Q-CONF-3 해소) — (a) 후보에 추가만, confirm 시점에 Medicine 일괄 생성. itemSeq + itemName 둘 다 클라이언트 전송 (서버측 itemSeq → itemName 조회 인프라 부재). PR #188로 머지.
 - 2026-04-30: **보호자 승인 모드 도입** (Q-CONF-5 해소) — `User.careMode` enum 컬럼 (`MANAGED` default / `AUTONOMOUS`). 모드 변경은 `PUT /api/v1/users/{seniorId}/care-mode` — **보호자만 호출 가능**, 시니어 본인 셀프 변경 엔드포인트 두지 않음. 처방전 변경 엔드포인트 4건(`PATCH /medicines/{candidateId}`, `POST /medicines`, `POST /confirm`, `POST /reject`)에 모드 분기 적용. AUTONOMOUS는 시니어/보호자 모두 즉시 가능, MANAGED는 0~72h 보호자만 + 72h 후 시니어 fallback. 보호자 미연동 시니어는 spec 범위 외 (보호자 연동 전제 유지). 의도: spec의 "보호자 검증 강제"가 코드에서 사실상 동작하지 않던 상태를 명시적 권한 모델로 끌어올림.
+- 2026-05-06: **OpenAI 모델 분리 구성 도입** — `OpenAiProperties`를 `model` 단일 필드에서 `textModel` / `visionModel` 두 필드로 분리. 본 spec(텍스트 OCR)은 **gpt-5.4-nano 유지** (속도/비용 우선, 품질은 운영상 충분). vision(`medication-log-phase2` 약 개수 인식)은 정확도 검증 결과로 **gpt-5.4-mini 업그레이드**. env 변수: `OPENAI_TEXT_MODEL` (default nano) / `OPENAI_VISION_MODEL` (default mini). 본 spec의 텍스트 OCR은 별도 정확도 회귀 테스트 안 함 — 운영 모니터링으로 추적.

--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -49,8 +49,7 @@ public class OpenAiClient {
         final long startTime = System.currentTimeMillis();
 
         try {
-            final String model = properties.model() != null ? properties.model() : "gpt-5.4-nano";
-            final String requestBody = buildRequest(model, maskedOcrText);
+            final String requestBody = buildRequest(properties.textModel(), maskedOcrText);
 
             final String responseBody = restClient.post()
                     .uri(API_URL)
@@ -181,8 +180,7 @@ public class OpenAiClient {
         for (int attempt = 1; attempt <= 2; attempt++) {
             final long startTime = System.currentTimeMillis();
             try {
-                final String model = properties.model() != null ? properties.model() : "gpt-5.4-nano";
-                final String requestBody = buildCountRequest(model, imageBytes, mediaType);
+                final String requestBody = buildCountRequest(properties.visionModel(), imageBytes, mediaType);
 
                 final String responseBody = restClient.post()
                         .uri(API_URL)

--- a/src/main/java/com/ppiyaki/common/ai/OpenAiProperties.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiProperties.java
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 @ConditionalOnProperty(prefix = "openai", name = "api-key")
 public record OpenAiProperties(
         @NotBlank String apiKey,
-        String model
+        @NotBlank String textModel,
+        @NotBlank String visionModel
 ) {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,4 +54,5 @@ mfds:
     read-timeout: 5000
 
 openai:
-  model: gpt-5.4-nano
+  text-model: ${OPENAI_TEXT_MODEL:gpt-5.4-nano}
+  vision-model: ${OPENAI_VISION_MODEL:gpt-5.4-mini}


### PR DESCRIPTION
## AS-IS
- `OpenAiProperties`에 `model` 단일 필드. 처방전 텍스트 추출(`extractMedicines`)과 약 개수 vision(`countPills`)이 같은 모델 공유 (gpt-5.4-nano).
- 2026-05-06 사용자 제공 custom 사진 3장 × 3-run 정확도 테스트에서 vision이 정답 11→8로 misread (재현 가능).

## TO-BE
- 텍스트/비전 모델 분리. 텍스트는 속도/비용 우선 → **gpt-5.4-nano 유지**, 비전은 정확도 → **gpt-5.4-mini 업그레이드**.
- `OpenAiProperties`에 `textModel` / `visionModel` 필드 (둘 다 `@NotBlank`).
- env: `OPENAI_TEXT_MODEL` (default nano) / `OPENAI_VISION_MODEL` (default mini).
- `backend-cd.yml`에 두 env var 추가.

## 검증

| 항목 | 결과 |
|---|---|
| Vision 정확도 (mini, 3-run × 3장) | 11/11/11 (이전 nano: 11/8/11) |
| 응답 시간 (mini, prod 직접 호출) | 평균 ~1.7s |
| 비용 영향 (vision) | nano 대비 ~4-5배. 처방전 1건 ~2원 추정. MVP 트래픽 절대값 부담 미미 |
| 텍스트 OCR 별도 회귀 테스트 | ❌ 진행 안 함 (모델 미변경) |

## 변경 파일
- `OpenAiProperties.java`, `OpenAiClient.java` — 필드 분리, 메서드별 모델 선택
- `application.yml`, `backend-cd.yml` — env 분리
- `medication-log-phase2.md`, `prescription-ocr.md`, `medicine-dur.md`, `06-domain-model.md` — spec/도메인 결정 로그 갱신

## 보호 영역
- `.github/workflows/backend-cd.yml` — `needs-human-review` 라벨 부여
- `application.yml` — `needs-human-review` 라벨 부여

## AI 체크리스트
- [x] 도메인 문서 갱신 (`06-domain-model.md §7-9`)
- [x] Feature Spec ↔ 구현 1:1 (3개 spec 갱신)
- [ ] Notion API 명세 갱신 — **불필요** (외부 모델 swap, API contract 무변동)
- [x] 품질 게이트 통과 (`./gradlew checkstyleMain spotlessCheck test`)
- [x] 라벨 부여 (PR 생성 후 별도 커맨드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 약 복용 검증 시스템 업그레이드(Phase 2): AI 기반 알약 개수 자동 인식 및 검증 추가
  * 보호자 약물 관리: 보호자의 수동 약품 추가 및 승인 워크플로우 지원
  * 보호자 승인 모드: 향상된 접근 제어 및 보안 기능

* **개선 사항**
  * AI 모델 구성 최적화로 성능 및 비용 효율성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->