### PR TITLE
feat(user): 시니어 식사 시간대 저장 API 추가 (#221)

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -102,6 +102,9 @@
 | dob | date | 생년월일 |
 | pet | bigint | `pets.id` PK 참조 (FK 제약 선언 여부는 §7-12) |
 | care_mode | varchar | DB는 varchar, Java는 `CareMode` enum(`MANAGED` default / `AUTONOMOUS`). 시니어 회원에 적용. 보호자 회원도 컬럼은 갖지만 처방전 흐름에서는 `prescription.owner_id`로 참조하는 시니어 측 값만 사용 |
+| breakfast_time | time nullable | 시니어 식사 시간대(아침). Java는 `LocalTime`. 미설정 가능. Phase 1: 클라이언트가 schedule 등록 시 활용. Phase 2~3: 슬롯 매핑/자동 생성 (별도 spec) |
+| lunch_time | time nullable | 시니어 식사 시간대(점심). 동일 |
+| dinner_time | time nullable | 시니어 식사 시간대(저녁). 동일 |
 | created_at / updated_at | timestamp | `BaseTimeEntity` |
 
 > **코드 갭(현재 HEAD 기준)**: 코드의 `User.java`는 `nickname`, `gender`, `dob`가 없고 `pet` 대신 `ppiyaki bigint` 컬럼명을 사용하며 `password`가 non-null. 이 문서는 **타깃 스키마**를 기술하며, 코드 갱신은 별도 PR로 진행한다. 추적: §7-16.
@@ -373,6 +376,9 @@ erDiagram
         date dob
         bigint pet FK
         varchar care_mode "MANAGED default / AUTONOMOUS"
+        time breakfast_time "nullable"
+        time lunch_time "nullable"
+        time dinner_time "nullable"
         timestamp created_at
         timestamp updated_at
     }

--- a/docs/features/meal-time-defaults.md
+++ b/docs/features/meal-time-defaults.md
@@ -126,12 +126,12 @@ UserMeResponse.from(user)
 ### 5-5) DB 마이그레이션
 ```sql
 ALTER TABLE users
-    ADD COLUMN breakfast_time TIME NULL,
-    ADD COLUMN lunch_time TIME NULL,
-    ADD COLUMN dinner_time TIME NULL;
+    ADD COLUMN breakfast_time TIME(6) NULL,
+    ADD COLUMN lunch_time TIME(6) NULL,
+    ADD COLUMN dinner_time TIME(6) NULL;
 ```
 - prod NCP MySQL에 머지 직후 수동 실행 (보호 영역)
-- `src/main/resources/schema.sql`도 같은 PR에서 갱신
+- `src/main/resources/schema.sql`은 Hibernate가 생성한 `time(6)` 형식과 동일
 
 ## 6) 작업 분할
 단일 PR로 진행 (Phase 1 자체가 작은 범위).

