### PR TITLE
feat(prescription): 처방전 후보에 식사 슬롯 제안/확정 필드 — 시간대 Phase 3 PR 2

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -66,6 +66,8 @@
 | 약물 | Medicine | 처방전에서 파생되거나 수동 등록된 복용 대상 |
 | 복약 일정 | Medication Schedule | 특정 약물을 어떤 식사 슬롯에 복용할지(`meal_slot`, `dosage`). 실제 시각은 시니어 mealTimes로 동적 계산 |
 | 식사 슬롯 | Meal Slot | 복약 일정이 묶이는 식사 단위. `BREAKFAST`/`LUNCH`/`DINNER`. 실제 시각은 시니어의 `breakfast_time`/`lunch_time`/`dinner_time`을 매번 참조 |
+| 제안 슬롯 | Suggested Meal Slots | OCR 시점에 LLM이 처방전 복약주기 텍스트로부터 제안한 식사 슬롯 후보. `prescription_medicine_candidates.suggested_meal_slots`(CSV)에 저장. 보호자 검수의 출발점 (Phase 3) |
+| 확정 슬롯 | Confirmed Meal Slots | 보호자가 검수·확정한 식사 슬롯. `prescription_medicine_candidates.confirmed_meal_slots`(CSV). confirm 시 슬롯별 `medication_schedules` 자동 생성에 사용 (Phase 3) |
 | 복약 기록 | Medication Log | 실제 복용 이행 여부 기록 (`status`, `ai_status`) |
 | 복약 상태 | Log Status | 복약 기록의 사용자 확정 상태. `TAKEN` / `MISSED` / `PENDING`. `medication_logs.status`에 enum 매핑 |
 | AI 검증 상태 | Log AI Status | 복약 인증 사진 약 개수 AI 검증 결과. `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED`. `medication_logs.ai_status`에 enum 매핑 (Phase 2). 사진 + status=TAKEN일 때만 채워짐 |
@@ -184,6 +186,8 @@ OCR + LLM 파싱으로 추출된 약물 후보. 처방전 1건당 N행. 보호�
 | caregiver_chosen_item_seq | varchar nullable | 보호자가 직접 선택한 품목 일련번호 (MODIFIED 시) |
 | reviewed_at | datetime nullable | 보호자 검토 완료 시각 |
 | created_medicine_id | bigint nullable | 확정 후 생성된 `medicines.id` 참조 |
+| suggested_meal_slots | varchar(64) nullable | LLM이 제안한 식사 슬롯 CSV (예: `BREAKFAST,LUNCH,DINNER`). 식사 무관/불명확이면 null. Phase 3 |
+| confirmed_meal_slots | varchar(64) nullable | 보호자가 확정한 식사 슬롯 CSV. confirm 시 슬롯별 `medication_schedules` 자동 생성. Phase 3 |
 | created_at | timestamp | `CreatedTimeEntity` |
 
 > **코드 갭**: 신규 엔티티 — 엔티티 클래스 및 마이그레이션 미구현. 추적: §7-A 항목 추가.
@@ -432,6 +436,8 @@ erDiagram
         varchar caregiver_chosen_item_seq "nullable"
         datetime reviewed_at "nullable"
         bigint created_medicine_id FK "nullable"
