### PR TITLE
fix(infra): 라우팅 미스 응답 404 NOT_FOUND로 정규화

### DIFF
--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     MALFORMED_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_002", "Malformed request"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_003", "Internal server error"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_004", "Access denied"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_005", "Resource not found"),
 
     // Auth
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "Invalid token"),

--- a/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -66,9 +67,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoHandlerFound(final NoHandlerFoundException exception) {
         log.debug("No handler found: {}", exception.getMessage());
-        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MALFORMED_REQUEST,
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND,
                 "No endpoint " + exception.getHttpMethod() + " " + exception.getRequestURL());
-        return ResponseEntity.status(ErrorCode.MALFORMED_REQUEST.getStatus()).body(errorResponse);
+        return ResponseEntity.status(ErrorCode.NOT_FOUND.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFound(final NoResourceFoundException exception) {
+        log.debug("No resource found: {} {}", exception.getHttpMethod(), exception.getResourcePath());
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND,
+                "No endpoint " + exception.getHttpMethod() + " /" + exception.getResourcePath());
+        return ResponseEntity.status(ErrorCode.NOT_FOUND.getStatus()).body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/test/java/com/ppiyaki/common/exception/GlobalExceptionHandlerNotFoundE2ETest.java
+++ b/src/test/java/com/ppiyaki/common/exception/GlobalExceptionHandlerNotFoundE2ETest.java
@@ -1,0 +1,88 @@
+package com.ppiyaki.common.exception;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("404 응답 정규화 E2E")
+class GlobalExceptionHandlerNotFoundE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("permitAll 경로 내 미존재 GET → 404 NOT_FOUND")
+    void unknown_get_path_returns_404() {
+        RestAssured.given()
+                .when()
+                .get("/api/v1/auth/this-endpoint-does-not-exist")
+                .then()
+                .statusCode(404)
+                .body("error.code", is("COMMON_005"))
+                .body("error.message", containsString("auth/this-endpoint-does-not-exist"));
+    }
+
+    @Test
+    @DisplayName("permitAll 경로 내 미존재 POST (presigned-url 오타 케이스 모사) → 404 NOT_FOUND")
+    void unknown_post_path_returns_404() {
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("{}")
+                .when()
+                .post("/api/v1/auth/non-existent-resource-url")
+                .then()
+                .statusCode(404)
+                .body("error.code", is("COMMON_005"))
+                .body("error.message", containsString("auth/non-existent-resource-url"));
+    }
+
+    @Test
+    @DisplayName("인증된 사용자가 미존재 경로 호출 시 → 404 NOT_FOUND (운영 시나리오)")
+    void authenticated_unknown_path_returns_404() {
+        final String accessToken = signupAndGetToken();
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body("{}")
+                .when()
+                .post("/api/v1/uploads/presigned-url")
+                .then()
+                .statusCode(404)
+                .body("error.code", is("COMMON_005"))
+                .body("error.message", containsString("uploads/presigned-url"));
+    }
+
+    private String signupAndGetToken() {
+        final String loginId = "notfound" + System.nanoTime();
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "테스트"
+                        }
+                        """.formatted(loginId))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        return io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+    }
+}


### PR DESCRIPTION
## AS-IS
- 프론트가 잘못된 URL 호출 시 (예: `/api/v1/uploads/presigned-url` 오타) **500 COMMON_003 Internal server error** 응답
- 원인: `NoResourceFoundException`이 `GlobalExceptionHandler` 전용 핸들러 없어서 catch-all 500으로 fallback
- 디버깅 혼선 발생 (실제 사례: 직전 프론트 버그 리포트)

## TO-BE
- 라우팅 미스 → **404 COMMON_005 Resource not found** + 호출 경로가 메시지에 포함

## 변경 사항

- `ErrorCode.NOT_FOUND` 추가 (404, `COMMON_005`)
- `GlobalExceptionHandler`에 `@ExceptionHandler(NoResourceFoundException.class)` 추가
- 기존 `NoHandlerFoundException` 핸들러도 일관성 위해 404로 변경 (이전 400 `COMMON_002`)
- 로그 레벨 DEBUG (라우팅 미스는 일반적이라 ERROR 노이즈 제거)

## 테스트 (E2E)

1. permitAll 경로 내 미존재 GET → 404 + COMMON_005 + 경로 echo
2. permitAll 경로 내 미존재 POST → 404 + COMMON_005 + 경로 echo
3. 인증된 사용자가 미존재 경로 호출 (presigned-url 오타 모사) → 404 + COMMON_005

## 응답 예시

```json
{
  "error": {
    "code": "COMMON_005",
    "message": "No endpoint POST /api/v1/uploads/presigned-url",
    "status": 404
  },
  "success": false
}
```

## 보호 영역 / 라벨
- 보호 영역 변경 없음
- 라벨: `type:fix`, `scope:infra`, `ai-generated`

## AI 체크리스트
- [x] 에러 코드 추가 (`COMMON_005`)
- [x] 품질 게이트 통과 (`./gradlew checkstyleMain spotlessCheck test`)
- [ ] 도메인 문서 갱신 — **불필요** (인프라 핸들러 변경)
- [ ] Notion API 명세 갱신 — **불필요** (신규 엔드포인트 없음, 에러 응답 정규화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)