--- a/docs/features/meal-time-defaults.md
+++ b/docs/features/meal-time-defaults.md
@@ -1,0 +1,170 @@
+---
+feature: 시니어 식사 시간대 기본값
+slug: meal-time-defaults
+status: draft
+owner: @goohong
+scope: user
+related_issues: [#221]
+related_prs: []
+last_reviewed: 2026-05-07
+---
+
+# 시니어 식사 시간대 기본값
+
+## 1) 개요 (What / Why)
+시니어가 평소 아침/점심/저녁 식사 시간을 사전 설정해두고, 처방전 기반 복약 일정 등록 시 이 시간대를 활용한다. 매번 약마다 수기로 시각을 입력하는 마찰을 줄이고, 향후 처방전 confirm 시 자동 schedule 생성의 기반 데이터를 마련한다.
+
+대상 사용자: 시니어 (본인 시간대 설정), 보호자 (조회만, 갱신은 시니어 본인).
+
+## 2) 사용자 시나리오
+- **온보딩**: 시니어가 회원가입 직후 아침 8시 / 점심 12시 30분 / 저녁 6시 30분으로 식사 시간을 설정한다.
+- **약 등록 흐름**: 시니어/보호자가 처방전 confirm 후 schedule 등록 화면에서, 약마다 "아침/점심/저녁" 슬롯을 고르면 프론트가 시니어의 mealTimes 값을 읽어 LocalTime을 채워 백엔드에 보낸다 (Phase 1 한정 — 백엔드는 슬롯 개념을 모름).
+- **수정**: 시니어가 식사 시간이 바뀌면 `PUT /api/v1/users/me/meal-times`로 3개 시각을 한 번에 갱신한다.
+
+## 3) 요구사항
+### 기능 요구사항
+- [ ] `User` 엔티티에 `breakfastTime` / `lunchTime` / `dinnerTime` (LocalTime, nullable) 필드 추가
+- [ ] `PUT /api/v1/users/me/meal-times` — 시니어 본인이 3개 시각을 한 번에 갱신 (전체 PUT, 3개 모두 필수)
+- [ ] `GET /api/v1/users/me` 응답에 `mealTimes` 객체 추가. 모두 미설정이면 `null`, 일부만 설정 가능
+- [ ] 권한: 시니어 본인만 갱신 (보호자 대리 갱신 불가, Phase 2 이후 검토)
+- [ ] DB 마이그레이션 SQL 준비, `schema.sql` 동기화
+
+### 비기능 요구사항
+- **성능**: 갱신/조회 모두 단일 user row 작업. 추가 인덱스 불필요.
+- **신뢰성**: 입력값 검증 — `LocalTime` 형식만 (00:00:00 ~ 23:59:59). 시각 간 순서(`breakfast < lunch < dinner`) 강제하지 않음 — 사용자 자율.
+- **보안**: 의료정보 아니므로 일반 사용자 데이터 정책. 로그에 시각 노출 OK.
+- **관측성**: 별도 메트릭 불필요. 일반 access log로 충분.
+
+## 4) 범위 / 비범위 (중요)
+
+### 포함
+- User에 시간대 컬럼 3개
+- 갱신/조회 API
+- 시니어 본인 권한 체크
+- 도메인 문서 + Notion API 명세 동기화
+- E2E 테스트 (성공 케이스 1개 이상)
+
+### 제외 (Out of Scope)
+- **`MealSlot` enum 도입** → Phase 2
+- **`MedicationSchedule`에 슬롯 매핑** → Phase 2
+- **시니어 시간 변경 시 기존 schedule cascade 갱신** → Phase 2
+- **처방전 confirm 시 schedule 자동 생성** → Phase 3
+- **OCR schedule 텍스트 → 슬롯 매핑 파서** → Phase 3
+- **보호자 대리 갱신** → 후속 결정
+- **`isOnboarded` 정의 변경** (mealTimes 미설정도 onboarded로 유지)
+- **시각 간 순서 검증** — 사용자 자율
+- **부분 갱신 (PATCH)** — Phase 1은 전체 PUT만
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+- 컨텍스트: `user` (참조: `docs/ai-harness/06-domain-model.md §5 users`)
+- `User`에 LocalTime 컬럼 3개 (`breakfast_time`, `lunch_time`, `dinner_time`, 모두 nullable)
+- 별도 테이블 도입 X — MVP 과잉. 향후 슬롯 추가(야간/간식) 필요 시 별도 테이블로 마이그레이션
+
+### 5-2) API 엔드포인트
+
+| Method | Path | 설명 | 인증 | Req | Res |
+|---|---|---|---|---|---|
+| PUT | `/api/v1/users/me/meal-times` | 시니어 본인의 식사 시간대 3개 일괄 갱신 | 필수 (시니어) | `MealTimesUpdateRequest` | `UserMeResponse` |
+| GET | `/api/v1/users/me` | 내 정보 + mealTimes (기존 엔드포인트 응답 확장) | 필수 | — | `UserMeResponse` |
+
+#### MealTimesUpdateRequest (전체 PUT, 3개 모두 필수)
+```json
+{
+  "breakfast": "08:00:00",
+  "lunch": "12:30:00",
+  "dinner": "18:30:00"
+}
+```
+- 모두 `@NotNull LocalTime` (jakarta.validation)
+- 형식: ISO-8601 LocalTime (`HH:mm:ss`)
+
+#### UserMeResponse (확장)
+```json
+{
+  "id": 16,
+  "nickname": "테스트시니어",
+  "role": "SENIOR",
+  "isOnboarded": true,
+  "mealTimes": {
+    "breakfast": "08:00:00",
+    "lunch": "12:30:00",
+    "dinner": "18:30:00"
+  }
+}
+```
+- `mealTimes`는 객체 — 3개 모두 미설정이면 `null` (객체 자체 누락), 일부만 설정 가능
+
+#### 에러 응답
+| 상황 | HTTP | code |
+|---|---|---|
+| 입력 누락/형식 오류 | 400 | `COMMON_001` |
+| 인증 없음/만료 | 401 | `AUTH_001` |
+| 권한 없음 (시니어가 아닌 경우 — Phase 1 한정) | 403 | `FORBIDDEN` (별도 로직 필요 시) |
+
+> **권한 검증 메모**: 본 PR 범위에서는 `@AuthenticationPrincipal Long userId`로 받은 사용자의 `me` 엔드포인트라 별도 시니어 검증 불필요. 보호자가 호출해도 자기 자신을 갱신하므로 무해. 단 보호자 mealTimes는 의미 없음 — Phase 2에서 슬롯 도입 시 시니어로 한정 검토.
+
+### 5-3) 외부 연동
+없음.
+
+### 5-4) 데이터 흐름
+```
+시니어 클라이언트
+  ↓ PUT /users/me/meal-times { breakfast, lunch, dinner }
+UserController.updateMealTimes(userId, request)
+  ↓
+UserService.updateMealTimes(userId, request)
+  ↓
+User.updateMealTimes(breakfast, lunch, dinner)
+  ↓ JPA dirty checking
+DB: UPDATE users SET breakfast_time=?, lunch_time=?, dinner_time=? WHERE id=?
+  ↓
+UserMeResponse.from(user)
+```
+
+### 5-5) DB 마이그레이션
+```sql
+ALTER TABLE users
+    ADD COLUMN breakfast_time TIME NULL,
+    ADD COLUMN lunch_time TIME NULL,
+    ADD COLUMN dinner_time TIME NULL;
+```
+- prod NCP MySQL에 머지 직후 수동 실행 (보호 영역)
+- `src/main/resources/schema.sql`도 같은 PR에서 갱신
+
+## 6) 작업 분할
+단일 PR로 진행 (Phase 1 자체가 작은 범위).
+
+- [ ] PR `feat(user)`:
+  - 엔티티 + 도메인 메서드
+  - DTO (request, response 갱신)
+  - Service + Controller 메서드
+  - 마이그레이션 SQL + schema.sql
+  - 도메인 문서 §5 갱신
+  - Notion API 명세 항목 (PUT 신규 / GET 갱신)
+  - E2E + 단위 테스트
+
+## 7) 테스트 전략
+- **단위 테스트**: `User.updateMealTimes` — null 거부, LocalTime 보관, 부분 변경 케이스
+- **E2E (RestAssured)**:
+  - 성공: 인증된 사용자 PUT → 200 → GET /users/me로 mealTimes 확인
+  - 입력 누락: 한 필드 빠지면 400
+  - 인증 없음: 401
+- 외부 연동 mock 불필요
+
+## 8) 오픈 질문
+
+| # | 질문 | 선택지 | 담당/기한 |
+|---|---|---|---|
+| Q1 | 보호자 대리 갱신 허용? | (a) Phase 1부터 보호자도 가능 / (b) Phase 1은 본인만, Phase 2에서 검토 | @goohong / Phase 2 진입 전 — **(b)로 잠정 결정** |
+| Q2 | 시각 간 순서 강제? | (a) breakfast<lunch<dinner / (b) 자율 | **(b) 자율 결정** — 사용자가 야간 근무 등 비전형 패턴 가질 수 있음 |
+| Q3 | 미설정 상태 표현 | (a) 3개 모두 null이면 mealTimes=null / (b) 항상 객체 반환 (필드별 null) | **(a) 결정** — 클라이언트 분기 단순 |
+
+## 9) 결정 로그
+- 2026-05-07: 초안 작성 (status=draft). Phase 1 범위 한정. Phase 2~3는 후속 spec.
+- 2026-05-07: **데이터 모델 = User 컬럼 3개**. 별도 테이블 도입 X. 이유: MVP 과잉. 향후 슬롯 확장(야간/간식) 시점에 마이그레이션 검토.
+- 2026-05-07: **전체 PUT 채택**. 부분 갱신(PATCH) 불채택. 이유: Phase 1 단순화. 사용자 사용 빈도 낮아 PATCH 가치 작음.
+- 2026-05-07: **시각 순서 검증 미도입**. 사용자 자율 (야간 근무 등 비전형 패턴 허용).
+- 2026-05-07: **보호자 대리 갱신 미포함**. Phase 1은 본인만. Phase 2 슬롯 도입 시점에 재검토.
+- 2026-05-07: **`isOnboarded` 정의 유지**. mealTimes 미설정도 onboarded. 시간대 설정 강제는 프론트 UX로 유도.

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -52,6 +53,15 @@ public class User extends BaseTimeEntity {
     @Column(name = "care_mode", nullable = false)
     private CareMode careMode;
 
+    @Column(name = "breakfast_time")
+    private LocalTime breakfastTime;
+
+    @Column(name = "lunch_time")
+    private LocalTime lunchTime;
+
+    @Column(name = "dinner_time")
+    private LocalTime dinnerTime;
+
     public User(
             final String loginId,
             final String password,
@@ -73,5 +83,15 @@ public class User extends BaseTimeEntity {
 
     public void changeCareMode(final CareMode careMode) {
         this.careMode = Objects.requireNonNull(careMode, "careMode must not be null");
+    }
+
+    public void updateMealTimes(
+            final LocalTime breakfastTime,
+            final LocalTime lunchTime,
+            final LocalTime dinnerTime
+    ) {
+        this.breakfastTime = Objects.requireNonNull(breakfastTime, "breakfastTime must not be null");
+        this.lunchTime = Objects.requireNonNull(lunchTime, "lunchTime must not be null");
+        this.dinnerTime = Objects.requireNonNull(dinnerTime, "dinnerTime must not be null");
     }
 }

--- a/src/main/java/com/ppiyaki/user/controller/UserController.java
+++ b/src/main/java/com/ppiyaki/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.ppiyaki.user.controller;
 
 import com.ppiyaki.user.controller.dto.CareModeResponse;
 import com.ppiyaki.user.controller.dto.CareModeUpdateRequest;
+import com.ppiyaki.user.controller.dto.MealTimesUpdateRequest;
+import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -29,5 +31,13 @@ public class UserController {
             @Valid @RequestBody final CareModeUpdateRequest request
     ) {
         return ResponseEntity.ok(userService.updateCareMode(requesterId, seniorId, request.careMode()));
+    }
+
+    @PutMapping("/me/meal-times")
+    public ResponseEntity<UserMeResponse> updateMealTimes(
+            @AuthenticationPrincipal final Long userId,
+            @Valid @RequestBody final MealTimesUpdateRequest request
+    ) {
+        return ResponseEntity.ok(userService.updateMealTimes(userId, request));
     }
 }

--- a/src/main/java/com/ppiyaki/user/controller/dto/MealTimesResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/MealTimesResponse.java
@@ -1,0 +1,23 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ppiyaki.user.User;
+import java.time.LocalTime;
+
+public record MealTimesResponse(
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime breakfast,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime lunch,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime dinner
+) {
+
+    public static MealTimesResponse from(final User user) {
+        if (user.getBreakfastTime() == null
+                && user.getLunchTime() == null
+                && user.getDinnerTime() == null) {
+            return null;
+        }
+        return new MealTimesResponse(user.getBreakfastTime(), user.getLunchTime(), user.getDinnerTime());
+    }
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/MealTimesUpdateRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/MealTimesUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalTime;
+
+public record MealTimesUpdateRequest(
+        @NotNull @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime breakfast,
+
+        @NotNull @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime lunch,
+
+        @NotNull @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime dinner
+) {
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/UserMeResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/UserMeResponse.java
@@ -6,12 +6,14 @@ public record UserMeResponse(
         Long id,
         String nickname,
         String role,
-        boolean isOnboarded
+        boolean isOnboarded,
+        MealTimesResponse mealTimes
 ) {
 
     public static UserMeResponse from(final User user) {
         final String roleName = user.getRole() != null ? user.getRole().name() : null;
         final boolean onboarded = user.getRole() != null;
-        return new UserMeResponse(user.getId(), user.getNickname(), roleName, onboarded);
+        final MealTimesResponse mealTimes = MealTimesResponse.from(user);
+        return new UserMeResponse(user.getId(), user.getNickname(), roleName, onboarded, mealTimes);
     }
 }

--- a/src/main/java/com/ppiyaki/user/service/UserService.java
+++ b/src/main/java/com/ppiyaki/user/service/UserService.java
@@ -5,6 +5,8 @@ import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.user.CareMode;
 import com.ppiyaki.user.User;
 import com.ppiyaki.user.controller.dto.CareModeResponse;
+import com.ppiyaki.user.controller.dto.MealTimesUpdateRequest;
+import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -38,5 +40,14 @@ public class UserService {
 
         senior.changeCareMode(careMode);
         return new CareModeResponse(senior.getId(), senior.getCareMode());
+    }
+
+    @Transactional
+    public UserMeResponse updateMealTimes(final Long userId, final MealTimesUpdateRequest request) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        user.updateMealTimes(request.breakfast(), request.lunch(), request.dinner());
+        return UserMeResponse.from(user);
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -145,6 +145,9 @@
 
     create table users (
         dob date,
+        breakfast_time time(6),
+        lunch_time time(6),
+        dinner_time time(6),
         created_at datetime(6),
         id bigint not null auto_increment,
         pet bigint,

--- a/src/test/java/com/ppiyaki/user/UserMealTimesTest.java
+++ b/src/test/java/com/ppiyaki/user/UserMealTimesTest.java
@@ -1,0 +1,107 @@
+package com.ppiyaki.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("User.mealTimes")
+class UserMealTimesTest {
+
+    @Test
+    @DisplayName("신규 User는 식사 시간 3개가 모두 null이다")
+    void 신규_유저_mealTimes_null() {
+        // when
+        final User user = newUser();
+
+        // then
+        assertThat(user.getBreakfastTime()).isNull();
+        assertThat(user.getLunchTime()).isNull();
+        assertThat(user.getDinnerTime()).isNull();
+    }
+
+    @Test
+    @DisplayName("updateMealTimes로 3개 시각을 한 번에 설정할 수 있다")
+    void updateMealTimes_정상() {
+        // given
+        final User user = newUser();
+        final LocalTime breakfast = LocalTime.of(8, 0);
+        final LocalTime lunch = LocalTime.of(12, 30);
+        final LocalTime dinner = LocalTime.of(18, 30);
+
+        // when
+        user.updateMealTimes(breakfast, lunch, dinner);
+
+        // then
+        assertThat(user.getBreakfastTime()).isEqualTo(breakfast);
+        assertThat(user.getLunchTime()).isEqualTo(lunch);
+        assertThat(user.getDinnerTime()).isEqualTo(dinner);
+    }
+
+    @Test
+    @DisplayName("updateMealTimes는 breakfast가 null이면 NPE")
+    void updateMealTimes_breakfast_null_거부() {
+        // given
+        final User user = newUser();
+
+        // when & then
+        assertThatThrownBy(() -> user.updateMealTimes(null, LocalTime.of(12, 0), LocalTime.of(18, 0)))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("breakfastTime");
+    }
+
+    @Test
+    @DisplayName("updateMealTimes는 lunch가 null이면 NPE")
+    void updateMealTimes_lunch_null_거부() {
+        // given
+        final User user = newUser();
+
+        // when & then
+        assertThatThrownBy(() -> user.updateMealTimes(LocalTime.of(8, 0), null, LocalTime.of(18, 0)))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("lunchTime");
+    }
+
+    @Test
+    @DisplayName("updateMealTimes는 dinner가 null이면 NPE")
+    void updateMealTimes_dinner_null_거부() {
+        // given
+        final User user = newUser();
+
+        // when & then
+        assertThatThrownBy(() -> user.updateMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 0), null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("dinnerTime");
+    }
+
+    @Test
+    @DisplayName("updateMealTimes는 호출 시마다 값을 덮어쓴다")
+    void updateMealTimes_가역() {
+        // given
+        final User user = newUser();
+        user.updateMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 0), LocalTime.of(18, 0));
+
+        // when
+        user.updateMealTimes(LocalTime.of(7, 30), LocalTime.of(13, 0), LocalTime.of(19, 30));
+
+        // then
+        assertThat(user.getBreakfastTime()).isEqualTo(LocalTime.of(7, 30));
+        assertThat(user.getLunchTime()).isEqualTo(LocalTime.of(13, 0));
+        assertThat(user.getDinnerTime()).isEqualTo(LocalTime.of(19, 30));
+    }
+
+    private User newUser() {
+        return new User(
+                "loginid",
+                "password",
+                UserRole.SENIOR,
+                "테스트유저",
+                Gender.UNKNOWN,
+                LocalDate.of(1950, 1, 1),
+                null
+        );
+    }
+}

--- a/src/test/java/com/ppiyaki/user/controller/MealTimesControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/MealTimesControllerE2ETest.java
@@ -1,0 +1,149 @@
+package com.ppiyaki.user.controller;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("PUT /api/v1/users/me/meal-times E2E")
+class MealTimesControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private static long userSequence = 800000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("인증된 사용자가 식사 시간 3개를 PUT 하면 200 + 응답에 mealTimes 포함 + DB 반영")
+    void update_meal_times_success() {
+        // given
+        final SignupResult user = signup("시니어A");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + user.accessToken())
+                .body("""
+                        {
+                            "breakfast": "08:00:00",
+                            "lunch": "12:30:00",
+                            "dinner": "18:30:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/me/meal-times")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(user.userId().intValue()))
+                .body("mealTimes.breakfast", is("08:00:00"))
+                .body("mealTimes.lunch", is("12:30:00"))
+                .body("mealTimes.dinner", is("18:30:00"));
+
+        final User reloaded = userRepository.findById(user.userId()).orElseThrow();
+        assert reloaded.getBreakfastTime().equals(LocalTime.of(8, 0));
+        assert reloaded.getLunchTime().equals(LocalTime.of(12, 30));
+        assert reloaded.getDinnerTime().equals(LocalTime.of(18, 30));
+    }
+
+    @Test
+    @DisplayName("미설정 사용자가 GET /users/me 호출 시 mealTimes는 null")
+    void get_me_returns_null_meal_times_when_unset() {
+        // given
+        final SignupResult user = signup("시니어B");
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + user.accessToken())
+                .when()
+                .get("/api/v1/users/me")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(user.userId().intValue()))
+                .body("mealTimes", nullValue());
+    }
+
+    @Test
+    @DisplayName("breakfast 누락 시 400")
+    void breakfast_missing_rejected() {
+        // given
+        final SignupResult user = signup("시니어C");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + user.accessToken())
+                .body("""
+                        {
+                            "lunch": "12:30:00",
+                            "dinner": "18:30:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/me/meal-times")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("인증 없이 PUT 호출 시 401")
+    void unauthenticated_rejected() {
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "breakfast": "08:00:00",
+                            "lunch": "12:30:00",
+                            "dinner": "18:30:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/me/meal-times")
+                .then()
+                .statusCode(401);
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "mealtime" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}

--- a/src/test/java/com/ppiyaki/user/controller/MealTimesControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/MealTimesControllerE2ETest.java
@@ -1,5 +1,6 @@
 package com.ppiyaki.user.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -60,9 +61,9 @@ class MealTimesControllerE2ETest {
                 .body("mealTimes.dinner", is("18:30:00"));
 
         final User reloaded = userRepository.findById(user.userId()).orElseThrow();
-        assert reloaded.getBreakfastTime().equals(LocalTime.of(8, 0));
-        assert reloaded.getLunchTime().equals(LocalTime.of(12, 30));
-        assert reloaded.getDinnerTime().equals(LocalTime.of(18, 30));
+        assertThat(reloaded.getBreakfastTime()).isEqualTo(LocalTime.of(8, 0));
+        assertThat(reloaded.getLunchTime()).isEqualTo(LocalTime.of(12, 30));
+        assertThat(reloaded.getDinnerTime()).isEqualTo(LocalTime.of(18, 30));
     }
 
     @Test


### PR DESCRIPTION
## AS-IS
- `User` 엔티티에 식사 시간대 필드 없음
- 시니어가 schedule 등록 시 매번 LocalTime 직접 입력 (마찰)
- 향후 처방전 confirm 자동 schedule 생성을 위한 기반 데이터 부재

## TO-BE
시니어가 평소 아침/점심/저녁 식사 시간을 사전 설정해두고, 프론트가 schedule 등록 시 활용한다.

이 PR은 **Phase 1만** 다룬다 — 시간 저장/조회 API. Phase 2 (`MealSlot` enum + schedule 슬롯 매핑) / Phase 3 (OCR 자동 schedule 생성)은 후속.

## 변경 사항

### 코드
- `User`: `breakfastTime` / `lunchTime` / `dinnerTime` (LocalTime, nullable) + `updateMealTimes()` 도메인 메서드
- `MealTimesUpdateRequest` (3개 모두 `@NotNull`, `HH:mm:ss` 형식)
- `MealTimesResponse` (모두 미설정 시 `null`)
- `UserMeResponse`에 `mealTimes` 필드 추가 (기존 GET `/users/me` 응답 확장)
- `UserController.PUT /api/v1/users/me/meal-times` — 시니어 본인 일괄 갱신
- `UserService.updateMealTimes`

### 데이터
- `schema.sql`: `users` 테이블에 `breakfast_time` / `lunch_time` / `dinner_time` (`time(6)` nullable) 컬럼 추가
- prod NCP MySQL 마이그레이션 SQL (머지 후 수동 실행):
  ```sql
  ALTER TABLE users
      ADD COLUMN breakfast_time TIME(6) NULL,
      ADD COLUMN lunch_time TIME(6) NULL,
      ADD COLUMN dinner_time TIME(6) NULL;
  ```

### 문서
- `docs/features/meal-time-defaults.md` — Feature Spec (Phase 1~3 로드맵 + Phase 1 상세)
- `docs/ai-harness/06-domain-model.md §5 users` 표 + `§6 ERD` 갱신
- Notion API 명세 DB:
  - PUT `/api/v1/users/me/meal-times` 신규 항목
  - GET `/api/v1/users/me` callout 갱신

### 테스트
- `UserMealTimesTest` — 도메인 단위 테스트 (null 거부, 가역 갱신 등 6개)
- `MealTimesControllerE2ETest` — RestAssured E2E (성공, 미설정 GET, 필드 누락 400, 미인증 401)

## 보호 영역
- `src/main/resources/schema.sql` — 스키마 변경 → `needs-human-review` 라벨

## 스코프 외 (후속)
- `MealSlot` enum 도입 → Phase 2
- `MedicationSchedule`에 슬롯 매핑 + 시간 변경 cascade → Phase 2
- 처방전 confirm 시 OCR 텍스트 → 슬롯 매핑 → 자동 schedule 생성 → Phase 3
- 보호자 대리 갱신 → 후속 결정
- 부분 갱신 (PATCH) → Phase 1은 전체 PUT만

## AI 체크리스트
- [x] 도메인 문서 갱신 (`§5 users` 표 + `§6 ERD`)
- [x] Feature Spec ↔ 구현 1:1 (`docs/features/meal-time-defaults.md`)
- [x] Notion API 명세 갱신 (PUT 신규 + GET 콜아웃)
- [x] 품질 게이트 통과 (`./gradlew checkstyleMain spotlessCheck test`)
- [x] 마이그레이션 SQL 첨부

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 아침, 점심, 저녁 식사 시간을 설정하고 관리할 수 있습니다.
  * 프로필 조회 시 설정된 식사 시간 정보를 확인할 수 있습니다.

* **문서**
  * 식사 시간 기능 및 도메인 모델 문서를 추가하고 업데이트했습니다.

* **테스트**
  * 식사 시간 기능에 대한 단위 및 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->