+        varchar suggested_meal_slots "nullable, CSV"
+        varchar confirmed_meal_slots "nullable, CSV"
         timestamp created_at
     }
     medicines {

--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.medication.MealSlot;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -98,7 +99,7 @@ public class OpenAiClient {
                     - 약물이 없으면 빈 배열 반환.
 
                     ## 출력 형식
-                    {"medicines": [{"name": "약물명", "manufacturer": "제약사명", "ingredientName": "성분명", "dosage": "용량", "schedule": "복약주기"}]}
+                    {"medicines": [{"name": "약물명", "manufacturer": "제약사명", "ingredientName": "성분명", "dosage": "용량", "schedule": "복약주기", "mealSlots": ["BREAKFAST","LUNCH","DINNER"]}]}
                     - name: 제품명+제형+용량. 제약사명과 괄호 안 내용은 **제외**.
                       예: "위더스세파클러캡슐250밀리그람" → name: "세파클러캡슐250밀리그람", manufacturer: "위더스"
                       예: "에빅사정(메만틴염산염)_(10mg/1정)" → name: "에빅사정10밀리그램"
@@ -110,6 +111,15 @@ public class OpenAiClient {
                       주의: "(10mg/1정)" 같은 용량 표기는 성분명이 아님. 성분명은 한글 화학명.
                     - dosage: 1회 투약량 (예: "1정", "0.5정", "2캡슐"). 모르면 null.
                     - schedule: 복약주기 (예: "1일 3회 식후 30분"). 모르면 null.
+                    - mealSlots: schedule을 식사 슬롯으로 매핑한 배열. 가능한 값은 "BREAKFAST", "LUNCH", "DINNER"만.
+                      매핑 규칙:
+                      * "1일 3회 식후/식전" → ["BREAKFAST","LUNCH","DINNER"]
+                      * "1일 2회 (아침/저녁 또는 식후)" → ["BREAKFAST","DINNER"]
+                      * "1일 1회 아침" → ["BREAKFAST"]
+                      * "1일 1회 점심/저녁" → ["LUNCH"] / ["DINNER"]
+                      * "취침 전", "공복", "필요시" 등 식사 무관/불명확 → 빈 배열 []
+                      * schedule이 null이거나 슬롯 판단 불가 → 빈 배열 []
+                      * 다른 enum 값(예: "BEDTIME") 추측 금지 — 빈 배열로.
                     - JSON만 반환. 다른 텍스트 없이.
                     """;
 
@@ -154,7 +164,8 @@ public class OpenAiClient {
                         item.path("manufacturer").asText(null),
                         item.path("ingredientName").asText(null),
                         item.path("dosage").asText(null),
-                        item.path("schedule").asText(null)
+                        item.path("schedule").asText(null),
+                        parseMealSlots(item.path("mealSlots"))
                 ));
             }
 
@@ -165,6 +176,28 @@ public class OpenAiClient {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
                     "AI response parse failed: " + e.getMessage());
         }
+    }
+
+    /**
+     * LLM 응답의 mealSlots 배열을 MealSlot 리스트로 정규화.
+     * 누락/null/잘못된 enum 값은 빈 리스트로.
+     */
+    private static List<MealSlot> parseMealSlots(final JsonNode node) {
+        if (node == null || node.isMissingNode() || !node.isArray()) {
+            return List.of();
+        }
+        final List<MealSlot> slots = new ArrayList<>();
+        for (final JsonNode item : node) {
+            if (!item.isTextual()) {
+                continue;
+            }
+            try {
+                slots.add(MealSlot.valueOf(item.asText().trim()));
+            } catch (final IllegalArgumentException ignored) {
+                // 잘못된 enum 값은 무시
+            }
+        }
+        return slots;
     }
 
     /**
@@ -257,7 +290,8 @@ public class OpenAiClient {
             String manufacturer,
             String ingredientName,
             String dosage,
-            String schedule
+            String schedule,
+            List<MealSlot> mealSlots
     ) {
     }
 }

--- a/src/main/java/com/ppiyaki/medication/MealSlot.java
+++ b/src/main/java/com/ppiyaki/medication/MealSlot.java
@@ -2,7 +2,10 @@ package com.ppiyaki.medication;
 
 import com.ppiyaki.user.User;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public enum MealSlot {
     BREAKFAST,
@@ -16,5 +19,31 @@ public enum MealSlot {
             case LUNCH -> user.getLunchTime();
             case DINNER -> user.getDinnerTime();
         };
+    }
+
+    public static List<MealSlot> parseCsv(final String csv) {
+        if (csv == null || csv.isBlank()) {
+            return List.of();
+        }
+        final List<MealSlot> result = new ArrayList<>();
+        for (final String token : csv.split(",")) {
+            final String trimmed = token.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            try {
+                result.add(MealSlot.valueOf(trimmed));
+            } catch (final IllegalArgumentException ignored) {
+                // 잘못된 enum 값은 무시 (LLM 응답 정규화)
+            }
+        }
+        return result;
+    }
+
+    public static String toCsv(final List<MealSlot> slots) {
+        if (slots == null || slots.isEmpty()) {
+            return null;
+        }
+        return slots.stream().map(MealSlot::name).collect(Collectors.joining(","));
     }
 }

--- a/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
+++ b/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.prescription;
 
 import com.ppiyaki.common.entity.CreatedTimeEntity;
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medicine.service.MatchType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -11,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -67,6 +69,12 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
     @Column(name = "created_medicine_id")
     private Long createdMedicineId;
 
+    @Column(name = "suggested_meal_slots", length = 64)
+    private String suggestedMealSlots;
+
+    @Column(name = "confirmed_meal_slots", length = 64)
+    private String confirmedMealSlots;
+
     private static final String MANUAL_ADD_REASON = "보호자 수동 추가";
     private static final String MANUAL_ADD_RAW_TEXT = "보호자 수동 추가";
 
@@ -79,7 +87,8 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
             final String matchedItemSeq,
             final String matchedItemName,
             final MatchType matchType,
-            final String matchReason
+            final String matchReason,
+            final List<MealSlot> suggestedMealSlots
     ) {
         this.prescriptionId = Objects.requireNonNull(prescriptionId, "prescriptionId must not be null");
         this.ocrRawText = ocrRawText;
@@ -91,6 +100,7 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
         this.matchType = matchType;
         this.matchReason = matchReason;
         this.caregiverDecision = CaregiverDecision.PENDING;
+        this.suggestedMealSlots = MealSlot.toCsv(suggestedMealSlots);
     }
 
     public static PrescriptionMedicineCandidate manualAdd(
@@ -111,7 +121,8 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
                 itemSeq,
                 itemName,
                 MatchType.EXACT,
-                MANUAL_ADD_REASON
+                MANUAL_ADD_REASON,
+                List.of()
         );
         candidate.caregiverDecision = CaregiverDecision.ACCEPTED;
         candidate.caregiverChosenItemSeq = itemSeq;
@@ -137,5 +148,17 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
 
     public void linkMedicine(final Long medicineId) {
         this.createdMedicineId = medicineId;
+    }
+
+    public void updateConfirmedMealSlots(final List<MealSlot> slots) {
+        this.confirmedMealSlots = MealSlot.toCsv(slots);
+    }
+
+    public List<MealSlot> getSuggestedMealSlotsList() {
+        return MealSlot.parseCsv(this.suggestedMealSlots);
+    }
+
+    public List<MealSlot> getConfirmedMealSlotsList() {
+        return MealSlot.parseCsv(this.confirmedMealSlots);
     }
 }

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
@@ -1,10 +1,13 @@
 package com.ppiyaki.prescription.controller.dto;
 
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.prescription.CaregiverDecision;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 public record CandidateDecisionRequest(
         @NotNull CaregiverDecision decision,
-        String chosenItemSeq
+        String chosenItemSeq,
+        List<MealSlot> confirmedMealSlots
 ) {
 }

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineCandidateResponse.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineCandidateResponse.java
@@ -1,6 +1,8 @@
 package com.ppiyaki.prescription.controller.dto;
 
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.prescription.PrescriptionMedicineCandidate;
+import java.util.List;
 
 public record PrescriptionMedicineCandidateResponse(
         Long id,
@@ -14,7 +16,9 @@ public record PrescriptionMedicineCandidateResponse(
         String matchReason,
         String caregiverDecision,
         String caregiverChosenItemSeq,
-        Long createdMedicineId
+        Long createdMedicineId,
+        List<MealSlot> suggestedMealSlots,
+        List<MealSlot> confirmedMealSlots
 ) {
 
     public static PrescriptionMedicineCandidateResponse from(final PrescriptionMedicineCandidate candidate) {
@@ -30,7 +34,9 @@ public record PrescriptionMedicineCandidateResponse(
                 candidate.getMatchReason(),
                 candidate.getCaregiverDecision().name(),
                 candidate.getCaregiverChosenItemSeq(),
-                candidate.getCreatedMedicineId()
+                candidate.getCreatedMedicineId(),
+                candidate.getSuggestedMealSlotsList(),
+                candidate.getConfirmedMealSlotsList()
         );
     }
 }

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -142,7 +142,8 @@ public class PrescriptionService {
                         matched != null ? matched.itemSeq() : null,
                         matched != null ? matched.itemName() : null,
                         matchResult.matchType(),
-                        matchResult.reason()
+                        matchResult.reason(),
+                        med.mealSlots()
                 ));
             }
 
@@ -197,6 +198,10 @@ public class PrescriptionService {
             case REJECTED -> candidate.reject();
             case MANUALLY_CORRECTED -> candidate.correctManually(request.chosenItemSeq());
             default -> throw new BusinessException(ErrorCode.INVALID_INPUT, "Invalid decision: " + request.decision());
+        }
+
+        if (request.confirmedMealSlots() != null) {
+            candidate.updateConfirmedMealSlots(request.confirmedMealSlots());
         }
     }
 

--- a/src/test/java/com/ppiyaki/medication/MealSlotTest.java
+++ b/src/test/java/com/ppiyaki/medication/MealSlotTest.java
@@ -51,6 +51,42 @@ class MealSlotTest {
                 .isInstanceOf(NullPointerException.class);
     }
 
+    @Test
+    @DisplayName("parseCsv: 표준 CSV → 리스트")
+    void parseCsv_standard() {
+        assertThat(MealSlot.parseCsv("BREAKFAST,LUNCH,DINNER"))
+                .containsExactly(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER);
+    }
+
+    @Test
+    @DisplayName("parseCsv: 공백/빈 토큰/잘못된 enum 값 → 무시")
+    void parseCsv_normalizes() {
+        assertThat(MealSlot.parseCsv(" BREAKFAST , ,BEDTIME, LUNCH "))
+                .containsExactly(MealSlot.BREAKFAST, MealSlot.LUNCH);
+    }
+
+    @Test
+    @DisplayName("parseCsv: null/blank → 빈 리스트")
+    void parseCsv_blank() {
+        assertThat(MealSlot.parseCsv(null)).isEmpty();
+        assertThat(MealSlot.parseCsv("")).isEmpty();
+        assertThat(MealSlot.parseCsv("   ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("toCsv: 표준 리스트 → CSV")
+    void toCsv_standard() {
+        assertThat(MealSlot.toCsv(java.util.List.of(MealSlot.BREAKFAST, MealSlot.DINNER)))
+                .isEqualTo("BREAKFAST,DINNER");
+    }
+
+    @Test
+    @DisplayName("toCsv: null/empty → null (DB에 null 저장)")
+    void toCsv_empty_returnsNull() {
+        assertThat(MealSlot.toCsv(null)).isNull();
+        assertThat(MealSlot.toCsv(java.util.List.of())).isNull();
+    }
+
     private User userWith(
             final LocalTime breakfast,
             final LocalTime lunch,

--- a/src/test/java/com/ppiyaki/prescription/PrescriptionMedicineCandidateMealSlotsTest.java
+++ b/src/test/java/com/ppiyaki/prescription/PrescriptionMedicineCandidateMealSlotsTest.java
@@ -1,0 +1,87 @@
+package com.ppiyaki.prescription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medicine.service.MatchType;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PrescriptionMedicineCandidate mealSlots 도메인 동작")
+class PrescriptionMedicineCandidateMealSlotsTest {
+
+    @Test
+    @DisplayName("생성 시 suggestedMealSlots는 CSV로 직렬화되고, 리스트 게터로 복원된다")
+    void constructor_persistsSuggestedSlotsAsCsv() {
+        final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                1L, "raw", "타이레놀정", "1정", "1일 3회 식후",
+                "ITEM-1", "타이레놀", MatchType.EXACT, "matched",
+                List.of(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER)
+        );
+
+        assertThat(candidate.getSuggestedMealSlots()).isEqualTo("BREAKFAST,LUNCH,DINNER");
+        assertThat(candidate.getSuggestedMealSlotsList())
+                .containsExactly(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER);
+        assertThat(candidate.getConfirmedMealSlotsList()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("suggestedMealSlots null/empty → CSV는 null, 리스트 게터는 빈 리스트")
+    void constructor_emptySuggestedSlots() {
+        final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                1L, "raw", "약", "1정", "취침 전",
+                null, null, MatchType.NO_MATCH, "no match",
+                List.of()
+        );
+
+        assertThat(candidate.getSuggestedMealSlots()).isNull();
+        assertThat(candidate.getSuggestedMealSlotsList()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("updateConfirmedMealSlots: 리스트 → CSV 저장")
+    void updateConfirmedMealSlots_persistsCsv() {
+        final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                1L, "raw", "약", "1정", "1일 2회",
+                null, null, MatchType.NO_MATCH, null,
+                List.of(MealSlot.BREAKFAST, MealSlot.DINNER)
+        );
+
+        candidate.updateConfirmedMealSlots(List.of(MealSlot.LUNCH, MealSlot.DINNER));
+
+        assertThat(candidate.getConfirmedMealSlots()).isEqualTo("LUNCH,DINNER");
+        assertThat(candidate.getConfirmedMealSlotsList())
+                .containsExactly(MealSlot.LUNCH, MealSlot.DINNER);
+    }
+
+    @Test
+    @DisplayName("updateConfirmedMealSlots: 빈 리스트 → null로 초기화")
+    void updateConfirmedMealSlots_emptyClearsField() {
+        final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                1L, "raw", "약", "1정", "1일 2회",
+                null, null, MatchType.NO_MATCH, null,
+                List.of(MealSlot.BREAKFAST)
+        );
+        candidate.updateConfirmedMealSlots(List.of(MealSlot.BREAKFAST));
+        assertThat(candidate.getConfirmedMealSlots()).isEqualTo("BREAKFAST");
+
+        candidate.updateConfirmedMealSlots(List.of());
+
+        assertThat(candidate.getConfirmedMealSlots()).isNull();
+        assertThat(candidate.getConfirmedMealSlotsList()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("manualAdd factory: suggestedMealSlots는 비어있음")
+    void manualAdd_emptySuggestedSlots() {
+        final PrescriptionMedicineCandidate candidate = PrescriptionMedicineCandidate.manualAdd(
+                1L, "ITEM-1", "타이레놀정", "1정", "1일 3회"
+        );
+
+        assertThat(candidate.getSuggestedMealSlots()).isNull();
+        assertThat(candidate.getSuggestedMealSlotsList()).isEmpty();
+        assertThat(candidate.getConfirmedMealSlotsList()).isEmpty();
+        assertThat(candidate.getCaregiverDecision()).isEqualTo(CaregiverDecision.ACCEPTED);
+    }
+}

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
@@ -1,0 +1,242 @@
+package com.ppiyaki.prescription.controller;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import com.ppiyaki.medicine.service.MatchType;
+import com.ppiyaki.prescription.Prescription;
+import com.ppiyaki.prescription.PrescriptionMedicineCandidate;
+import com.ppiyaki.prescription.PrescriptionStatus;
+import com.ppiyaki.prescription.repository.PrescriptionMedicineCandidateRepository;
+import com.ppiyaki.prescription.repository.PrescriptionRepository;
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("PATCH /prescriptions/{id}/medicines/{candidateId} confirmedMealSlots E2E")
+class PrescriptionConfirmedMealSlotsE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PrescriptionRepository prescriptionRepository;
+
+    @Autowired
+    private PrescriptionMedicineCandidateRepository candidateRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 700000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("PATCH로 confirmedMealSlots 갱신 후 GET 응답에 노출된다")
+    void patch_persists_and_exposes_confirmedMealSlots() {
+        // given — 자율형 시니어 + 처방전 + candidate 1건 (suggestedMealSlots 포함)
+        final SignupResult senior = signup("자율시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedCandidate(prescriptionId,
+                List.of(com.ppiyaki.medication.MealSlot.BREAKFAST,
+                        com.ppiyaki.medication.MealSlot.LUNCH,
+                        com.ppiyaki.medication.MealSlot.DINNER));
+
+        // when — 보호자 검수: ACCEPTED + confirmedMealSlots = [LUNCH, DINNER]
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {
+                            "decision": "ACCEPTED",
+                            "confirmedMealSlots": ["LUNCH", "DINNER"]
+                        }
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // then — GET 응답에 suggested/confirmed 둘 다 노출
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/prescriptions/" + prescriptionId)
+                .then()
+                .statusCode(200)
+                .body("candidates", hasSize(1))
+                .body("candidates[0].caregiverDecision", is("ACCEPTED"))
+                .body("candidates[0].suggestedMealSlots", contains("BREAKFAST", "LUNCH", "DINNER"))
+                .body("candidates[0].confirmedMealSlots", contains("LUNCH", "DINNER"));
+    }
+
+    @Test
+    @DisplayName("PATCH 본문에 confirmedMealSlots 미포함이면 기존 값 유지 (decision만 갱신)")
+    void patch_without_slots_keepsExistingConfirmedSlots() {
+        // given
+        final SignupResult senior = signup("기존유지시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedCandidate(prescriptionId, List.of());
+
+        // 1차 PATCH: 슬롯 확정
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {"decision": "ACCEPTED", "confirmedMealSlots": ["BREAKFAST"]}
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // 2차 PATCH: 결정만 다시(슬롯 필드 미포함)
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {"decision": "ACCEPTED"}
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // then — 슬롯은 1차 값 유지
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/prescriptions/" + prescriptionId)
+                .then()
+                .statusCode(200)
+                .body("candidates[0].confirmedMealSlots", contains("BREAKFAST"));
+    }
+
+    @Test
+    @DisplayName("잘못된 enum 값이면 400")
+    void patch_invalidEnum_returns400() {
+        final SignupResult senior = signup("잘못된슬롯시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedCandidate(prescriptionId, List.of());
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {"decision": "ACCEPTED", "confirmedMealSlots": ["BEDTIME"]}
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(400);
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "presslot" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private void setSeniorMode(final Long seniorId, final CareMode mode) {
+        transactionTemplate.executeWithoutResult(status -> {
+            final User user = userRepository.findById(seniorId).orElseThrow();
+            user.changeCareMode(mode);
+            userRepository.save(user);
+        });
+    }
+
+    private Long seedPrescription(final Long seniorId) {
+        return transactionTemplate.execute(status -> {
+            final Prescription prescription = new Prescription(seniorId);
+            setHierarchicalField(prescription, "status", PrescriptionStatus.PENDING_REVIEW);
+            return prescriptionRepository.save(prescription).getId();
+        });
+    }
+
+    private Long seedCandidate(
+            final Long prescriptionId,
+            final List<com.ppiyaki.medication.MealSlot> suggestedSlots
+    ) {
+        return transactionTemplate.execute(status -> {
+            final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                    prescriptionId, "raw", "타이레놀정", "1정", "1일 3회 식후",
+                    "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
+                    suggestedSlots
+            );
+            return candidateRepository.save(candidate).getId();
+        });
+    }
+
+    private static void setHierarchicalField(final Object target, final String fieldName, final Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Field not found: " + fieldName);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}


### PR DESCRIPTION
## Summary
시간대 Phase 3 spec (`prescription-schedule-auto-suggest.md`) §6 PR 2.
- OCR 추출 시점에 LLM이 식사 슬롯 후보(`mealSlots`)를 함께 추출
- `prescription_medicine_candidates`에 `suggested_meal_slots`/`confirmed_meal_slots` 컬럼 신설(VARCHAR(64) CSV)
- candidate 응답에 두 필드 노출, PATCH 본문에 `confirmedMealSlots` 추가(선택 필드, 미포함 시 기존 값 유지)
- **prod 동작 무변** — confirm 시 schedule 자동 생성은 PR 3로 분리

## AS-IS / TO-BE
**AS-IS**: 보호자가 confirm 후 약마다 schedule CRUD UI에서 슬롯·dosage 재입력. OCR이 `extractedSchedule` 텍스트만 저장.

**TO-BE**: OCR 시점에 LLM이 슬롯까지 매핑해 candidate에 저장. 보호자가 PATCH로 슬롯 검수·확정. (PR 3에서 confirm 시 슬롯별 `MedicationSchedule` 자동 생성 도입 예정)

## 변경 파일
- `MealSlot.java` — `parseCsv`/`toCsv` 헬퍼
- `OpenAiClient.java` — `ExtractedMedicine.mealSlots`, 프롬프트 매핑 규칙, 응답 파싱 정규화
- `PrescriptionMedicineCandidate.java` — 컬럼 2개 + 도메인 메서드
- `CandidateDecisionRequest.java` / `PrescriptionMedicineCandidateResponse.java` — 필드 노출
- `PrescriptionService.java` — 생성/PATCH 흐름 갱신
- `06-domain-model.md` §4 유비쿼터스 랭귀지(제안/확정 슬롯), §5 candidates 컬럼, §6 ERD

## 테스트
- `MealSlotTest`: `parseCsv`/`toCsv` 정규화 5건 추가
- `PrescriptionMedicineCandidateMealSlotsTest` 신규: 도메인 단위 5건
- `PrescriptionConfirmedMealSlotsE2ETest` 신규: PATCH 갱신/유지/잘못된 enum 3건
- `./gradlew checkstyleMain spotlessCheck test` 통과

## prod 마이그레이션 (별도 적용 필요)
```sql
ALTER TABLE prescription_medicine_candidates
    ADD COLUMN suggested_meal_slots VARCHAR(64) NULL,
    ADD COLUMN confirmed_meal_slots VARCHAR(64) NULL;
```

## Test plan
- [ ] PR 머지 후 prod 마이그레이션 SQL 실행 (수동)
- [ ] prod에서 처방전 OCR → candidate 응답에 `suggestedMealSlots` 채워지는지 확인 (LLM 실호출)
- [ ] `PATCH /prescriptions/{id}/medicines/{candidateId}` 본문에 `confirmedMealSlots` 포함해서 갱신 → GET 확인

## 선행 / 후속
- 선행: PR #222 (Phase 1), PR #225 (Phase 2)
- 후속 PR 3 — `feat(prescription)`: confirm 시 schedule 자동 생성 + 멱등 + E2E + Notion API 명세 동기화

🤖 Generated with [Claude Code](https://claude.com/claude-code)