### PR TITLE
feat(prescription): confirm 시 슬롯별 schedule 자동 생성 — 시간대 Phase 3 PR 3 (완결)

### DIFF
--- a/docs/features/prescription-schedule-auto-suggest.md
+++ b/docs/features/prescription-schedule-auto-suggest.md
@@ -1,11 +1,11 @@
 ---
 feature: 처방전 confirm 시 복약 일정 자동 제안 (시간대 Phase 3)
 slug: prescription-schedule-auto-suggest
-status: draft
+status: done
 owner: @goohong
 scope: prescription
 related_issues: []
-related_prs: []
+related_prs: [#228, #229]
 last_reviewed: 2026-05-07
 ---
 
@@ -30,19 +30,19 @@ last_reviewed: 2026-05-07
 
 ## 3) 요구사항
 ### 기능 요구사항
-- [ ] `OpenAiClient.ExtractedMedicine`에 `mealSlots: List<MealSlot>` 필드 추가, 시스템 프롬프트에 슬롯 매핑 규칙 추가
-- [ ] LLM 응답 파싱: `mealSlots`가 누락/null이면 빈 리스트로 처리. 잘못된 enum 값(예: "BEDTIME")은 필터링
-- [ ] `PrescriptionMedicineCandidate`에 `suggested_meal_slots`, `confirmed_meal_slots` (둘 다 VARCHAR CSV, nullable) 컬럼 신설
-- [ ] OCR 처리(`PrescriptionService.processAndCreate`)에서 LLM `mealSlots`를 `suggestedMealSlots`로 저장
-- [ ] `PrescriptionMedicineCandidateResponse`에 `suggestedMealSlots`, `confirmedMealSlots` 노출
-- [ ] `PATCH /api/v1/prescriptions/{id}/medicines/{candidateId}` 본문에 `confirmedMealSlots: List<MealSlot>` 추가 (선택, 기존 결정 갱신과 별도 갱신 가능)
-- [ ] `POST /api/v1/prescriptions/{id}/confirm`: ACCEPTED/MANUALLY_CORRECTED candidate 중 `confirmedMealSlots`가 비어있지 않으면 슬롯별로 `MedicationSchedule` 자동 생성 (dosage는 candidate `extractedDosage` 사용, daysOfWeek=`DAILY`, startDate=오늘, endDate=null)
-- [ ] confirm 시 시니어 mealTimes의 해당 슬롯이 null이면 400 `MEAL_TIMES_NOT_SET`로 거절 (기존 `MedicationScheduleService.create` 검증 재사용)
-- [ ] confirm 호출의 멱등성: 동일 candidate 재confirm 시 `created_medicine_id`가 이미 있으면 schedule 중복 생성 방지 (Medicine 1건당 schedule N건 제한 — schedule도 동일 (medicineId, mealSlot) 중복 방지)
-- [ ] 도메인 문서 §4 유비쿼터스 랭귀지에 "제안 슬롯 / 확정 슬롯" 등재
-- [ ] 도메인 문서 §5 `prescription_medicine_candidates` 컬럼 추가
-- [ ] `schema.sql` 동기화 + prod 마이그레이션 SQL
-- [ ] Notion API 명세: candidate 응답·PATCH 본문·confirm 동작 변경
+- [x] `OpenAiClient.ExtractedMedicine`에 `mealSlots: List<MealSlot>` 필드 추가, 시스템 프롬프트에 슬롯 매핑 규칙 추가 (PR #229)
+- [x] LLM 응답 파싱: `mealSlots`가 누락/null이면 빈 리스트로 처리. 잘못된 enum 값(예: "BEDTIME")은 필터링 (PR #229)
+- [x] `PrescriptionMedicineCandidate`에 `suggested_meal_slots`, `confirmed_meal_slots` (둘 다 VARCHAR CSV, nullable) 컬럼 신설 (PR #229)
+- [x] OCR 처리(`PrescriptionService.processAndCreate`)에서 LLM `mealSlots`를 `suggestedMealSlots`로 저장 (PR #229)
+- [x] `PrescriptionMedicineCandidateResponse`에 `suggestedMealSlots`, `confirmedMealSlots` 노출 (PR #229)
+- [x] `PATCH /api/v1/prescriptions/{id}/medicines/{candidateId}` 본문에 `confirmedMealSlots: List<MealSlot>` 추가 (선택, 기존 결정 갱신과 별도 갱신 가능) (PR #229)
+- [x] `POST /api/v1/prescriptions/{id}/confirm`: ACCEPTED/MANUALLY_CORRECTED candidate 중 `confirmedMealSlots`가 비어있지 않으면 슬롯별로 `MedicationSchedule` 자동 생성 (dosage는 candidate `extractedDosage` 사용, daysOfWeek=`DAILY`, startDate=오늘, endDate=null) (PR #230)
+- [x] confirm 시 시니어 mealTimes의 해당 슬롯이 null이면 400 `MEAL_TIMES_NOT_SET`로 거절 — 트랜잭션 변경 시작 전 사전 검증으로 구현(전체 롤백). `MedicationScheduleService.create` 검증과 동일 의미. (PR #230)
+- [x] confirm 호출의 멱등성: 동일 candidate 재confirm 시 `created_medicine_id`가 이미 있으면 Medicine·schedule 중복 생성 방지 (PR #230). (medicineId, mealSlot) UNIQUE 인덱스는 본 spec 외 follow-up
+- [x] 도메인 문서 §4 유비쿼터스 랭귀지에 "제안 슬롯 / 확정 슬롯" 등재 (PR #229)
+- [x] 도메인 문서 §5 `prescription_medicine_candidates` 컬럼 추가 (PR #229)
+- [x] `schema.sql` 동기화 + prod 마이그레이션 SQL — `prescription_medicine_candidates`는 `clova.ocr.secret` ConditionalOnProperty로 schema.sql에서 제외되므로 DDL은 prod 마이그레이션 SQL로만 관리 (§5-5)
+- [x] Notion API 명세: candidate 응답·PATCH 본문·confirm 동작 변경 — 사용자 사이클 안에서 동기화
 
 ### 비기능 요구사항
 - **성능**: confirm은 ACCEPTED candidate × 슬롯 수만큼 schedule INSERT. 평균 3종 약 × 평균 2슬롯 = 6 INSERT. 추가 비용 미미.
@@ -181,9 +181,9 @@ ALTER TABLE prescription_medicine_candidates
 | `test/.../PrescriptionServiceTest.java` 또는 `PrescriptionControllerE2ETest.java` | confirm 시 schedule 자동 생성 검증, mealTimes 미설정 400 |
 
 ## 6) 작업 분할 (예상 PR 리스트)
-- [ ] PR 1 (`docs(prescription)`): 본 spec
-- [ ] PR 2 (`feat(prescription)`): LLM 프롬프트 + candidate 컬럼 + suggestedMealSlots 응답 노출 + PATCH 갱신
-- [ ] PR 3 (`feat(prescription)`): confirm 시 schedule 자동 생성 + 멱등 보장 + E2E
+- [x] PR 1 (`docs(prescription)`): 본 spec — PR #228
+- [x] PR 2 (`feat(prescription)`): LLM 프롬프트 + candidate 컬럼 + suggestedMealSlots 응답 노출 + PATCH 갱신 — PR #229
+- [x] PR 3 (`feat(prescription)`): confirm 시 schedule 자동 생성 + 멱등 보장 + E2E — PR #230
 
 PR 2/3 분리 이유: PR 2는 prod 동작 변경 없이 데이터/응답만 확장 (사용자 기존 흐름 유지). PR 3는 confirm 동작 변경(schedule 자동 생성). 각각 독립 검증 가능.
 

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -8,6 +8,9 @@ import com.ppiyaki.common.ocr.ClovaOcrClient;
 import com.ppiyaki.common.ocr.ClovaOcrClient.OcrResult;
 import com.ppiyaki.common.ocr.ClovaOcrClient.OcrToken;
 import com.ppiyaki.common.storage.NcpStorageProperties;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.controller.dto.MedicineCandidate;
 import com.ppiyaki.medicine.repository.MedicineRepository;
@@ -33,6 +36,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -59,6 +63,7 @@ public class PrescriptionService {
     private final PrescriptionRepository prescriptionRepository;
     private final PrescriptionMedicineCandidateRepository candidateRepository;
     private final MedicineRepository medicineRepository;
+    private final MedicationScheduleRepository medicationScheduleRepository;
     private final CareRelationRepository careRelationRepository;
     private final UserRepository userRepository;
     private final ClovaOcrClient clovaOcrClient;
@@ -73,6 +78,7 @@ public class PrescriptionService {
             final PrescriptionRepository prescriptionRepository,
             final PrescriptionMedicineCandidateRepository candidateRepository,
             final MedicineRepository medicineRepository,
+            final MedicationScheduleRepository medicationScheduleRepository,
             final CareRelationRepository careRelationRepository,
             final UserRepository userRepository,
             final ClovaOcrClient clovaOcrClient,
@@ -86,6 +92,7 @@ public class PrescriptionService {
         this.prescriptionRepository = prescriptionRepository;
         this.candidateRepository = candidateRepository;
         this.medicineRepository = medicineRepository;
+        this.medicationScheduleRepository = medicationScheduleRepository;
         this.careRelationRepository = careRelationRepository;
         this.userRepository = userRepository;
         this.clovaOcrClient = clovaOcrClient;
@@ -245,27 +252,63 @@ public class PrescriptionService {
                     "All candidates must be decided before confirming.");
         }
 
+        // 시니어 mealTimes 사전 검증: 슬롯 자동 생성 대상 candidate가 있는데
+        // 해당 슬롯의 mealTime이 null이면 트랜잭션 변경 시작 전에 거절 (spec §3, USER_002).
+        final User owner = userRepository.findById(prescription.getOwnerId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         for (final PrescriptionMedicineCandidate candidate : candidates) {
-            if (candidate.getCaregiverDecision() == CaregiverDecision.ACCEPTED
-                    || candidate.getCaregiverDecision() == CaregiverDecision.MANUALLY_CORRECTED) {
+            if (!isAcceptedOrCorrected(candidate) || candidate.getCreatedMedicineId() != null) {
+                continue;
+            }
+            for (final MealSlot slot : candidate.getConfirmedMealSlotsList()) {
+                if (slot.resolveTime(owner) == null) {
+                    throw new BusinessException(ErrorCode.MEAL_TIMES_NOT_SET);
+                }
+            }
+        }
 
-                final String itemSeq = candidate.getCaregiverChosenItemSeq() != null
-                        ? candidate.getCaregiverChosenItemSeq()
-                        : candidate.getMatchedItemSeq();
-                final String name = candidate.getMatchedItemName() != null
-                        ? candidate.getMatchedItemName()
-                        : candidate.getExtractedName();
+        final LocalDate today = LocalDate.now();
+        for (final PrescriptionMedicineCandidate candidate : candidates) {
+            if (!isAcceptedOrCorrected(candidate)) {
+                continue;
+            }
+            // 멱등: 이미 Medicine이 생성된 candidate는 skip (재confirm 시 중복 생성 방지).
+            if (candidate.getCreatedMedicineId() != null) {
+                continue;
+            }
 
-                final Medicine medicine = new Medicine(
-                        prescription.getOwnerId(), prescription.getId(),
-                        name, 0, 0, itemSeq, null);
-                medicineRepository.save(medicine);
-                candidate.linkMedicine(medicine.getId());
+            final String itemSeq = candidate.getCaregiverChosenItemSeq() != null
+                    ? candidate.getCaregiverChosenItemSeq()
+                    : candidate.getMatchedItemSeq();
+            final String name = candidate.getMatchedItemName() != null
+                    ? candidate.getMatchedItemName()
+                    : candidate.getExtractedName();
+
+            final Medicine medicine = new Medicine(
+                    prescription.getOwnerId(), prescription.getId(),
+                    name, 0, 0, itemSeq, null);
+            medicineRepository.save(medicine);
+            candidate.linkMedicine(medicine.getId());
+
+            // dosage가 비어있으면 schedule 자동 생성 skip — Medicine만 등록.
+            // 보호자가 후속으로 schedule CRUD API로 보완 (spec §3 Q2).
+            final String dosage = candidate.getExtractedDosage();
+            if (dosage == null || dosage.isBlank()) {
+                continue;
+            }
+            for (final MealSlot slot : candidate.getConfirmedMealSlotsList()) {
+                medicationScheduleRepository.save(new MedicationSchedule(
+                        medicine.getId(), slot, dosage, "DAILY", today, null));
             }
         }
 
         prescription.confirm();
         return PrescriptionDetailResponse.from(prescription, candidates);
+    }
+
+    private boolean isAcceptedOrCorrected(final PrescriptionMedicineCandidate candidate) {
+        return candidate.getCaregiverDecision() == CaregiverDecision.ACCEPTED
+                || candidate.getCaregiverDecision() == CaregiverDecision.MANUALLY_CORRECTED;
     }
 
     @Transactional

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
@@ -1,0 +1,319 @@
+package com.ppiyaki.prescription.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.medicine.service.MatchType;
+import com.ppiyaki.prescription.Prescription;
+import com.ppiyaki.prescription.PrescriptionMedicineCandidate;
+import com.ppiyaki.prescription.PrescriptionStatus;
+import com.ppiyaki.prescription.repository.PrescriptionMedicineCandidateRepository;
+import com.ppiyaki.prescription.repository.PrescriptionRepository;
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.lang.reflect.Field;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("POST /prescriptions/{id}/confirm 시 슬롯별 schedule 자동 생성 E2E")
+class PrescriptionConfirmAutoScheduleE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PrescriptionRepository prescriptionRepository;
+
+    @Autowired
+    private PrescriptionMedicineCandidateRepository candidateRepository;
+
+    @Autowired
+    private MedicineRepository medicineRepository;
+
+    @Autowired
+    private MedicationScheduleRepository medicationScheduleRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 600000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("ACCEPTED + confirmedMealSlots=[BREAKFAST,LUNCH,DINNER] → schedule 3건 생성")
+    void confirm_createsSchedulesForEachSlot() {
+        // given
+        final SignupResult senior = signup("정상시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        setMealTimes(senior.userId(),
+                LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedAcceptedCandidate(prescriptionId, "1정",
+                List.of(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER));
+
+        // when
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(200)
+                .body("status", is("CONFIRMED"));
+
+        // then — Medicine 1건 + schedule 3건
+        final List<Medicine> medicines = medicineRepository.findByOwnerId(senior.userId());
+        assertThat(medicines).hasSize(1);
+        final Long medicineId = medicines.get(0).getId();
+
+        final List<MedicationSchedule> schedules = medicationScheduleRepository.findByMedicineId(medicineId);
+        assertThat(schedules).extracting(MedicationSchedule::getMealSlot)
+                .containsExactlyInAnyOrder(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER);
+        assertThat(schedules).allMatch(s -> "1정".equals(s.getDosage()));
+        assertThat(schedules).allMatch(s -> "DAILY".equals(s.getDaysOfWeek()));
+
+        // candidate에 created_medicine_id 채워짐
+        final PrescriptionMedicineCandidate after = candidateRepository.findById(candidateId).orElseThrow();
+        assertThat(after.getCreatedMedicineId()).isEqualTo(medicineId);
+    }
+
+    @Test
+    @DisplayName("confirmedMealSlots에 mealTime 미설정 슬롯 포함 → 400 USER_002, 트랜잭션 롤백")
+    void confirm_mealTimesNotSet_returns400_andRollsBack() {
+        // given — lunchTime만 null
+        final SignupResult senior = signup("미설정시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        setMealTimes(senior.userId(), LocalTime.of(8, 0), null, LocalTime.of(18, 30));
+        final Long prescriptionId = seedPrescription(senior.userId());
+        seedAcceptedCandidate(prescriptionId, "1정",
+                List.of(MealSlot.LUNCH)); // lunchTime null이라 거절돼야 함
+
+        // when
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(400)
+                .body("error.code", is("USER_002"));
+
+        // then — Medicine/Schedule 모두 생성되지 않음, prescription status도 CONFIRMED 아님
+        assertThat(medicineRepository.findByOwnerId(senior.userId())).isEmpty();
+        final Prescription after = prescriptionRepository.findById(prescriptionId).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(PrescriptionStatus.PENDING_REVIEW);
+    }
+
+    @Test
+    @DisplayName("dosage가 null이면 schedule skip — Medicine만 생성")
+    void confirm_dosageNull_skipsScheduleCreation() {
+        // given
+        final SignupResult senior = signup("도세지없음시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        setMealTimes(senior.userId(),
+                LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final Long prescriptionId = seedPrescription(senior.userId());
+        seedAcceptedCandidate(prescriptionId, null,
+                List.of(MealSlot.BREAKFAST));
+
+        // when
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(200);
+
+        // then — Medicine 1건, schedule 0건
+        final List<Medicine> medicines = medicineRepository.findByOwnerId(senior.userId());
+        assertThat(medicines).hasSize(1);
+        assertThat(medicationScheduleRepository.findByMedicineId(medicines.get(0).getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("confirmedMealSlots empty면 Medicine만 생성, schedule 0건")
+    void confirm_emptyMealSlots_onlyMedicine() {
+        // given
+        final SignupResult senior = signup("슬롯없음시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        setMealTimes(senior.userId(),
+                LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final Long prescriptionId = seedPrescription(senior.userId());
+        seedAcceptedCandidate(prescriptionId, "1정", List.of());
+
+        // when
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(200);
+
+        // then — Medicine 1건, schedule 0건
+        final List<Medicine> medicines = medicineRepository.findByOwnerId(senior.userId());
+        assertThat(medicines).hasSize(1);
+        assertThat(medicationScheduleRepository.findByMedicineId(medicines.get(0).getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("confirm 두 번째 호출은 멱등 — Medicine/schedule 중복 생성 안 됨")
+    void confirm_idempotent_secondCallNoOp() {
+        // given
+        final SignupResult senior = signup("멱등시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        setMealTimes(senior.userId(),
+                LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final Long prescriptionId = seedPrescription(senior.userId());
+        seedAcceptedCandidate(prescriptionId, "1정",
+                List.of(MealSlot.BREAKFAST, MealSlot.DINNER));
+
+        // when — 1차 confirm
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(200);
+        final List<Medicine> afterFirst = medicineRepository.findByOwnerId(senior.userId());
+        assertThat(afterFirst).hasSize(1);
+        final Long medicineId = afterFirst.get(0).getId();
+        assertThat(medicationScheduleRepository.findByMedicineId(medicineId)).hasSize(2);
+
+        // when — 2차 confirm (이미 CONFIRMED라 동일 호출)
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(200);
+
+        // then — Medicine·schedule 카운트 그대로
+        assertThat(medicineRepository.findByOwnerId(senior.userId())).hasSize(1);
+        assertThat(medicationScheduleRepository.findByMedicineId(medicineId)).hasSize(2);
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "presauto" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private void setSeniorMode(final Long seniorId, final CareMode mode) {
+        transactionTemplate.executeWithoutResult(status -> {
+            final User user = userRepository.findById(seniorId).orElseThrow();
+            user.changeCareMode(mode);
+            userRepository.save(user);
+        });
+    }
+
+    private void setMealTimes(
+            final Long userId,
+            final LocalTime breakfast,
+            final LocalTime lunch,
+            final LocalTime dinner
+    ) {
+        transactionTemplate.executeWithoutResult(status -> {
+            final User user = userRepository.findById(userId).orElseThrow();
+            setHierarchicalField(user, "breakfastTime", breakfast);
+            setHierarchicalField(user, "lunchTime", lunch);
+            setHierarchicalField(user, "dinnerTime", dinner);
+            userRepository.save(user);
+        });
+    }
+
+    private Long seedPrescription(final Long seniorId) {
+        return transactionTemplate.execute(status -> {
+            final Prescription prescription = new Prescription(seniorId);
+            setHierarchicalField(prescription, "status", PrescriptionStatus.PENDING_REVIEW);
+            return prescriptionRepository.save(prescription).getId();
+        });
+    }
+
+    private Long seedAcceptedCandidate(
+            final Long prescriptionId,
+            final String dosage,
+            final List<MealSlot> confirmedSlots
+    ) {
+        return transactionTemplate.execute(status -> {
+            final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                    prescriptionId, "raw", "타이레놀정", dosage, "1일 3회 식후",
+                    "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
+                    confirmedSlots
+            );
+            candidate.accept();
+            candidate.updateConfirmedMealSlots(confirmedSlots);
+            return candidateRepository.save(candidate).getId();
+        });
+    }
+
+    private static void setHierarchicalField(final Object target, final String fieldName, final Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Field not found: " + fieldName);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}


### PR DESCRIPTION
## Summary
시간대 Phase 3 spec (`prescription-schedule-auto-suggest.md`) §6 PR 3. **본 PR로 Phase 3 완결**.

- `PrescriptionService.confirm`이 ACCEPTED/MANUALLY_CORRECTED candidate의 `confirmedMealSlots` 슬롯별로 `MedicationSchedule` 자동 생성
- 시니어 mealTimes 사전 검증으로 슬롯 중 미설정이 있으면 트랜잭션 시작 전 `400 USER_002`로 거절(전체 롤백)
- 멱등 보장: `candidate.created_medicine_id` 있으면 전체 skip — 재confirm 시 Medicine·schedule 중복 생성 없음
- `dosage` null이면 schedule skip + Medicine만 생성 (spec §3 Q2)
- spec frontmatter `status: done`, §3·§6 체크박스 마킹

## AS-IS / TO-BE
**AS-IS** (PR #229 머지 후 상태): confirm 시 Medicine만 자동 생성. schedule은 보호자가 별도 CRUD UI에서 수동 등록.

**TO-BE**: confirm 시 candidate `confirmedMealSlots` 슬롯별로 `MedicationSchedule(medicineId, slot, dosage, "DAILY", today, null)` 자동 생성. 시니어가 confirm 직후부터 슬롯별 알림을 받을 수 있는 상태.

## prod 마이그레이션 (PR #229와 동일)
PR #229에서 명시한 ALTER TABLE이 prod에 이미 적용되어 있어야 본 PR 동작. 미적용 상태라면 본 PR 머지 직전 함께 적용:
```sql
ALTER TABLE prescription_medicine_candidates
    ADD COLUMN suggested_meal_slots VARCHAR(64) NULL,
    ADD COLUMN confirmed_meal_slots VARCHAR(64) NULL;
```

## 변경 파일
- `PrescriptionService.java` — confirm 본문 확장, `MedicationScheduleRepository` DI
- `prescription-schedule-auto-suggest.md` — status done, 체크박스 마킹
- `PrescriptionConfirmAutoScheduleE2ETest.java` 신규 — 5 케이스

## 테스트
- 정상 슬롯 3개 → schedule 3건 생성 + dosage/daysOfWeek 검증
- mealTimes 미설정 슬롯 → 400 USER_002 + 트랜잭션 롤백 (Medicine/schedule 미생성, prescription status는 PENDING_REVIEW 유지)
- dosage null → schedule skip, Medicine만 생성
- confirmedMealSlots empty → schedule skip, Medicine만 생성
- 두 번째 confirm 호출 → 멱등 (카운트 그대로)
- `./gradlew checkstyleMain spotlessCheck test` 통과

## Test plan
- [ ] PR 머지 후 prod에서 처방전 confirm 흐름 검증 (시니어 token으로)
- [ ] mealTimes 미설정 케이스에서 400 응답 + Medicine/schedule 미생성 확인
- [ ] confirmedMealSlots를 PATCH로 갱신 후 confirm → DB의 medication_schedules 슬롯별 row 확인
- [ ] Notion API 명세 동기화: `POST /prescriptions/{id}/confirm` 동작 변경 노트 + `PATCH .../medicines/{candidateId}` `confirmedMealSlots` 본문 (사용자 사이클)

## 선행
- PR #228 (spec)
- PR #229 (PR 2 — candidate 컬럼/프롬프트/PATCH)

## AI 작성 체크리스트
- [x] AI 보조/생성 PR (`ai-generated` 라벨)
- [x] 보호 영역 변경 없음 (`schema.sql` 무변, application.yml 무변, CI 무변)
- [x] prod 마이그레이션은 PR #229에서 명시한 SQL 그대로 (본 PR에서 새 컬럼 추가 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)