### PR TITLE
release: v0.8.1

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -77,6 +77,8 @@ jobs:
               -e CLOVA_OCR_SECRET='${{ secrets.CLOVA_OCR_SECRET }}' \
               -e CLOVA_OCR_INVOKE_URL='${{ secrets.CLOVA_OCR_INVOKE_URL }}' \
               -e OPENAI_API_KEY='${{ secrets.OPENAI_API_KEY }}' \
+              -e OPENAI_TEXT_MODEL='gpt-5.4-nano' \
+              -e OPENAI_VISION_MODEL='gpt-5.4-mini' \
               ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
             
             echo "Cleaning up old images..."

--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -102,6 +102,9 @@
 | dob | date | 생년월일 |
 | pet | bigint | `pets.id` PK 참조 (FK 제약 선언 여부는 §7-12) |
 | care_mode | varchar | DB는 varchar, Java는 `CareMode` enum(`MANAGED` default / `AUTONOMOUS`). 시니어 회원에 적용. 보호자 회원도 컬럼은 갖지만 처방전 흐름에서는 `prescription.owner_id`로 참조하는 시니어 측 값만 사용 |
+| breakfast_time | time nullable | 시니어 식사 시간대(아침). Java는 `LocalTime`. 미설정 가능. Phase 1: 클라이언트가 schedule 등록 시 활용. Phase 2~3: 슬롯 매핑/자동 생성 (별도 spec) |
+| lunch_time | time nullable | 시니어 식사 시간대(점심). 동일 |
+| dinner_time | time nullable | 시니어 식사 시간대(저녁). 동일 |
 | created_at / updated_at | timestamp | `BaseTimeEntity` |
 
 > **코드 갭(현재 HEAD 기준)**: 코드의 `User.java`는 `nickname`, `gender`, `dob`가 없고 `pet` 대신 `ppiyaki bigint` 컬럼명을 사용하며 `password`가 non-null. 이 문서는 **타깃 스키마**를 기술하며, 코드 갱신은 별도 PR로 진행한다. 추적: §7-16.
@@ -373,6 +376,9 @@ erDiagram
         date dob
         bigint pet FK
         varchar care_mode "MANAGED default / AUTONOMOUS"
+        time breakfast_time "nullable"
+        time lunch_time "nullable"
+        time dinner_time "nullable"
         timestamp created_at
         timestamp updated_at
     }

--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -568,7 +568,7 @@ erDiagram
 
 | # | 주제 | 현재 상태 |
 |---|---|---|
-| ~~7-9~~ | ~~약 개수 인식 세부~~ | ✅ **해소됨** (Phase 2, v0.8.0). gpt-5.4-nano Vision API 동기 검증으로 구현. 명세는 `docs/features/medication-log-phase2.md`. 알약 식별(Phase 3, #185)은 별도 spec에서 진행 |
+| ~~7-9~~ | ~~약 개수 인식 세부~~ | ✅ **해소됨** (Phase 2, v0.8.0). gpt-5.4-mini Vision API 동기 검증으로 구현 (2026-05-06 nano→mini 정확도 업그레이드). 명세는 `docs/features/medication-log-phase2.md`. 알약 식별(Phase 3, #185)은 별도 spec에서 진행 |
 | 7-23 | DB 마이그레이션 도구 도입 | **후순위.** 현재는 `src/main/resources/schema.sql`을 Hibernate metadata에서 추출해 운영 스키마를 관리. 운영 안정화 단계에서 Flyway/Liquibase 도입 검토. 도입 시 `application-prod.yml`의 `ddl-auto: validate` 정책과 부트스트랩 흐름(초기 schema.sql → migration baseline) 정리 필요 |
 
 ## 8) 외부 연동 인벤토리

--- a/docs/features/meal-time-defaults.md
+++ b/docs/features/meal-time-defaults.md
@@ -1,0 +1,170 @@
+---
+feature: 시니어 식사 시간대 기본값
+slug: meal-time-defaults
+status: draft
+owner: @goohong
+scope: user
+related_issues: [#221]
+related_prs: []
+last_reviewed: 2026-05-07
+---
+
+# 시니어 식사 시간대 기본값
+
+## 1) 개요 (What / Why)
+시니어가 평소 아침/점심/저녁 식사 시간을 사전 설정해두고, 처방전 기반 복약 일정 등록 시 이 시간대를 활용한다. 매번 약마다 수기로 시각을 입력하는 마찰을 줄이고, 향후 처방전 confirm 시 자동 schedule 생성의 기반 데이터를 마련한다.
+
+대상 사용자: 시니어 (본인 시간대 설정), 보호자 (조회만, 갱신은 시니어 본인).
+
+## 2) 사용자 시나리오
+- **온보딩**: 시니어가 회원가입 직후 아침 8시 / 점심 12시 30분 / 저녁 6시 30분으로 식사 시간을 설정한다.
+- **약 등록 흐름**: 시니어/보호자가 처방전 confirm 후 schedule 등록 화면에서, 약마다 "아침/점심/저녁" 슬롯을 고르면 프론트가 시니어의 mealTimes 값을 읽어 LocalTime을 채워 백엔드에 보낸다 (Phase 1 한정 — 백엔드는 슬롯 개념을 모름).
+- **수정**: 시니어가 식사 시간이 바뀌면 `PUT /api/v1/users/me/meal-times`로 3개 시각을 한 번에 갱신한다.
+
+## 3) 요구사항
+### 기능 요구사항
+- [ ] `User` 엔티티에 `breakfastTime` / `lunchTime` / `dinnerTime` (LocalTime, nullable) 필드 추가
+- [ ] `PUT /api/v1/users/me/meal-times` — 시니어 본인이 3개 시각을 한 번에 갱신 (전체 PUT, 3개 모두 필수)
+- [ ] `GET /api/v1/users/me` 응답에 `mealTimes` 객체 추가. 모두 미설정이면 `null`, 일부만 설정 가능
+- [ ] 권한: 시니어 본인만 갱신 (보호자 대리 갱신 불가, Phase 2 이후 검토)
+- [ ] DB 마이그레이션 SQL 준비, `schema.sql` 동기화
+
+### 비기능 요구사항
+- **성능**: 갱신/조회 모두 단일 user row 작업. 추가 인덱스 불필요.
+- **신뢰성**: 입력값 검증 — `LocalTime` 형식만 (00:00:00 ~ 23:59:59). 시각 간 순서(`breakfast < lunch < dinner`) 강제하지 않음 — 사용자 자율.
+- **보안**: 의료정보 아니므로 일반 사용자 데이터 정책. 로그에 시각 노출 OK.
+- **관측성**: 별도 메트릭 불필요. 일반 access log로 충분.
+
+## 4) 범위 / 비범위 (중요)
+
+### 포함
+- User에 시간대 컬럼 3개
+- 갱신/조회 API
+- 시니어 본인 권한 체크
+- 도메인 문서 + Notion API 명세 동기화
+- E2E 테스트 (성공 케이스 1개 이상)
+
+### 제외 (Out of Scope)
+- **`MealSlot` enum 도입** → Phase 2
+- **`MedicationSchedule`에 슬롯 매핑** → Phase 2
+- **시니어 시간 변경 시 기존 schedule cascade 갱신** → Phase 2
+- **처방전 confirm 시 schedule 자동 생성** → Phase 3
+- **OCR schedule 텍스트 → 슬롯 매핑 파서** → Phase 3
+- **보호자 대리 갱신** → 후속 결정
+- **`isOnboarded` 정의 변경** (mealTimes 미설정도 onboarded로 유지)
+- **시각 간 순서 검증** — 사용자 자율
+- **부분 갱신 (PATCH)** — Phase 1은 전체 PUT만
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+- 컨텍스트: `user` (참조: `docs/ai-harness/06-domain-model.md §5 users`)
+- `User`에 LocalTime 컬럼 3개 (`breakfast_time`, `lunch_time`, `dinner_time`, 모두 nullable)
+- 별도 테이블 도입 X — MVP 과잉. 향후 슬롯 추가(야간/간식) 필요 시 별도 테이블로 마이그레이션
+
+### 5-2) API 엔드포인트
+
+| Method | Path | 설명 | 인증 | Req | Res |
+|---|---|---|---|---|---|
+| PUT | `/api/v1/users/me/meal-times` | 시니어 본인의 식사 시간대 3개 일괄 갱신 | 필수 (시니어) | `MealTimesUpdateRequest` | `UserMeResponse` |
+| GET | `/api/v1/users/me` | 내 정보 + mealTimes (기존 엔드포인트 응답 확장) | 필수 | — | `UserMeResponse` |
+
+#### MealTimesUpdateRequest (전체 PUT, 3개 모두 필수)
+```json
+{
+  "breakfast": "08:00:00",
+  "lunch": "12:30:00",
+  "dinner": "18:30:00"
+}
+```
+- 모두 `@NotNull LocalTime` (jakarta.validation)
+- 형식: ISO-8601 LocalTime (`HH:mm:ss`)
+
+#### UserMeResponse (확장)
+```json
+{
+  "id": 16,
+  "nickname": "테스트시니어",
+  "role": "SENIOR",
+  "isOnboarded": true,
+  "mealTimes": {
+    "breakfast": "08:00:00",
+    "lunch": "12:30:00",
+    "dinner": "18:30:00"
+  }
+}
+```
+- `mealTimes`는 객체 — 3개 모두 미설정이면 `null` (객체 자체 누락), 일부만 설정 가능
+
+#### 에러 응답
+| 상황 | HTTP | code |
+|---|---|---|
+| 입력 누락/형식 오류 | 400 | `COMMON_001` |
+| 인증 없음/만료 | 401 | `AUTH_001` |
+| 권한 없음 (시니어가 아닌 경우 — Phase 1 한정) | 403 | `FORBIDDEN` (별도 로직 필요 시) |
+
+> **권한 검증 메모**: 본 PR 범위에서는 `@AuthenticationPrincipal Long userId`로 받은 사용자의 `me` 엔드포인트라 별도 시니어 검증 불필요. 보호자가 호출해도 자기 자신을 갱신하므로 무해. 단 보호자 mealTimes는 의미 없음 — Phase 2에서 슬롯 도입 시 시니어로 한정 검토.
+
+### 5-3) 외부 연동
+없음.
+
+### 5-4) 데이터 흐름
+```
+시니어 클라이언트
+  ↓ PUT /users/me/meal-times { breakfast, lunch, dinner }
+UserController.updateMealTimes(userId, request)
+  ↓
+UserService.updateMealTimes(userId, request)
+  ↓
+User.updateMealTimes(breakfast, lunch, dinner)
+  ↓ JPA dirty checking
+DB: UPDATE users SET breakfast_time=?, lunch_time=?, dinner_time=? WHERE id=?
+  ↓
+UserMeResponse.from(user)
+```
+
+### 5-5) DB 마이그레이션
+```sql
+ALTER TABLE users
+    ADD COLUMN breakfast_time TIME(6) NULL,
+    ADD COLUMN lunch_time TIME(6) NULL,
+    ADD COLUMN dinner_time TIME(6) NULL;
+```
+- prod NCP MySQL에 머지 직후 수동 실행 (보호 영역)
+- `src/main/resources/schema.sql`은 Hibernate가 생성한 `time(6)` 형식과 동일
+
+## 6) 작업 분할
+단일 PR로 진행 (Phase 1 자체가 작은 범위).
+
+- [ ] PR `feat(user)`:
+  - 엔티티 + 도메인 메서드
+  - DTO (request, response 갱신)
+  - Service + Controller 메서드
+  - 마이그레이션 SQL + schema.sql
+  - 도메인 문서 §5 갱신
+  - Notion API 명세 항목 (PUT 신규 / GET 갱신)
+  - E2E + 단위 테스트
+
+## 7) 테스트 전략
+- **단위 테스트**: `User.updateMealTimes` — null 거부, LocalTime 보관, 부분 변경 케이스
+- **E2E (RestAssured)**:
+  - 성공: 인증된 사용자 PUT → 200 → GET /users/me로 mealTimes 확인
+  - 입력 누락: 한 필드 빠지면 400
+  - 인증 없음: 401
+- 외부 연동 mock 불필요
+
+## 8) 오픈 질문
+
+| # | 질문 | 선택지 | 담당/기한 |
+|---|---|---|---|
+| Q1 | 보호자 대리 갱신 허용? | (a) Phase 1부터 보호자도 가능 / (b) Phase 1은 본인만, Phase 2에서 검토 | @goohong / Phase 2 진입 전 — **(b)로 잠정 결정** |
+| Q2 | 시각 간 순서 강제? | (a) breakfast<lunch<dinner / (b) 자율 | **(b) 자율 결정** — 사용자가 야간 근무 등 비전형 패턴 가질 수 있음 |
+| Q3 | 미설정 상태 표현 | (a) 3개 모두 null이면 mealTimes=null / (b) 항상 객체 반환 (필드별 null) | **(a) 결정** — 클라이언트 분기 단순 |
+
+## 9) 결정 로그
+- 2026-05-07: 초안 작성 (status=draft). Phase 1 범위 한정. Phase 2~3는 후속 spec.
+- 2026-05-07: **데이터 모델 = User 컬럼 3개**. 별도 테이블 도입 X. 이유: MVP 과잉. 향후 슬롯 확장(야간/간식) 시점에 마이그레이션 검토.
+- 2026-05-07: **전체 PUT 채택**. 부분 갱신(PATCH) 불채택. 이유: Phase 1 단순화. 사용자 사용 빈도 낮아 PATCH 가치 작음.
+- 2026-05-07: **시각 순서 검증 미도입**. 사용자 자율 (야간 근무 등 비전형 패턴 허용).
+- 2026-05-07: **보호자 대리 갱신 미포함**. Phase 1은 본인만. Phase 2 슬롯 도입 시점에 재검토.
+- 2026-05-07: **`isOnboarded` 정의 유지**. mealTimes 미설정도 onboarded. 시간대 설정 강제는 프론트 UX로 유도.

--- a/docs/features/medication-log-phase2.md
+++ b/docs/features/medication-log-phase2.md
@@ -36,8 +36,8 @@ last_reviewed: 2026-04-30
 - [ ] 결과를 `ai_status` 컬럼에 저장. 응답 DTO에 노출 (이미 Phase 1 응답에 `aiStatus` 필드 있음).
 
 ### 비기능 요구사항
-- **응답 시간**: 동기 처리. **실측 기반(2026-04-30 prod 서버에서 OpenAI Vision API 직접 호출): gpt-5.4-nano 평균 ~3s (1x1 더미 이미지), 실제 폰 카메라 사진은 ~4-6s 예상.** p50 ~3s / p95 ~6s 목표. 클라이언트 timeout 30s 권장.
-- **비용**: gpt-5.4-nano 호출당 약 0.4~1원 수준 추정 (이미지 토큰 포함). 처방전 OCR 비용 대비 차수 동일. 일일 트래픽 모니터링 권장.
+- **응답 시간**: 동기 처리. **실측 기반(2026-05-06 prod 서버에서 OpenAI Vision API 직접 호출): gpt-5.4-mini 평균 ~1.7s (custom 사진 3장 × 3-run), 실제 폰 카메라 사진은 ~3-5s 예상.** p50 ~2s / p95 ~5s 목표. 클라이언트 timeout 30s 권장.
+- **비용**: gpt-5.4-mini 호출당 약 2원 수준 추정 (이미지 토큰 포함). gpt-5.4-nano 대비 약 4-5배. MVP 단계 트래픽 작아 절대값 부담 미미. 일일 트래픽 모니터링 권장.
 - **보안**: 사진은 메모리에서만 처리 (이미 NCP S3에 저장된 것을 fetch). Vision API에 사용자 ID/PII 전송 안 함.
 - **타임아웃**: 서버측 30초 (Vision LLM 처리 시간 여유). 클라이언트 측 타임아웃 30초 이상 권장.
 - **민감정보 로깅 금지**: dosage·objectKey·결과 카운트는 로그에 남기지 않음 (id/userId만).
@@ -82,10 +82,10 @@ public enum LogAiStatus {
 ### 5-2) API 엔드포인트 변경
 **없음**. 기존 `PUT /api/v1/medication-logs` / `GET /api/v1/medication-logs` 응답에 `aiStatus`가 enum 값으로 채워질 뿐.
 
-### 5-3) 외부 연동 — OpenAI GPT-4o Vision
+### 5-3) 외부 연동 — OpenAI Vision
 
 - 엔드포인트: `https://api.openai.com/v1/chat/completions` (이미 사용 중)
-- 모델: **`gpt-5.4-nano`** — 프로젝트 표준 (prescription-ocr와 동일, `OpenAiProperties.model`로 주입). vision 입력 지원.
+- 모델: **`gpt-5.4-mini`** — `OpenAiProperties.visionModel`로 주입 (`OPENAI_VISION_MODEL` env, default `gpt-5.4-mini`). 텍스트 모델(`textModel`)과 분리 구성. vision 입력 지원.
 - 입력: `messages` 배열에 image_url(base64 data URL) + system prompt
 - 출력: JSON Mode로 `{"count": <integer>}` 강제. 파싱 실패 시 retry 1회.
 - System prompt 초안:
@@ -161,11 +161,12 @@ public enum LogAiStatus {
 | # | 질문 | 선택지 | 담당/기한 |
 |---|---|---|---|
 | Q1 | 동일 시각 정렬 허용 오차 | 동일 `scheduledTime` 정확 일치만 합산. 인접 시각 합산은 후속 | ✅ 결정 |
-| Q2 | gpt-5.4-nano vision 정확도 | 운영 데이터로 측정 후 모델 변경 여부 결정 | 운영 모니터링 |
+| ~~Q2~~ | ~~gpt-5.4-nano vision 정확도~~ | ✅ **해소됨** (2026-05-06). custom 사진 3장 × 3-run 정확도 테스트에서 nano가 정답 11→8로 misread. mini로 분리 업그레이드 (11/11/11 정확). 결정 로그 §9 참조 |
 
 ## 9) 결정 로그
 - 2026-04-30: 초안 작성. Phase 1 머지 직후 진행.
-- 2026-04-30: **Vision LLM = OpenAI gpt-5.4-nano** — 프로젝트 표준 모델 사용 (prescription-ocr와 동일). 기존 `OpenAiClient` + `OpenAiProperties.model` 인프라 그대로 확장. Clova Vision 미채택.
+- 2026-04-30: **Vision LLM = OpenAI gpt-5.4-nano** — 프로젝트 표준 모델 사용 (prescription-ocr와 동일). 기존 `OpenAiClient` + `OpenAiProperties.model` 인프라 그대로 확장. Clova Vision 미채택. (→ 2026-05-06 mini 업그레이드, 하단 참조)
+- 2026-05-06: **Vision LLM gpt-5.4-mini 업그레이드 + 텍스트 모델 분리** — 사용자 제공 custom 사진 3장 × 3-run 정확도 테스트에서 gpt-5.4-nano가 정답 11→8로 misread (재현 가능). gpt-4o(11/11/11) 동등 정확도 + 5.x 패밀리 유지 + 응답시간 ~1.7s + gpt-4o 대비 비용↓ 이유로 **gpt-5.4-mini 채택**. 텍스트 모델은 OCR 속도/비용 우선 고려해 nano 유지하고 `OpenAiProperties.textModel` / `visionModel`로 분리. env: `OPENAI_TEXT_MODEL` (default nano) / `OPENAI_VISION_MODEL` (default mini).
 - 2026-04-30: **동기 처리** — UX 단순성 우선. 실측 기반 p50 ~3s / p95 ~6s 응답 시간 감수. 시니어가 응답 받기 전 화면이 안 넘어가는 자연 차단 효과까지 부수적으로 확보. 비동기는 운영 트래픽 데이터 보고 후속 결정.
 - 2026-04-30: **트리거 = `photoObjectKey != null && status == TAKEN`** — 미복용/사진 없음은 검증 무의미.
 - 2026-04-30: **동일 시각 schedule 합산** — 시니어가 같은 시각에 여러 약 한 번에 촬영하는 실제 행동 패턴 정합.

--- a/docs/features/medicine-dur.md
+++ b/docs/features/medicine-dur.md
@@ -335,4 +335,5 @@ DurCheckService
 - 2026-04-15: **Layer 1 저장 방식 — 인메모리 우선, Redis TODO**. 이유: Redis 인프라 부담 회피, 단일 인스턴스 운영 중, 인터페이스 추상화(`MfdsResponseCache`)로 후속 Redis 스왑 용이. 마이그레이션 트리거: 다중 인스턴스 배포 / 엔트리 1만+ / 콜드 캐시 운영 비용 가시화. **TODO는 spec §5-3-A에 명시 유지**.
 - 2026-04-15: **Layer 2 무효화 방식 — `combo_hash` 포함 키**. 시니어가 약물을 추가/제거할 때 자동으로 캐시 미스. 단순 TTL만으로는 부정확하다는 판단.
 - 2026-04-16: **OpenAI 모델 맥락 공유** — prescription-ocr spec의 AI 모델이 gpt-4o-mini에서 gpt-5.4-nano로 변경됨 (OpenAI 라인업 변경, 단가: 입력 $0.20/1M, 출력 $1.25/1M). 본 spec(DUR)은 OpenAI를 직접 호출하지 않으나, prescription-ocr 통합 파이프라인과의 연계 구현 시 참고.
+- 2026-05-06: **OpenAI 모델 분리 구성 (맥락 공유)** — `OpenAiProperties.model`이 `textModel`/`visionModel`로 분리. text(prescription-ocr)는 nano 유지, vision(medication-log-phase2)은 mini 업그레이드. 본 spec은 영향 없음.
 - 2026-04-16: **구현 순서 확정** — ① item_seq 컬럼 추가 → ② medicine-search (+ medicine-dur 병렬 가능) → ③ medicine-dur (현재 spec) → ④ prescription-ocr 통합본 → ⑤ mcp-server-foundation. medicine-search와 병렬 진행 가능.

--- a/docs/features/prescription-ocr.md
+++ b/docs/features/prescription-ocr.md
@@ -197,7 +197,7 @@ function checkPrescriptionMutation(requesterId, prescription):
 - 인증: `OPENAI_API_KEY` 환경변수
 - 입력: 시스템 prompt(약물 추출 지시) + 마스킹된 OCR 텍스트
 - 출력: JSON Mode 활성화로 약물 후보 리스트 강제
-- 모델: **gpt-5.4-nano** (잠정 확정). 단가: 입력 $0.20/1M, 출력 $1.25/1M → 건당 약 0.4원
+- 모델: **gpt-5.4-nano** (`OpenAiProperties.textModel`로 주입, env `OPENAI_TEXT_MODEL`). vision 모델(`visionModel`, gpt-5.4-mini)과 분리 구성. 단가: 입력 $0.20/1M, 출력 $1.25/1M → 건당 약 0.4원
 - 타임아웃: 10s (LLM은 5s보다 여유)
 - 실패 처리: 동일
 
@@ -392,3 +392,4 @@ function checkPrescriptionMutation(requesterId, prescription):
 - 2026-04-16: **검색 전략 변경** — 약물명 검색 실패 시 prefix 축소 fallback 제거, `ingredientName` fallback 검색으로 대체. 성분명 동일 약물 후보군 반환 → `CANDIDATES` 결과로 처리.
 - 2026-04-30: **보호자 수동 약물 추가 정책 확정** (Q-CONF-3 해소) — (a) 후보에 추가만, confirm 시점에 Medicine 일괄 생성. itemSeq + itemName 둘 다 클라이언트 전송 (서버측 itemSeq → itemName 조회 인프라 부재). PR #188로 머지.
 - 2026-04-30: **보호자 승인 모드 도입** (Q-CONF-5 해소) — `User.careMode` enum 컬럼 (`MANAGED` default / `AUTONOMOUS`). 모드 변경은 `PUT /api/v1/users/{seniorId}/care-mode` — **보호자만 호출 가능**, 시니어 본인 셀프 변경 엔드포인트 두지 않음. 처방전 변경 엔드포인트 4건(`PATCH /medicines/{candidateId}`, `POST /medicines`, `POST /confirm`, `POST /reject`)에 모드 분기 적용. AUTONOMOUS는 시니어/보호자 모두 즉시 가능, MANAGED는 0~72h 보호자만 + 72h 후 시니어 fallback. 보호자 미연동 시니어는 spec 범위 외 (보호자 연동 전제 유지). 의도: spec의 "보호자 검증 강제"가 코드에서 사실상 동작하지 않던 상태를 명시적 권한 모델로 끌어올림.
+- 2026-05-06: **OpenAI 모델 분리 구성 도입** — `OpenAiProperties`를 `model` 단일 필드에서 `textModel` / `visionModel` 두 필드로 분리. 본 spec(텍스트 OCR)은 **gpt-5.4-nano 유지** (속도/비용 우선, 품질은 운영상 충분). vision(`medication-log-phase2` 약 개수 인식)은 정확도 검증 결과로 **gpt-5.4-mini 업그레이드**. env 변수: `OPENAI_TEXT_MODEL` (default nano) / `OPENAI_VISION_MODEL` (default mini). 본 spec의 텍스트 OCR은 별도 정확도 회귀 테스트 안 함 — 운영 모니터링으로 추적.

--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -49,8 +49,7 @@ public class OpenAiClient {
         final long startTime = System.currentTimeMillis();
 
         try {
-            final String model = properties.model() != null ? properties.model() : "gpt-5.4-nano";
-            final String requestBody = buildRequest(model, maskedOcrText);
+            final String requestBody = buildRequest(properties.textModel(), maskedOcrText);
 
             final String responseBody = restClient.post()
                     .uri(API_URL)
@@ -181,8 +180,7 @@ public class OpenAiClient {
         for (int attempt = 1; attempt <= 2; attempt++) {
             final long startTime = System.currentTimeMillis();
             try {
-                final String model = properties.model() != null ? properties.model() : "gpt-5.4-nano";
-                final String requestBody = buildCountRequest(model, imageBytes, mediaType);
+                final String requestBody = buildCountRequest(properties.visionModel(), imageBytes, mediaType);
 
                 final String responseBody = restClient.post()
                         .uri(API_URL)

--- a/src/main/java/com/ppiyaki/common/ai/OpenAiProperties.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiProperties.java
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 @ConditionalOnProperty(prefix = "openai", name = "api-key")
 public record OpenAiProperties(
         @NotBlank String apiKey,
-        String model
+        @NotBlank String textModel,
+        @NotBlank String visionModel
 ) {
 }

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     MALFORMED_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_002", "Malformed request"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_003", "Internal server error"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_004", "Access denied"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_005", "Resource not found"),
 
     // Auth
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "Invalid token"),

--- a/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -66,9 +67,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoHandlerFound(final NoHandlerFoundException exception) {
         log.debug("No handler found: {}", exception.getMessage());
-        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MALFORMED_REQUEST,
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND,
                 "No endpoint " + exception.getHttpMethod() + " " + exception.getRequestURL());
-        return ResponseEntity.status(ErrorCode.MALFORMED_REQUEST.getStatus()).body(errorResponse);
+        return ResponseEntity.status(ErrorCode.NOT_FOUND.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFound(final NoResourceFoundException exception) {
+        log.debug("No resource found: {} {}", exception.getHttpMethod(), exception.getResourcePath());
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND,
+                "No endpoint " + exception.getHttpMethod() + " /" + exception.getResourcePath());
+        return ResponseEntity.status(ErrorCode.NOT_FOUND.getStatus()).body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -52,6 +53,15 @@ public class User extends BaseTimeEntity {
     @Column(name = "care_mode", nullable = false)
     private CareMode careMode;
 
+    @Column(name = "breakfast_time")
+    private LocalTime breakfastTime;
+
+    @Column(name = "lunch_time")
+    private LocalTime lunchTime;
+
+    @Column(name = "dinner_time")
+    private LocalTime dinnerTime;
+
     public User(
             final String loginId,
             final String password,
@@ -73,5 +83,15 @@ public class User extends BaseTimeEntity {
 
     public void changeCareMode(final CareMode careMode) {
         this.careMode = Objects.requireNonNull(careMode, "careMode must not be null");
+    }
+
+    public void updateMealTimes(
+            final LocalTime breakfastTime,
+            final LocalTime lunchTime,
+            final LocalTime dinnerTime
+    ) {
+        this.breakfastTime = Objects.requireNonNull(breakfastTime, "breakfastTime must not be null");
+        this.lunchTime = Objects.requireNonNull(lunchTime, "lunchTime must not be null");
+        this.dinnerTime = Objects.requireNonNull(dinnerTime, "dinnerTime must not be null");
     }
 }

--- a/src/main/java/com/ppiyaki/user/controller/UserController.java
+++ b/src/main/java/com/ppiyaki/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.ppiyaki.user.controller;
 
 import com.ppiyaki.user.controller.dto.CareModeResponse;
 import com.ppiyaki.user.controller.dto.CareModeUpdateRequest;
+import com.ppiyaki.user.controller.dto.MealTimesUpdateRequest;
+import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -29,5 +31,13 @@ public class UserController {
             @Valid @RequestBody final CareModeUpdateRequest request
     ) {
         return ResponseEntity.ok(userService.updateCareMode(requesterId, seniorId, request.careMode()));
+    }
+
+    @PutMapping("/me/meal-times")
+    public ResponseEntity<UserMeResponse> updateMealTimes(
+            @AuthenticationPrincipal final Long userId,
+            @Valid @RequestBody final MealTimesUpdateRequest request
+    ) {
+        return ResponseEntity.ok(userService.updateMealTimes(userId, request));
     }
 }

--- a/src/main/java/com/ppiyaki/user/controller/dto/MealTimesResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/MealTimesResponse.java
@@ -1,0 +1,23 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ppiyaki.user.User;
+import java.time.LocalTime;
+
+public record MealTimesResponse(
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime breakfast,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime lunch,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime dinner
+) {
+
+    public static MealTimesResponse from(final User user) {
+        if (user.getBreakfastTime() == null
+                && user.getLunchTime() == null
+                && user.getDinnerTime() == null) {
+            return null;
+        }
+        return new MealTimesResponse(user.getBreakfastTime(), user.getLunchTime(), user.getDinnerTime());
+    }
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/MealTimesUpdateRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/MealTimesUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalTime;
+
+public record MealTimesUpdateRequest(
+        @NotNull @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime breakfast,
+
+        @NotNull @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime lunch,
+
+        @NotNull @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss") LocalTime dinner
+) {
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/UserMeResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/UserMeResponse.java
@@ -6,12 +6,14 @@ public record UserMeResponse(
         Long id,
         String nickname,
         String role,
-        boolean isOnboarded
+        boolean isOnboarded,
+        MealTimesResponse mealTimes
 ) {
 
     public static UserMeResponse from(final User user) {
         final String roleName = user.getRole() != null ? user.getRole().name() : null;
         final boolean onboarded = user.getRole() != null;
-        return new UserMeResponse(user.getId(), user.getNickname(), roleName, onboarded);
+        final MealTimesResponse mealTimes = MealTimesResponse.from(user);
+        return new UserMeResponse(user.getId(), user.getNickname(), roleName, onboarded, mealTimes);
     }
 }

--- a/src/main/java/com/ppiyaki/user/service/UserService.java
+++ b/src/main/java/com/ppiyaki/user/service/UserService.java
@@ -5,6 +5,8 @@ import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.user.CareMode;
 import com.ppiyaki.user.User;
 import com.ppiyaki.user.controller.dto.CareModeResponse;
+import com.ppiyaki.user.controller.dto.MealTimesUpdateRequest;
+import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -38,5 +40,14 @@ public class UserService {
 
         senior.changeCareMode(careMode);
         return new CareModeResponse(senior.getId(), senior.getCareMode());
+    }
+
+    @Transactional
+    public UserMeResponse updateMealTimes(final Long userId, final MealTimesUpdateRequest request) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        user.updateMealTimes(request.breakfast(), request.lunch(), request.dinner());
+        return UserMeResponse.from(user);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,4 +54,5 @@ mfds:
     read-timeout: 5000
 
 openai:
-  model: gpt-5.4-nano
+  text-model: ${OPENAI_TEXT_MODEL:gpt-5.4-nano}
+  vision-model: ${OPENAI_VISION_MODEL:gpt-5.4-mini}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -145,6 +145,9 @@
 
     create table users (
         dob date,
+        breakfast_time time(6),
+        lunch_time time(6),
+        dinner_time time(6),
         created_at datetime(6),
         id bigint not null auto_increment,
         pet bigint,

--- a/src/test/java/com/ppiyaki/common/exception/GlobalExceptionHandlerNotFoundE2ETest.java
+++ b/src/test/java/com/ppiyaki/common/exception/GlobalExceptionHandlerNotFoundE2ETest.java
@@ -1,0 +1,88 @@
+package com.ppiyaki.common.exception;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("404 응답 정규화 E2E")
+class GlobalExceptionHandlerNotFoundE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("permitAll 경로 내 미존재 GET → 404 NOT_FOUND")
+    void unknown_get_path_returns_404() {
+        RestAssured.given()
+                .when()
+                .get("/api/v1/auth/this-endpoint-does-not-exist")
+                .then()
+                .statusCode(404)
+                .body("error.code", is("COMMON_005"))
+                .body("error.message", containsString("auth/this-endpoint-does-not-exist"));
+    }
+
+    @Test
+    @DisplayName("permitAll 경로 내 미존재 POST (presigned-url 오타 케이스 모사) → 404 NOT_FOUND")
+    void unknown_post_path_returns_404() {
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("{}")
+                .when()
+                .post("/api/v1/auth/non-existent-resource-url")
+                .then()
+                .statusCode(404)
+                .body("error.code", is("COMMON_005"))
+                .body("error.message", containsString("auth/non-existent-resource-url"));
+    }
+
+    @Test
+    @DisplayName("인증된 사용자가 미존재 경로 호출 시 → 404 NOT_FOUND (운영 시나리오)")
+    void authenticated_unknown_path_returns_404() {
+        final String accessToken = signupAndGetToken();
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body("{}")
+                .when()
+                .post("/api/v1/uploads/presigned-url")
+                .then()
+                .statusCode(404)
+                .body("error.code", is("COMMON_005"))
+                .body("error.message", containsString("uploads/presigned-url"));
+    }
+
+    private String signupAndGetToken() {
+        final String loginId = "notfound" + System.nanoTime();
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "테스트"
+                        }
+                        """.formatted(loginId))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        return io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+    }
+}

--- a/src/test/java/com/ppiyaki/user/UserMealTimesTest.java
+++ b/src/test/java/com/ppiyaki/user/UserMealTimesTest.java
@@ -1,0 +1,107 @@
+package com.ppiyaki.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("User.mealTimes")
+class UserMealTimesTest {
+
+    @Test
+    @DisplayName("신규 User는 식사 시간 3개가 모두 null이다")
+    void 신규_유저_mealTimes_null() {
+        // when
+        final User user = newUser();
+
+        // then
+        assertThat(user.getBreakfastTime()).isNull();
+        assertThat(user.getLunchTime()).isNull();
+        assertThat(user.getDinnerTime()).isNull();
+    }
+
+    @Test
+    @DisplayName("updateMealTimes로 3개 시각을 한 번에 설정할 수 있다")
+    void updateMealTimes_정상() {
+        // given
+        final User user = newUser();
+        final LocalTime breakfast = LocalTime.of(8, 0);
+        final LocalTime lunch = LocalTime.of(12, 30);
+        final LocalTime dinner = LocalTime.of(18, 30);
+
+        // when
+        user.updateMealTimes(breakfast, lunch, dinner);
+
+        // then
+        assertThat(user.getBreakfastTime()).isEqualTo(breakfast);
+        assertThat(user.getLunchTime()).isEqualTo(lunch);
+        assertThat(user.getDinnerTime()).isEqualTo(dinner);
+    }
+
+    @Test
+    @DisplayName("updateMealTimes는 breakfast가 null이면 NPE")
+    void updateMealTimes_breakfast_null_거부() {
+        // given
+        final User user = newUser();
+
+        // when & then
+        assertThatThrownBy(() -> user.updateMealTimes(null, LocalTime.of(12, 0), LocalTime.of(18, 0)))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("breakfastTime");
+    }
+
+    @Test
+    @DisplayName("updateMealTimes는 lunch가 null이면 NPE")
+    void updateMealTimes_lunch_null_거부() {
+        // given
+        final User user = newUser();
+
+        // when & then
+        assertThatThrownBy(() -> user.updateMealTimes(LocalTime.of(8, 0), null, LocalTime.of(18, 0)))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("lunchTime");
+    }
+
+    @Test
+    @DisplayName("updateMealTimes는 dinner가 null이면 NPE")
+    void updateMealTimes_dinner_null_거부() {
+        // given
+        final User user = newUser();
+
+        // when & then
+        assertThatThrownBy(() -> user.updateMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 0), null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("dinnerTime");
+    }
+
+    @Test
+    @DisplayName("updateMealTimes는 호출 시마다 값을 덮어쓴다")
+    void updateMealTimes_가역() {
+        // given
+        final User user = newUser();
+        user.updateMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 0), LocalTime.of(18, 0));
+
+        // when
+        user.updateMealTimes(LocalTime.of(7, 30), LocalTime.of(13, 0), LocalTime.of(19, 30));
+
+        // then
+        assertThat(user.getBreakfastTime()).isEqualTo(LocalTime.of(7, 30));
+        assertThat(user.getLunchTime()).isEqualTo(LocalTime.of(13, 0));
+        assertThat(user.getDinnerTime()).isEqualTo(LocalTime.of(19, 30));
+    }
+
+    private User newUser() {
+        return new User(
+                "loginid",
+                "password",
+                UserRole.SENIOR,
+                "테스트유저",
+                Gender.UNKNOWN,
+                LocalDate.of(1950, 1, 1),
+                null
+        );
+    }
+}

--- a/src/test/java/com/ppiyaki/user/controller/MealTimesControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/MealTimesControllerE2ETest.java
@@ -1,0 +1,150 @@
+package com.ppiyaki.user.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("PUT /api/v1/users/me/meal-times E2E")
+class MealTimesControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private static long userSequence = 800000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("인증된 사용자가 식사 시간 3개를 PUT 하면 200 + 응답에 mealTimes 포함 + DB 반영")
+    void update_meal_times_success() {
+        // given
+        final SignupResult user = signup("시니어A");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + user.accessToken())
+                .body("""
+                        {
+                            "breakfast": "08:00:00",
+                            "lunch": "12:30:00",
+                            "dinner": "18:30:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/me/meal-times")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(user.userId().intValue()))
+                .body("mealTimes.breakfast", is("08:00:00"))
+                .body("mealTimes.lunch", is("12:30:00"))
+                .body("mealTimes.dinner", is("18:30:00"));
+
+        final User reloaded = userRepository.findById(user.userId()).orElseThrow();
+        assertThat(reloaded.getBreakfastTime()).isEqualTo(LocalTime.of(8, 0));
+        assertThat(reloaded.getLunchTime()).isEqualTo(LocalTime.of(12, 30));
+        assertThat(reloaded.getDinnerTime()).isEqualTo(LocalTime.of(18, 30));
+    }
+
+    @Test
+    @DisplayName("미설정 사용자가 GET /users/me 호출 시 mealTimes는 null")
+    void get_me_returns_null_meal_times_when_unset() {
+        // given
+        final SignupResult user = signup("시니어B");
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + user.accessToken())
+                .when()
+                .get("/api/v1/users/me")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(user.userId().intValue()))
+                .body("mealTimes", nullValue());
+    }
+
+    @Test
+    @DisplayName("breakfast 누락 시 400")
+    void breakfast_missing_rejected() {
+        // given
+        final SignupResult user = signup("시니어C");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + user.accessToken())
+                .body("""
+                        {
+                            "lunch": "12:30:00",
+                            "dinner": "18:30:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/me/meal-times")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("인증 없이 PUT 호출 시 401")
+    void unauthenticated_rejected() {
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "breakfast": "08:00:00",
+                            "lunch": "12:30:00",
+                            "dinner": "18:30:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/me/meal-times")
+                .then()
+                .statusCode(401);
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "mealtime" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}


### PR DESCRIPTION
## v0.8.1 — 시니어 식사 시간대 저장 + Vision 모델 분리 + 404 응답 정규화

### feat
- **`feat(user)`: 시니어 식사 시간대(아침/점심/저녁) 저장 API 추가 (#222, Phase 1 of #221)** — `User`에 `breakfast_time`/`lunch_time`/`dinner_time` LocalTime nullable 컬럼 추가. `PUT /api/v1/users/me/meal-times`로 시니어 본인이 3개 시각을 한 번에 갱신. `GET /api/v1/users/me` 응답에 `mealTimes` 객체 포함 (미설정 시 null). Phase 2~3(MealSlot enum, schedule 슬롯 매핑, 처방전 confirm 자동 schedule 생성)은 후속 spec.

### fix
- **`fix(infra)`: 라우팅 미스 응답 404 NOT_FOUND로 정규화 (#223)** — 잘못된 URL 호출 시 500 COMMON_003 → 404 COMMON_005. `NoResourceFoundException` / `NoHandlerFoundException` 핸들러 추가. 디버깅 시 라우팅 실수와 서버 오류 구분 가능.

### refactor
- **`refactor(infra)`: Vision 모델 gpt-5.4-mini 업그레이드 + 텍스트/비전 모델 분리 (#220)** — `OpenAiProperties`를 `textModel`(default `gpt-5.4-nano`) / `visionModel`(default `gpt-5.4-mini`) 두 필드로 분리. 약 개수 vision은 정확도 검증 결과 mini로 업그레이드, 처방전 OCR 텍스트는 속도/비용 우선으로 nano 유지. env: `OPENAI_TEXT_MODEL` / `OPENAI_VISION_MODEL`.

### prod 마이그레이션 (이미 적용됨)
```sql
ALTER TABLE users
    ADD COLUMN breakfast_time TIME(6) NULL,
    ADD COLUMN lunch_time TIME(6) NULL,
    ADD COLUMN dinner_time TIME(6) NULL;
```
2026-05-07 NCP MySQL prod에 사전 적용 완료. 본 릴리즈로 코드 측 schema 검증 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)