### PR TITLE
release: v0.9.0

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -64,7 +64,8 @@
 | OCR 원문 | Extracted Text | Clova OCR이 추출한 텍스트(구조화 전) |
 | 파싱 결과 | Parsed Result | LLM이 OCR 원문을 구조화한 약물 목록(JSON) |
 | 약물 | Medicine | 처방전에서 파생되거나 수동 등록된 복용 대상 |
-| 복약 일정 | Medication Schedule | 특정 약물을 언제 복용할지(`scheduled_time`, `dosage`) |
+| 복약 일정 | Medication Schedule | 특정 약물을 어떤 식사 슬롯에 복용할지(`meal_slot`, `dosage`). 실제 시각은 시니어 mealTimes로 동적 계산 |
+| 식사 슬롯 | Meal Slot | 복약 일정이 묶이는 식사 단위. `BREAKFAST`/`LUNCH`/`DINNER`. 실제 시각은 시니어의 `breakfast_time`/`lunch_time`/`dinner_time`을 매번 참조 |
 | 복약 기록 | Medication Log | 실제 복용 이행 여부 기록 (`status`, `ai_status`) |
 | 복약 상태 | Log Status | 복약 기록의 사용자 확정 상태. `TAKEN` / `MISSED` / `PENDING`. `medication_logs.status`에 enum 매핑 |
 | AI 검증 상태 | Log AI Status | 복약 인증 사진 약 개수 AI 검증 결과. `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED`. `medication_logs.ai_status`에 enum 매핑 (Phase 2). 사진 + status=TAKEN일 때만 채워짐 |
@@ -206,20 +207,20 @@ OCR + LLM 파싱으로 추출된 약물 후보. 처방전 1건당 N행. 보호�
 > **코드 갭**: `item_seq` 컬럼 추가 필요. 추적: §7-A 항목 추가.
 
 ### medication_schedules (target: `@Table(name = "medication_schedules")`, extends `CreatedTimeEntity`)
-복약 일정. `medicine` 1건당 시간대별 N행.
+복약 일정. `medicine` 1건당 식사 슬롯별 N행.
 
 | 컬럼 | 타입 | 설명 |
 |---|---|---|
 | id | bigint PK | |
 | medicine_id | bigint | `medicines.id` 참조 |
-| scheduled_time | time (`LocalTime`) | 복용 시각 |
+| meal_slot | varchar | DB는 varchar, Java는 `MealSlot` enum(`BREAKFAST`/`LUNCH`/`DINNER`). NOT NULL. 실제 시각은 시니어 mealTimes로 동적 계산 |
 | dosage | varchar | 1회 복용량 (예: `1정`) |
 | days_of_week | varchar | 요일 패턴 (예: `MON,TUE,WED,THU,FRI` 또는 `DAILY`). 7비트 마스크 대신 가독성 우선 |
 | start_date | date | 복약 시작일 |
 | end_date | date nullable | 복약 종료일. NULL이면 무기한 |
 | created_at | timestamp | `CreatedTimeEntity` |
 
-> **코드 갭 해소됨**: `days_of_week`, `start_date`, `end_date` 추가 완료 (#16). 현재 코드와 타깃 스키마 일치.
+> 시각 컬럼(`scheduled_time`)은 v0.9.0에서 제거되고 `meal_slot`으로 대체. 시니어 식사 시간 변경이 자동 반영되어 cascade 불필요. 자세한 내용은 `docs/features/medication-schedule-meal-slot.md`.
 
 ### medication_logs (`@Table(name = "medication_logs")`, extends `CreatedTimeEntity`)
 복약 이행 기록. 일자별 × 스케줄별 1행.
@@ -447,7 +448,7 @@ erDiagram
     medication_schedules {
         bigint id PK
         bigint medicine_id FK
-        time scheduled_time
+        varchar meal_slot "BREAKFAST/LUNCH/DINNER"
         varchar dosage
         varchar days_of_week
         date start_date

--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -66,6 +66,8 @@
 | 약물 | Medicine | 처방전에서 파생되거나 수동 등록된 복용 대상 |
 | 복약 일정 | Medication Schedule | 특정 약물을 어떤 식사 슬롯에 복용할지(`meal_slot`, `dosage`). 실제 시각은 시니어 mealTimes로 동적 계산 |
 | 식사 슬롯 | Meal Slot | 복약 일정이 묶이는 식사 단위. `BREAKFAST`/`LUNCH`/`DINNER`. 실제 시각은 시니어의 `breakfast_time`/`lunch_time`/`dinner_time`을 매번 참조 |
+| 제안 슬롯 | Suggested Meal Slots | OCR 시점에 LLM이 처방전 복약주기 텍스트로부터 제안한 식사 슬롯 후보. `prescription_medicine_candidates.suggested_meal_slots`(CSV)에 저장. 보호자 검수의 출발점 (Phase 3) |
+| 확정 슬롯 | Confirmed Meal Slots | 보호자가 검수·확정한 식사 슬롯. `prescription_medicine_candidates.confirmed_meal_slots`(CSV). confirm 시 슬롯별 `medication_schedules` 자동 생성에 사용 (Phase 3) |
 | 복약 기록 | Medication Log | 실제 복용 이행 여부 기록 (`status`, `ai_status`) |
 | 복약 상태 | Log Status | 복약 기록의 사용자 확정 상태. `TAKEN` / `MISSED` / `PENDING`. `medication_logs.status`에 enum 매핑 |
 | AI 검증 상태 | Log AI Status | 복약 인증 사진 약 개수 AI 검증 결과. `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED`. `medication_logs.ai_status`에 enum 매핑 (Phase 2). 사진 + status=TAKEN일 때만 채워짐 |
@@ -184,6 +186,8 @@ OCR + LLM 파싱으로 추출된 약물 후보. 처방전 1건당 N행. 보호�
 | caregiver_chosen_item_seq | varchar nullable | 보호자가 직접 선택한 품목 일련번호 (MODIFIED 시) |
 | reviewed_at | datetime nullable | 보호자 검토 완료 시각 |
 | created_medicine_id | bigint nullable | 확정 후 생성된 `medicines.id` 참조 |
+| suggested_meal_slots | varchar(64) nullable | LLM이 제안한 식사 슬롯 CSV (예: `BREAKFAST,LUNCH,DINNER`). 식사 무관/불명확이면 null. Phase 3 |
+| confirmed_meal_slots | varchar(64) nullable | 보호자가 확정한 식사 슬롯 CSV. confirm 시 슬롯별 `medication_schedules` 자동 생성. Phase 3 |
 | created_at | timestamp | `CreatedTimeEntity` |
 
 > **코드 갭**: 신규 엔티티 — 엔티티 클래스 및 마이그레이션 미구현. 추적: §7-A 항목 추가.
@@ -432,6 +436,8 @@ erDiagram
         varchar caregiver_chosen_item_seq "nullable"
         datetime reviewed_at "nullable"
         bigint created_medicine_id FK "nullable"
+        varchar suggested_meal_slots "nullable, CSV"
+        varchar confirmed_meal_slots "nullable, CSV"
         timestamp created_at
     }
     medicines {

--- a/docs/erd.dbml
+++ b/docs/erd.dbml
@@ -67,7 +67,7 @@ Table medicines {
 Table medication_schedules {
   id bigint [pk, increment, not null]
   medicine_id bigint [not null]
-  scheduled_time time
+  meal_slot varchar [not null, note: 'BREAKFAST/LUNCH/DINNER. 실제 시각은 시니어 mealTimes로 동적 계산']
   dosage varchar
   days_of_week varchar
   start_date date

--- a/docs/features/meal-time-defaults.md
+++ b/docs/features/meal-time-defaults.md
@@ -1,15 +1,19 @@
 ---
 feature: 시니어 식사 시간대 기본값
 slug: meal-time-defaults
-status: draft
+status: done
 owner: @goohong
 scope: user
 related_issues: [#221]
-related_prs: []
+related_prs: [#222]
 last_reviewed: 2026-05-07
 ---
 
 # 시니어 식사 시간대 기본값
+
+> **Phase 1 완료 (v0.8.1, PR #222)**.
+> Phase 2(복약 일정의 식사 슬롯 모델 전환): `docs/features/medication-schedule-meal-slot.md` (#225)
+> Phase 3(OCR → 슬롯 자동 매핑, 처방전 confirm 시 schedule 자동 생성): 별도 spec 미작성
 
 ## 1) 개요 (What / Why)
 시니어가 평소 아침/점심/저녁 식사 시간을 사전 설정해두고, 처방전 기반 복약 일정 등록 시 이 시간대를 활용한다. 매번 약마다 수기로 시각을 입력하는 마찰을 줄이고, 향후 처방전 confirm 시 자동 schedule 생성의 기반 데이터를 마련한다.
@@ -23,11 +27,11 @@ last_reviewed: 2026-05-07
 
 ## 3) 요구사항
 ### 기능 요구사항
-- [ ] `User` 엔티티에 `breakfastTime` / `lunchTime` / `dinnerTime` (LocalTime, nullable) 필드 추가
-- [ ] `PUT /api/v1/users/me/meal-times` — 시니어 본인이 3개 시각을 한 번에 갱신 (전체 PUT, 3개 모두 필수)
-- [ ] `GET /api/v1/users/me` 응답에 `mealTimes` 객체 추가. 모두 미설정이면 `null`, 일부만 설정 가능
-- [ ] 권한: 시니어 본인만 갱신 (보호자 대리 갱신 불가, Phase 2 이후 검토)
-- [ ] DB 마이그레이션 SQL 준비, `schema.sql` 동기화
+- [x] `User` 엔티티에 `breakfastTime` / `lunchTime` / `dinnerTime` (LocalTime, nullable) 필드 추가
+- [x] `PUT /api/v1/users/me/meal-times` — 시니어 본인이 3개 시각을 한 번에 갱신 (전체 PUT, 3개 모두 필수)
+- [x] `GET /api/v1/users/me` 응답에 `mealTimes` 객체 추가. 모두 미설정이면 `null` (전체 설정 또는 전체 미설정만)
+- [x] 권한: 시니어 본인만 갱신 (보호자 대리 갱신 불가, Phase 2 이후 검토)
+- [x] DB 마이그레이션 SQL 준비, `schema.sql` 동기화
 
 ### 비기능 요구사항
 - **성능**: 갱신/조회 모두 단일 user row 작업. 추가 인덱스 불필요.
@@ -168,3 +172,4 @@ ALTER TABLE users
 - 2026-05-07: **시각 순서 검증 미도입**. 사용자 자율 (야간 근무 등 비전형 패턴 허용).
 - 2026-05-07: **보호자 대리 갱신 미포함**. Phase 1은 본인만. Phase 2 슬롯 도입 시점에 재검토.
 - 2026-05-07: **`isOnboarded` 정의 유지**. mealTimes 미설정도 onboarded. 시간대 설정 강제는 프론트 UX로 유도.
+- 2026-05-07: PR #222로 Phase 1 머지·prod 배포 완료. status=done. **mealTimes는 전체 설정 또는 전체 미설정만 허용** (§3 "일부만 설정" 표현 정정). Phase 2는 #225 별도 spec.

--- a/docs/features/medication-log-phase2.md
+++ b/docs/features/medication-log-phase2.md
@@ -6,20 +6,22 @@ owner: @goohong
 scope: medication
 related_issues: [184]
 related_prs: []
-last_reviewed: 2026-04-30
+last_reviewed: 2026-05-07
 ---
 
 # 복약 사진 약 개수 AI 검증 (Phase 2)
 
 ## 1) 개요 (What / Why)
-- 시니어가 복약 인증으로 업로드한 사진에서 **알약 개수**를 Vision LLM으로 추출해, 같은 시각에 예정된 모든 schedule의 dosage 합과 비교한다.
+- 시니어가 복약 인증으로 업로드한 사진에서 **알약 개수**를 Vision LLM으로 추출해, 같은 식사 슬롯에 예정된 모든 schedule의 dosage 합과 비교한다.
+
+> **v0.9.0 변경 (#225)**: schedule 모델이 `scheduledTime` → `mealSlot`으로 전환됨에 따라, 기대 카운트 산출도 동일 슬롯(`mealSlot`) 기준으로 변경. 시니어가 평소 식사 시간을 옮겨도 슬롯은 그대로라 동작에 영향 없음.
 - 일치 여부를 `MedicationLog.ai_status`에 기록하여 보호자/시니어가 GET 응답으로 확인 가능.
 - Phase 3 (#185, 알약 종류 식별)와 분리: Phase 2는 **개수 세기만** 수행 (식별 X).
 - **Primary Why**: 복약 정확도 1차 검증. "약을 손에 들고 사진은 찍었지만 정작 안 먹음" 같은 위장 케이스를 줄이는 안전장치.
 
 ## 2) 사용자 시나리오
-- 시니어가 아침 8시에 약 2종(아스피린 1정 + 비타민 1정)을 손바닥에 올리고 촬영 → PUT.
-- 서버가 GPT-4o Vision으로 사진 속 알약 개수 추출 (예: 2개) → 같은 시각 schedule들의 dosage 합 계산 (예: 1+1=2) → 일치 → `ai_status=COUNT_MATCH`.
+- 시니어가 아침 슬롯에 약 2종(아스피린 1정 + 비타민 1정)을 손바닥에 올리고 촬영 → PUT.
+- 서버가 GPT-4o Vision으로 사진 속 알약 개수 추출 (예: 2개) → 같은 슬롯 schedule들의 dosage 합 계산 (예: 1+1=2) → 일치 → `ai_status=COUNT_MATCH`.
 - 만약 사진에 1개만 보이면 `COUNT_MISMATCH` → 보호자가 GET으로 발견 → 시니어에게 재촬영/재복약 요청 (UX는 후속).
 - dosage 파싱 실패 또는 Vision 실패 시 `COUNT_UNKNOWN` / `COUNT_FAILED`.
 
@@ -30,7 +32,7 @@ last_reviewed: 2026-04-30
 - [ ] `OpenAiClient.countPills(imageBytes, mediaType): Optional<Integer>` 신규 메서드 — GPT-4o Vision JSON Mode로 정수 반환. 실패 시 `Optional.empty()`.
 - [ ] `DosageParser.parsePillCount(dosage): Optional<Integer>` 유틸 — 정규식 `(\d+)` 첫 매치만 추출. "1정" → 1, "2알" → 2, "반알" → empty.
 - [ ] `MedicationLogService.upsert`에 검증 트리거: `photoObjectKey != null && status == TAKEN`일 때만.
-- [ ] 트리거 시 동일 `(seniorId, targetDate, scheduledTime)` 의 모든 active schedule 조회 → dosage 합산.
+- [ ] 트리거 시 동일 `(seniorId, targetDate, mealSlot)` 의 모든 active schedule 조회 → dosage 합산.
 - [ ] dosage 파싱 실패가 1개라도 있으면 → `COUNT_UNKNOWN`.
 - [ ] Vision API 실패 시 → `COUNT_FAILED`. retry 1회 (timeout 30s).
 - [ ] 결과를 `ai_status` 컬럼에 저장. 응답 DTO에 노출 (이미 Phase 1 응답에 `aiStatus` 필드 있음).
@@ -48,7 +50,7 @@ last_reviewed: 2026-04-30
 - `LogAiStatus` enum 신설
 - Vision LLM 어댑터 확장 (`OpenAiClient.countPills`)
 - dosage 파싱 유틸
-- 동일 시각 schedule 합산 로직
+- 동일 식사 슬롯 schedule 합산 로직
 - 동기 검증 흐름
 - 단위 + E2E 테스트 (Vision 응답은 mock)
 
@@ -56,7 +58,7 @@ last_reviewed: 2026-04-30
 - **알약 종류 식별 (Phase 3, #185)** — 별도 spec
 - **비동기 처리 / 재시도 큐** — Phase 2.1로 분리. 동기 MVP가 운영 데이터로 검증된 후 도입.
 - **FCM 푸시 알림 (mismatch 시)** — 별도 spec.
-- **시각 정렬 허용 오차** — 동일 `scheduledTime`만 합산. 7:55 vs 8:00 같은 인접 시각 합산은 후속.
+- **시각 정렬 허용 오차** — 동일 `mealSlot`만 합산. 슬롯 간 인접 합산은 후속.
 - **dosage 0.5 처리** — 정수 추출만. "반알"은 UNKNOWN로 fallback.
 - **사진 다중 촬영(여러 사진을 한 번에)** — Phase 1 단일 사진 모델 그대로 유지.
 
@@ -102,7 +104,7 @@ public enum LogAiStatus {
   └─ photoObjectKey 있음 + status == TAKEN
        ↓
        1. NCP S3에서 사진 fetch (byte[])
-       2. 동일 (seniorId, targetDate, scheduledTime) 의 모든 active schedule 조회
+       2. 동일 (seniorId, targetDate, mealSlot) 의 모든 active schedule 조회
        3. 각 schedule.dosage를 DosageParser.parsePillCount() 적용 → 정수 합산
           ├─ 하나라도 파싱 실패 → ai_status = COUNT_UNKNOWN, Vision 호출 스킵
           └─ 모두 성공 → expectedCount 산출 → 다음 단계
@@ -153,14 +155,14 @@ public enum LogAiStatus {
 
 ### 통합 (E2E)
 - `@SpringBootTest`로 mock OpenAiClient 빈 주입
-- 정상 흐름: 시니어 PUT (사진 + status=TAKEN, 동일 시각 schedule 2개, Vision mock=2) → ai_status=COUNT_MATCH 응답 검증
+- 정상 흐름: 시니어 PUT (사진 + status=TAKEN, 동일 슬롯 schedule 2개, Vision mock=2) → ai_status=COUNT_MATCH 응답 검증
 - mismatch 케이스: Vision mock=1 (실제 2 예정) → ai_status=COUNT_MISMATCH
 - Vision 실패: mock throws → ai_status=COUNT_FAILED
 
 ## 8) 오픈 질문
 | # | 질문 | 선택지 | 담당/기한 |
 |---|---|---|---|
-| Q1 | 동일 시각 정렬 허용 오차 | 동일 `scheduledTime` 정확 일치만 합산. 인접 시각 합산은 후속 | ✅ 결정 |
+| Q1 | 동일 시각 정렬 허용 오차 | 동일 `mealSlot` 정확 일치만 합산. 슬롯 간 인접 합산은 후속 (v0.9.0 #225 모델 전환 반영) | ✅ 결정 |
 | ~~Q2~~ | ~~gpt-5.4-nano vision 정확도~~ | ✅ **해소됨** (2026-05-06). custom 사진 3장 × 3-run 정확도 테스트에서 nano가 정답 11→8로 misread. mini로 분리 업그레이드 (11/11/11 정확). 결정 로그 §9 참조 |
 
 ## 9) 결정 로그
@@ -170,5 +172,6 @@ public enum LogAiStatus {
 - 2026-04-30: **동기 처리** — UX 단순성 우선. 실측 기반 p50 ~3s / p95 ~6s 응답 시간 감수. 시니어가 응답 받기 전 화면이 안 넘어가는 자연 차단 효과까지 부수적으로 확보. 비동기는 운영 트래픽 데이터 보고 후속 결정.
 - 2026-04-30: **트리거 = `photoObjectKey != null && status == TAKEN`** — 미복용/사진 없음은 검증 무의미.
 - 2026-04-30: **동일 시각 schedule 합산** — 시니어가 같은 시각에 여러 약 한 번에 촬영하는 실제 행동 패턴 정합.
+- 2026-05-07: v0.9.0 (#225) — 기대 카운트 산출 키를 `scheduledTime` → `mealSlot`으로 전환. schedule 모델 변경에 따른 자연 후속.
 - 2026-04-30: **dosage 파싱 = 정규식 `(\d+)` 첫 매치** — 단순 / 실패 시 `COUNT_UNKNOWN`로 fallback. "반알" 등은 검증 불가로 처리.
 - 2026-04-30: **결과 알림은 Phase 2 범위 외** — `ai_status` 갱신만 하고, FCM 푸시는 별도 spec 의존.

--- a/docs/features/medication-schedule-crud.md
+++ b/docs/features/medication-schedule-crud.md
@@ -5,22 +5,26 @@ status: in-review
 owner: @goohong
 scope: medication
 related_issues: []
-related_prs: [91]
-last_reviewed: 2026-04-11
+related_prs: [91, #225]
+last_reviewed: 2026-05-07
 ---
 
 # 복약 일정 등록/조회/수정/삭제
 
+> **v0.9.0 변경 (#225)**: `scheduledTime` (LocalTime) → `mealSlot` (BREAKFAST/LUNCH/DINNER) 모델 전환.
+> 절대 시각 대신 식사 슬롯을 저장하고, 응답 시 시니어의 mealTimes(Phase 1)를 join해 동적 시각을 함께 반환한다.
+> 모델 배경/결정 근거: `docs/features/medication-schedule-meal-slot.md`
+
 ## 1) 개요 (What / Why)
-- 약물(Medicine)에 대한 복약 일정(시간, 용량, 요일, 기간)을 등록·관리할 수 있도록 한다.
+- 약물(Medicine)에 대한 복약 일정(식사 슬롯, 용량, 요일, 기간)을 등록·관리할 수 있도록 한다.
 - 복약 일정은 알림(MedicationReminder), 복약 기록(MedicationLog)의 기반이 되므로 선행 구현이 필수이다.
-- 하나의 약물에 여러 시간대의 일정을 등록할 수 있다 (예: 아침 8시 1정, 저녁 8시 1정).
+- 하나의 약물에 여러 슬롯의 일정을 등록할 수 있다 (예: 아침 1정, 저녁 1정).
 
 ## 2) 사용자 시나리오
 
 ### SC-1: 시니어가 약물에 복약 일정 등록
 1. 시니어가 약 상세 화면에서 "일정 추가"를 탭한다.
-2. 복용 시각, 1회 복용량, 요일 패턴, 시작일을 입력한다.
+2. 식사 슬롯(아침/점심/저녁), 1회 복용량, 요일 패턴, 시작일을 입력한다.
 3. `POST /api/v1/medicines/{medicineId}/schedules`로 일정이 생성된다.
 
 ### SC-2: 시니어가 약물의 복약 일정 목록 확인
@@ -28,7 +32,7 @@ last_reviewed: 2026-04-11
 2. `GET /api/v1/medicines/{medicineId}/schedules`로 조회.
 
 ### SC-3: 시니어가 복약 일정 수정
-1. 복용 시각이나 용량을 변경한다.
+1. 식사 슬롯이나 용량을 변경한다.
 2. `PATCH /api/v1/medicines/{medicineId}/schedules/{scheduleId}`로 수정.
 
 ### SC-4: 시니어가 복약 일정 삭제
@@ -38,14 +42,16 @@ last_reviewed: 2026-04-11
 ## 3) 요구사항
 
 ### 기능 요구사항
-- [x] 약물에 복약 일정을 등록할 수 있다 (scheduledTime, dosage 필수)
+- [x] 약물에 복약 일정을 등록할 수 있다 (mealSlot, dosage 필수)
 - [x] 등록 시 medicineId가 존재하는지 검증
 - [x] 등록 시 해당 약물의 소유자(또는 연동된 보호자)인지 검증
+- [x] 시니어 mealTimes 미설정 상태에서 등록 시 400 (`MEAL_TIMES_NOT_SET` / `USER_002`)
 - [x] 약물별 복약 일정 목록 조회 (페이징 없이 전체 반환)
 - [x] 복약 일정 단건 상세 조회
-- [x] 복약 일정 수정 (scheduledTime, dosage, daysOfWeek, startDate, endDate)
+- [x] 복약 일정 수정 (mealSlot, dosage, daysOfWeek, startDate, endDate)
 - [x] 복약 일정 삭제
 - [x] 소유자 또는 연동된 보호자가 아닌 사용자의 접근 시 403 응답
+- [x] 응답에 `mealSlot`과 함께 시니어 mealTimes를 join한 동적 `scheduledTime` 포함
 
 ### 비기능 요구사항
 - daysOfWeek는 "MON,TUE,WED" 또는 "DAILY" 형식의 문자열
@@ -91,7 +97,7 @@ last_reviewed: 2026-04-11
 **ScheduleCreateRequest**
 ```json
 {
-  "scheduledTime": "08:00" (필수, HH:mm),
+  "mealSlot": "BREAKFAST" (필수, BREAKFAST/LUNCH/DINNER),
   "dosage": "1정" (필수),
   "daysOfWeek": "DAILY" (선택, 기본값 "DAILY"),
   "startDate": "2026-04-11" (선택, 기본값 오늘),
@@ -102,7 +108,7 @@ last_reviewed: 2026-04-11
 **ScheduleUpdateRequest**
 ```json
 {
-  "scheduledTime": "09:00" (선택),
+  "mealSlot": "LUNCH" (선택),
   "dosage": "2정" (선택),
   "daysOfWeek": "MON,WED,FRI" (선택),
   "startDate": "2026-04-15" (선택),
@@ -115,7 +121,8 @@ last_reviewed: 2026-04-11
 {
   "id": Long,
   "medicineId": Long,
-  "scheduledTime": "08:00",
+  "mealSlot": "BREAKFAST",
+  "scheduledTime": "08:00:00",
   "dosage": "1정",
   "daysOfWeek": "DAILY",
   "startDate": "2026-04-11",
@@ -123,6 +130,7 @@ last_reviewed: 2026-04-11
   "createdAt": LocalDateTime
 }
 ```
+> `scheduledTime`은 service 레이어에서 시니어의 `breakfastTime/lunchTime/dinnerTime` 중 슬롯에 해당하는 값을 매핑한 결과(읽기 전용 파생 필드).
 
 **ScheduleListResponse**
 ```json
@@ -147,7 +155,7 @@ Client → [Authorization: Bearer token]
 ```
 
 ### 5-5) DB 마이그레이션
-- 없음. `medication_schedules` 테이블과 `MedicationSchedule.java` 엔티티가 이미 타깃 스키마와 일치.
+- v0.9.0 (#225)에서 `scheduled_time` → `meal_slot` 컬럼 교체. 자세한 SQL은 `docs/features/medication-schedule-meal-slot.md §5-5`.
 
 ## 6) 작업 분할 (예상 PR 리스트)
 - [x] PR 1 (#91): `feat(medication)` MedicationScheduleService + MedicationScheduleController (CRUD 5개) + DTO + E2E 테스트
@@ -172,3 +180,4 @@ Client → [Authorization: Bearer token]
 - 2026-04-11: 초안 작성 (status=draft). 알림/복약 기록은 out-of-scope.
 - 2026-04-11: Q1 결정 — 소유자 검증은 medicine.ownerId를 통한 간접 검증. schedule 자체에 ownerId를 두지 않음.
 - 2026-04-11: Q2 결정 — URI는 중첩 방식(`/medicines/{medicineId}/schedules`). schedule은 medicine의 종속 리소스이므로 관계가 URL에 드러나는 게 RESTful.
+- 2026-05-07: v0.9.0 (#225) — `scheduledTime` (LocalTime) → `mealSlot` (BREAKFAST/LUNCH/DINNER) 모델 전환. 응답엔 시니어 mealTimes로 매핑된 동적 `scheduledTime` 포함. mealTimes 미설정 시 등록 400. 자세한 결정 로그는 `medication-schedule-meal-slot.md §9`.

--- a/docs/features/medication-schedule-meal-slot.md
+++ b/docs/features/medication-schedule-meal-slot.md
@@ -1,0 +1,231 @@
+---
+feature: 복약 일정 식사 슬롯 모델
+slug: medication-schedule-meal-slot
+status: done
+owner: @goohong
+scope: medication
+related_issues: [#225]
+related_prs: [#225]
+last_reviewed: 2026-05-07
+---
+
+# 복약 일정 식사 슬롯 모델 (meal-time-defaults Phase 2)
+
+## 1) 개요 (What / Why)
+복약 일정(`MedicationSchedule`)이 보관하는 시각을 절대 시각(`scheduled_time LocalTime`)에서 식사 슬롯(`meal_slot ENUM`)으로 전환한다. 실제 알림/표시 시각은 시니어의 `breakfastTime/lunchTime/dinnerTime`(Phase 1에서 도입)을 매번 참조해 동적으로 계산한다.
+
+이 모델은 **변경 cascade가 필요 없다** — schedule이 슬롯만 보유하므로 시니어가 식사 시간을 바꾸면 자동으로 모든 약 알림 시각이 따라온다. Phase 2의 본질은 "초기 등록 시 사용자별 식사 시간을 자연스럽게 반영"이다.
+
+대상 사용자: 시니어(약 schedule이 본인 식사 시간 따라 동작), 보호자(시니어 약 등록 시 슬롯 입력).
+
+## 2) 사용자 시나리오
+- **약 등록**: 보호자/시니어가 약 등록 화면에서 "점심" 슬롯을 선택해 schedule을 만든다. 백엔드는 `mealSlot=LUNCH`로 저장한다. 응답에는 시니어의 lunchTime을 join해 `scheduledTime=12:30:00`도 함께 내려간다.
+- **시니어 식사 시간 변경**: 시니어가 lunchTime을 12:30 → 13:00으로 갱신. 별도 cascade API 호출 없이, 다음 schedule 조회/알림 발송부터 13:00으로 계산된다.
+- **mealTimes 미설정 상태에서 약 등록 시도**: `MEAL_TIMES_NOT_SET` 400 에러로 거절. 클라이언트는 mealTimes 설정 화면으로 유도.
+
+## 3) 요구사항
+### 기능 요구사항
+- [x] `MealSlot` enum 추가: `BREAKFAST` / `LUNCH` / `DINNER`
+- [x] `MedicationSchedule.scheduled_time` 컬럼 제거, `meal_slot VARCHAR NOT NULL` 컬럼 추가 (Java enum + AttributeConverter 또는 EnumType.STRING)
+- [x] `ScheduleCreateRequest`/`ScheduleUpdateRequest`: `scheduledTime LocalTime` → `mealSlot MealSlot` 치환. 검증: `@NotNull MealSlot`, jackson enum binding으로 잘못된 값 시 400
+- [x] `ScheduleResponse`: `mealSlot` + 동적 계산된 `scheduledTime` 둘 다 포함. service 레이어에서 owner의 mealTimes 한 번 join해 매핑
+- [x] `POST /api/v1/medicines/{medicineId}/schedules`: 시니어(=`medicine.owner_id`)의 해당 슬롯 mealTime이 NULL이면 `MEAL_TIMES_NOT_SET` 400
+- [x] `PATCH /api/v1/medicines/{medicineId}/schedules/{scheduleId}`: 동일 검증
+- [x] `MedicationScheduleRepository.findActiveByOwnerAndScheduledTime` → `findActiveByOwnerAndMealSlot`으로 변경. medication-log-phase2 약 개수 검증 흐름 갱신
+- [x] MCP tool `get_today_medication_schedule`: `scheduledTime` → 시니어 mealTimes로 동적 변환해 반환 (LLM 응답 포맷 유지)
+- [x] 기존 `medication_schedules` 데이터 전부 DROP (마이그레이션 SQL에 포함)
+- [x] `ErrorCode.MEAL_TIMES_NOT_SET` 추가: HTTP 400, code `USER_002`
+- [x] 도메인 문서 §4 유비쿼터스 랭귀지에 `식사 슬롯 / Meal Slot` 등재
+- [x] 도메인 문서 §5 `medication_schedules` 갱신 (scheduled_time 제거, meal_slot 추가)
+- [x] 도메인 문서 §6 ERD 갱신
+- [x] `schema.sql` 동기화
+- [x] Notion API 명세 동기화: schedule POST/PATCH/GET 응답 변경
+
+### 비기능 요구사항
+- **성능**: schedule 조회 시 owner의 mealTimes를 가져오기 위한 join 1회 추가. medicine→user 1-hop이라 비용 작음. n+1 방지 위해 service 레이어에서 owner 1회 fetch 후 schedule 리스트 매핑.
+- **신뢰성**: 슬롯 enum은 DB varchar + Java enum (기존 패턴 일관). 잘못된 값은 jackson 단계에서 400.
+- **보안**: 의료정보 아니므로 일반 데이터 정책. 슬롯 정보 로그 노출 OK.
+- **관측성**: 별도 메트릭 불필요.
+
+## 4) 범위 / 비범위 (중요)
+
+### 포함
+- `MedicationSchedule` 모델 변경 (scheduled_time 제거, meal_slot 추가)
+- 모든 schedule CRUD API의 입력/출력 변경
+- `medication-log-phase2` 약 개수 검증 쿼리 갱신
+- MCP tool 응답 포맷 유지(슬롯→시각 변환은 백엔드)
+- 기존 데이터 DROP
+- 도메인 문서 + Notion API 명세 동기화
+- E2E 테스트 (성공 + mealTimes 미설정 400 케이스)
+
+### 제외 (Out of Scope)
+- **시니어 mealTimes 변경 시 cascade API** — 동적 계산 모델이라 불필요
+- **알림 발송 큐(`MedicationReminder`) 시각 계산** — 현재 미구현. 알림 인프라 도입 시점에 결정 (enqueue 시점 stamp vs 발송 시점 동적)
+- **OCR schedule 텍스트 → 슬롯 자동 매핑** → Phase 3 (별도 spec)
+- **처방전 confirm 시 schedule 자동 생성** → Phase 3
+- **mealTimes 부분 설정** — Phase 1 결정 유지(전체 설정 또는 전체 미설정만)
+- **회원가입 시 mealTimes 기본값 자동 채움** — 후속 검토 (사용자 메모: "초기에 기본값이 채워지게 디자인할 것 같음")
+- **시니어 권한 강제** — 보호자 mealTimes 의미 없지만 별도 검증 안 함. 권한 도입(role 기반) 후 처리
+- **식사와 무관한 약**(자기 전, 공복 등) — 모든 schedule은 식사 슬롯에 묶이는 모델 채택. 향후 필요 시 별도 슬롯 enum 확장(`BEDTIME` 등) 또는 fixed_time 모델 도입 검토
+- **기존 데이터 슬롯 자동 매핑 backfill** — DROP 채택
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+- 컨텍스트: `medication`
+- `MedicationSchedule.scheduled_time` (LocalTime) **제거**
+- `MedicationSchedule.meal_slot` (varchar, Java `MealSlot` enum) **추가, NOT NULL**
+- `MealSlot { BREAKFAST, LUNCH, DINNER }` — `com.ppiyaki.medication.MealSlot`
+- `User.breakfastTime/lunchTime/dinnerTime` (Phase 1) 활용. 변경 없음.
+
+### 5-2) API 엔드포인트
+
+| Method | Path | 설명 | 인증 | Req | Res |
+|---|---|---|---|---|---|
+| POST | `/api/v1/medicines/{medicineId}/schedules` | 슬롯 기반 schedule 등록 | 필수 | `ScheduleCreateRequest` | `ScheduleResponse` |
+| PATCH | `/api/v1/medicines/{medicineId}/schedules/{scheduleId}` | schedule 수정 (mealSlot 변경 가능) | 필수 | `ScheduleUpdateRequest` | `ScheduleResponse` |
+| GET | `/api/v1/medicines/{medicineId}/schedules` | schedule 목록 (응답에 동적 시각 포함) | 필수 | — | `ScheduleListResponse` |
+| GET | `/api/v1/medicines/{medicineId}/schedules/{scheduleId}` | 단건 조회 | 필수 | — | `ScheduleResponse` |
+| DELETE | `/api/v1/medicines/{medicineId}/schedules/{scheduleId}` | 삭제 (변경 없음) | 필수 | — | — |
+
+#### ScheduleCreateRequest
+```json
+{
+  "mealSlot": "LUNCH",
+  "dosage": "1정",
+  "daysOfWeek": "DAILY",
+  "startDate": "2026-05-07",
+  "endDate": null
+}
+```
+- `mealSlot`: `@NotNull MealSlot` (`BREAKFAST`/`LUNCH`/`DINNER` 외 400)
+- `dosage`, `daysOfWeek`, `startDate`, `endDate`: 변경 없음
+
+#### ScheduleResponse (확장)
+```json
+{
+  "id": 42,
+  "medicineId": 7,
+  "mealSlot": "LUNCH",
+  "scheduledTime": "12:30:00",
+  "dosage": "1정",
+  "daysOfWeek": "DAILY",
+  "startDate": "2026-05-07",
+  "endDate": null,
+  "createdAt": "2026-05-07T10:15:00"
+}
+```
+- `scheduledTime`: 시니어의 슬롯별 mealTime을 service에서 매핑. `mealSlot=LUNCH`이면 `user.lunchTime`.
+- 매핑 시점에 mealTime이 NULL이면 schedule이 존재하지 말아야 하나(생성 시 검증), 안전을 위해 응답에선 `null`로 fallback.
+
+#### 에러 응답
+| 상황 | HTTP | code |
+|---|---|---|
+| `mealSlot` 누락/오타 | 400 | `COMMON_001` |
+| 시니어 해당 슬롯 mealTime 미설정 상태에서 schedule 생성/수정 | 400 | `USER_002` (`MEAL_TIMES_NOT_SET`) |
+| 인증 없음 | 401 | `AUTH_001` |
+| 본인 약/연동 시니어 약 아님 | 403 | `CARE_001` |
+
+### 5-3) 외부 연동
+없음.
+
+### 5-4) 데이터 흐름
+```
+클라이언트
+  ↓ POST /medicines/{id}/schedules { mealSlot: LUNCH, dosage, ... }
+MedicationScheduleController.create
+  ↓
+MedicationScheduleService.create(userId, medicineId, request)
+  ├─ findMedicineAndValidateAccess
+  ├─ Medicine.ownerId(=시니어) → User 조회
+  ├─ user.lunchTime == null ⇒ throw MEAL_TIMES_NOT_SET
+  └─ MedicationSchedule(meal_slot=LUNCH, dosage, ...) 저장
+       ↓
+ScheduleResponse.from(schedule, user)
+  └─ scheduledTime = user.lunchTime
+```
+
+조회 흐름:
+```
+GET /medicines/{id}/schedules
+  → service.readAll
+    → Medicine 조회 → owner User 1회 조회 (mealTimes 포함)
+    → schedules 리스트 조회
+    → 각 schedule: mealSlot 보고 user.{slot}Time 매핑하여 ScheduleResponse 생성
+```
+
+### 5-5) DB 마이그레이션
+
+```sql
+-- 1) 기존 schedule 데이터 DROP (사용자 동의함, prod에 운영 데이터 없음 가정)
+DELETE FROM medication_logs WHERE schedule_id IN (SELECT id FROM medication_schedules);
+DELETE FROM medication_reminders WHERE schedule_id IN (SELECT id FROM medication_schedules);
+DELETE FROM medication_schedules;
+
+-- 2) 컬럼 교체
+ALTER TABLE medication_schedules
+    DROP COLUMN scheduled_time,
+    ADD COLUMN meal_slot VARCHAR(16) NOT NULL;
+```
+
+- prod NCP MySQL에 머지 직전 수동 실행 (보호 영역 + DDL).
+- `schema.sql`도 동일하게 갱신.
+- `medication_logs` / `medication_reminders` FK 정리는 cascade 미설정 가정해 명시 DELETE.
+
+### 5-6) 코드 영향 범위
+| 파일 | 변경 |
+|---|---|
+| `medication/MealSlot.java` | **신규** enum |
+| `medication/MedicationSchedule.java` | `scheduledTime` → `mealSlot`, 생성자/update 시그니처 |
+| `medication/repository/MedicationScheduleRepository.java` | `findActiveByOwnerAndScheduledTime` → `findActiveByOwnerAndMealSlot` |
+| `medication/service/MedicationScheduleService.java` | owner User join, mealTime 검증 |
+| `medication/controller/dto/ScheduleCreateRequest.java` | `scheduledTime` → `mealSlot` |
+| `medication/controller/dto/ScheduleUpdateRequest.java` | 동일 |
+| `medication/controller/dto/ScheduleResponse.java` | `mealSlot` + 동적 `scheduledTime` |
+| `medication/service/MedicationLogService.java` (Phase 2 약 개수 검증) | 슬롯 기준 기대 카운트 쿼리로 전환 |
+| `common/mcp/MedicationMcpTools.java` | LLM 응답 시 슬롯→시각 변환 |
+| `resources/schema.sql` | 컬럼 정의 변경 |
+| `test/.../MedicationScheduleControllerE2ETest.java` | 입력/응답 갱신, 신규 400 케이스 |
+| `test/.../MedicationLogControllerE2ETest.java` | 슬롯 기반 schedule fixture |
+| `test/.../MedicationLogServicePhase2Test.java` | 동일 |
+| `docs/ai-harness/06-domain-model.md` | §4 유비쿼터스 랭귀지, §5 medication_schedules, §6 ERD |
+| `docs/features/medication-schedule-crud.md` | 슬롯 모델 반영 |
+| `docs/features/medication-log-phase2.md` | §5-4 기대 카운트 쿼리 슬롯 매칭으로 |
+| `docs/features/meal-time-defaults.md` | status=done 처리, "후속: medication-schedule-meal-slot.md" 링크 |
+
+## 6) 작업 분할
+단일 PR `feat(medication)`로 진행. 컬럼 변경 + 모든 호출처 동시 갱신이 분리 시 빌드 깨짐.
+
+- [x] PR #225 `feat(medication)`:
+  - `MealSlot` enum 신규
+  - 엔티티/repository/service/controller/DTO 변경
+  - MCP tool 갱신
+  - 마이그레이션 SQL + schema.sql
+  - 도메인 문서 §4/§5/§6 갱신
+  - 관련 spec 갱신 (medication-schedule-crud, medication-log-phase2, meal-time-defaults)
+  - Notion API 명세 동기화
+  - E2E + 단위 테스트
+
+## 7) 테스트 전략
+- **단위 테스트**:
+  - `MedicationSchedule` 생성자 — `mealSlot` null 거부
+  - `ScheduleResponse.from` — 슬롯별 시각 매핑 (LUNCH → user.lunchTime)
+- **E2E (RestAssured)**:
+  - 성공: 시니어 mealTimes 설정 → POST schedule with LUNCH → 200, 응답에 `scheduledTime=lunchTime`
+  - mealTimes 미설정 시니어가 POST → 400 `USER_002`
+  - 잘못된 mealSlot 값 → 400
+  - 시니어 mealTimes 갱신 후 GET schedule → 응답 시각이 새 시간 반영
+- 외부 연동 mock 불필요
+
+## 8) 오픈 질문
+없음 — 합의 완료 (§9 참조).
+
+## 9) 결정 로그
+- 2026-05-07: 초안 작성 (status=draft). meal-time-defaults Phase 2를 별도 spec으로 분리.
+- 2026-05-07: **schedule엔 슬롯만 저장, 시각은 동적 계산**. 시니어가 식사 시간 변경하면 자동 반영 → cascade API 불필요. 사용자 의도: "변경을 염두에 둔 설계가 아니라, 초기에 사람마다 다른 식사시간을 설정하기 위한 설계".
+- 2026-05-07: **`scheduled_time` 컬럼 완전 제거**. 모든 schedule은 식사 슬롯에 묶임. 자기 전·공복약 등 비식사 약은 현재 범위 외.
+- 2026-05-07: **기존 prod schedule 데이터 DROP**. 운영 데이터 없음 (테스트 데이터만).
+- 2026-05-07: **mealTimes 미설정 시 schedule 등록 400**. 의도 명확. 회원가입 시 기본값 자동 채움은 후속 과제.
+- 2026-05-07: **mealTimes는 전체 설정 또는 전체 미설정만**. Phase 1 spec §5-2 채택, §4 "일부 가능" 정정 대상.
+- 2026-05-07: **응답에 `mealSlot` + 동적 `scheduledTime` 둘 다 포함**. 클라이언트 호출 1회로 화면 표시 가능. owner user 1회 join.
+- 2026-05-07: **알림 큐 시각 계산은 본 spec 범위 외**. `MedicationReminder` 발송 로직 미구현 상태. 인프라 도입 시 결정.

--- a/docs/features/prescription-schedule-auto-suggest.md
+++ b/docs/features/prescription-schedule-auto-suggest.md
@@ -1,11 +1,11 @@
 ---
 feature: 처방전 confirm 시 복약 일정 자동 제안 (시간대 Phase 3)
 slug: prescription-schedule-auto-suggest
-status: draft
+status: done
 owner: @goohong
 scope: prescription
 related_issues: []
-related_prs: []
+related_prs: [#228, #229]
 last_reviewed: 2026-05-07
 ---
 
@@ -30,19 +30,19 @@ last_reviewed: 2026-05-07
 
 ## 3) 요구사항
 ### 기능 요구사항
-- [ ] `OpenAiClient.ExtractedMedicine`에 `mealSlots: List<MealSlot>` 필드 추가, 시스템 프롬프트에 슬롯 매핑 규칙 추가
-- [ ] LLM 응답 파싱: `mealSlots`가 누락/null이면 빈 리스트로 처리. 잘못된 enum 값(예: "BEDTIME")은 필터링
-- [ ] `PrescriptionMedicineCandidate`에 `suggested_meal_slots`, `confirmed_meal_slots` (둘 다 VARCHAR CSV, nullable) 컬럼 신설
-- [ ] OCR 처리(`PrescriptionService.processAndCreate`)에서 LLM `mealSlots`를 `suggestedMealSlots`로 저장
-- [ ] `PrescriptionMedicineCandidateResponse`에 `suggestedMealSlots`, `confirmedMealSlots` 노출
-- [ ] `PATCH /api/v1/prescriptions/{id}/medicines/{candidateId}` 본문에 `confirmedMealSlots: List<MealSlot>` 추가 (선택, 기존 결정 갱신과 별도 갱신 가능)
-- [ ] `POST /api/v1/prescriptions/{id}/confirm`: ACCEPTED/MANUALLY_CORRECTED candidate 중 `confirmedMealSlots`가 비어있지 않으면 슬롯별로 `MedicationSchedule` 자동 생성 (dosage는 candidate `extractedDosage` 사용, daysOfWeek=`DAILY`, startDate=오늘, endDate=null)
-- [ ] confirm 시 시니어 mealTimes의 해당 슬롯이 null이면 400 `MEAL_TIMES_NOT_SET`로 거절 (기존 `MedicationScheduleService.create` 검증 재사용)
-- [ ] confirm 호출의 멱등성: 동일 candidate 재confirm 시 `created_medicine_id`가 이미 있으면 schedule 중복 생성 방지 (Medicine 1건당 schedule N건 제한 — schedule도 동일 (medicineId, mealSlot) 중복 방지)
-- [ ] 도메인 문서 §4 유비쿼터스 랭귀지에 "제안 슬롯 / 확정 슬롯" 등재
-- [ ] 도메인 문서 §5 `prescription_medicine_candidates` 컬럼 추가
-- [ ] `schema.sql` 동기화 + prod 마이그레이션 SQL
-- [ ] Notion API 명세: candidate 응답·PATCH 본문·confirm 동작 변경
+- [x] `OpenAiClient.ExtractedMedicine`에 `mealSlots: List<MealSlot>` 필드 추가, 시스템 프롬프트에 슬롯 매핑 규칙 추가 (PR #229)
+- [x] LLM 응답 파싱: `mealSlots`가 누락/null이면 빈 리스트로 처리. 잘못된 enum 값(예: "BEDTIME")은 필터링 (PR #229)
+- [x] `PrescriptionMedicineCandidate`에 `suggested_meal_slots`, `confirmed_meal_slots` (둘 다 VARCHAR CSV, nullable) 컬럼 신설 (PR #229)
+- [x] OCR 처리(`PrescriptionService.processAndCreate`)에서 LLM `mealSlots`를 `suggestedMealSlots`로 저장 (PR #229)
+- [x] `PrescriptionMedicineCandidateResponse`에 `suggestedMealSlots`, `confirmedMealSlots` 노출 (PR #229)
+- [x] `PATCH /api/v1/prescriptions/{id}/medicines/{candidateId}` 본문에 `confirmedMealSlots: List<MealSlot>` 추가 (선택, 기존 결정 갱신과 별도 갱신 가능) (PR #229)
+- [x] `POST /api/v1/prescriptions/{id}/confirm`: ACCEPTED/MANUALLY_CORRECTED candidate 중 `confirmedMealSlots`가 비어있지 않으면 슬롯별로 `MedicationSchedule` 자동 생성 (dosage는 candidate `extractedDosage` 사용, daysOfWeek=`DAILY`, startDate=오늘, endDate=null) (PR #230)
+- [x] confirm 시 시니어 mealTimes의 해당 슬롯이 null이면 400 `MEAL_TIMES_NOT_SET`로 거절 — 트랜잭션 변경 시작 전 사전 검증으로 구현(전체 롤백). `MedicationScheduleService.create` 검증과 동일 의미. (PR #230)
+- [x] confirm 호출의 멱등성: 동일 candidate 재confirm 시 `created_medicine_id`가 이미 있으면 Medicine·schedule 중복 생성 방지 (PR #230). (medicineId, mealSlot) UNIQUE 인덱스는 본 spec 외 follow-up
+- [x] 도메인 문서 §4 유비쿼터스 랭귀지에 "제안 슬롯 / 확정 슬롯" 등재 (PR #229)
+- [x] 도메인 문서 §5 `prescription_medicine_candidates` 컬럼 추가 (PR #229)
+- [x] `schema.sql` 동기화 + prod 마이그레이션 SQL — `prescription_medicine_candidates`는 `clova.ocr.secret` ConditionalOnProperty로 schema.sql에서 제외되므로 DDL은 prod 마이그레이션 SQL로만 관리 (§5-5)
+- [x] Notion API 명세: candidate 응답·PATCH 본문·confirm 동작 변경 — 사용자 사이클 안에서 동기화
 
 ### 비기능 요구사항
 - **성능**: confirm은 ACCEPTED candidate × 슬롯 수만큼 schedule INSERT. 평균 3종 약 × 평균 2슬롯 = 6 INSERT. 추가 비용 미미.
@@ -181,9 +181,9 @@ ALTER TABLE prescription_medicine_candidates
 | `test/.../PrescriptionServiceTest.java` 또는 `PrescriptionControllerE2ETest.java` | confirm 시 schedule 자동 생성 검증, mealTimes 미설정 400 |
 
 ## 6) 작업 분할 (예상 PR 리스트)
-- [ ] PR 1 (`docs(prescription)`): 본 spec
-- [ ] PR 2 (`feat(prescription)`): LLM 프롬프트 + candidate 컬럼 + suggestedMealSlots 응답 노출 + PATCH 갱신
-- [ ] PR 3 (`feat(prescription)`): confirm 시 schedule 자동 생성 + 멱등 보장 + E2E
+- [x] PR 1 (`docs(prescription)`): 본 spec — PR #228
+- [x] PR 2 (`feat(prescription)`): LLM 프롬프트 + candidate 컬럼 + suggestedMealSlots 응답 노출 + PATCH 갱신 — PR #229
+- [x] PR 3 (`feat(prescription)`): confirm 시 schedule 자동 생성 + 멱등 보장 + E2E — PR #230
 
 PR 2/3 분리 이유: PR 2는 prod 동작 변경 없이 데이터/응답만 확장 (사용자 기존 흐름 유지). PR 3는 confirm 동작 변경(schedule 자동 생성). 각각 독립 검증 가능.
 

--- a/docs/features/prescription-schedule-auto-suggest.md
+++ b/docs/features/prescription-schedule-auto-suggest.md
@@ -1,0 +1,218 @@
+---
+feature: 처방전 confirm 시 복약 일정 자동 제안 (시간대 Phase 3)
+slug: prescription-schedule-auto-suggest
+status: draft
+owner: @goohong
+scope: prescription
+related_issues: []
+related_prs: []
+last_reviewed: 2026-05-07
+---
+
+# 처방전 confirm 시 복약 일정 자동 제안 (시간대 Phase 3)
+
+> 시간대 기능 Phase 3. 선행 스펙: `meal-time-defaults.md`(Phase 1, done), `medication-schedule-meal-slot.md`(Phase 2, done).
+> 처방전 spec과 동시에 영향: `prescription-ocr.md`.
+
+## 1) 개요 (What / Why)
+- 보호자/시니어가 처방전 OCR confirm 시, **약별로 식사 슬롯(BREAKFAST/LUNCH/DINNER)을 함께 확정**하면 백엔드가 `MedicationSchedule`을 자동 생성한다.
+- 슬롯 후보는 OCR 추출 시점에 LLM이 제안한다 (예: "1일 3회 식후" → `[BREAKFAST, LUNCH, DINNER]`). 보호자가 그대로 수락하거나 수정 가능.
+- **Why**: 현재는 confirm 후 보호자가 약마다 schedule CRUD UI를 따로 거쳐 슬롯·dosage를 다시 입력. 처방전 OCR이 이미 복약주기 텍스트(`extractedSchedule`)를 추출하고 있어 LLM이 슬롯까지 매핑하면 마찰을 한 단계 줄일 수 있다.
+- **Safety**: 자동 적용이 아니라 "제안 + 보호자 확정" 모델. LLM 잘못 매핑 시 시니어가 잘못된 시각에 알림 받는 사고 위험을 보호자 검수가 차단한다.
+
+대상 사용자: 보호자(다중 약 처방전 검수가 잦음), 시니어 본인(자율형 모드).
+
+## 2) 사용자 시나리오
+- **표준 흐름 (식후 3회)**: 보호자가 처방전 사진 업로드 → OCR 결과에 약 3종 표시. 약 1번 candidate에 `suggestedMealSlots: [BREAKFAST, LUNCH, DINNER]` 자동 채워짐. 보호자가 그대로 ACCEPTED 결정 → confirm. 백엔드가 약 1번에 대해 schedule 3건(아침·점심·저녁) 자동 생성.
+- **수정 흐름**: LLM이 "1일 2회 식후"를 `[BREAKFAST, DINNER]`로 매핑했지만 보호자가 점심·저녁이 맞다고 판단. PATCH로 `confirmedMealSlots: [LUNCH, DINNER]` 갱신 → confirm 시 점심·저녁 schedule 생성.
+- **무관 약 흐름**: "취침 전" 약은 LLM이 `mealSlots: []` (빈 배열) 반환. candidate `suggestedMealSlots`도 빈 값. confirm 시 해당 약은 schedule 자동 생성 skip(Medicine만 생성). 보호자가 후속으로 수동 schedule 등록.
+- **mealTimes 미설정 흐름**: 시니어 mealTimes 미설정 상태에서 confirm 시 비어있는 슬롯이 하나라도 schedule 생성 시도되면 400 `MEAL_TIMES_NOT_SET` 반환 → 보호자가 시니어에게 mealTimes 설정 요청 후 재시도.
+
+## 3) 요구사항
+### 기능 요구사항
+- [ ] `OpenAiClient.ExtractedMedicine`에 `mealSlots: List<MealSlot>` 필드 추가, 시스템 프롬프트에 슬롯 매핑 규칙 추가
+- [ ] LLM 응답 파싱: `mealSlots`가 누락/null이면 빈 리스트로 처리. 잘못된 enum 값(예: "BEDTIME")은 필터링
+- [ ] `PrescriptionMedicineCandidate`에 `suggested_meal_slots`, `confirmed_meal_slots` (둘 다 VARCHAR CSV, nullable) 컬럼 신설
+- [ ] OCR 처리(`PrescriptionService.processAndCreate`)에서 LLM `mealSlots`를 `suggestedMealSlots`로 저장
+- [ ] `PrescriptionMedicineCandidateResponse`에 `suggestedMealSlots`, `confirmedMealSlots` 노출
+- [ ] `PATCH /api/v1/prescriptions/{id}/medicines/{candidateId}` 본문에 `confirmedMealSlots: List<MealSlot>` 추가 (선택, 기존 결정 갱신과 별도 갱신 가능)
+- [ ] `POST /api/v1/prescriptions/{id}/confirm`: ACCEPTED/MANUALLY_CORRECTED candidate 중 `confirmedMealSlots`가 비어있지 않으면 슬롯별로 `MedicationSchedule` 자동 생성 (dosage는 candidate `extractedDosage` 사용, daysOfWeek=`DAILY`, startDate=오늘, endDate=null)
+- [ ] confirm 시 시니어 mealTimes의 해당 슬롯이 null이면 400 `MEAL_TIMES_NOT_SET`로 거절 (기존 `MedicationScheduleService.create` 검증 재사용)
+- [ ] confirm 호출의 멱등성: 동일 candidate 재confirm 시 `created_medicine_id`가 이미 있으면 schedule 중복 생성 방지 (Medicine 1건당 schedule N건 제한 — schedule도 동일 (medicineId, mealSlot) 중복 방지)
+- [ ] 도메인 문서 §4 유비쿼터스 랭귀지에 "제안 슬롯 / 확정 슬롯" 등재
+- [ ] 도메인 문서 §5 `prescription_medicine_candidates` 컬럼 추가
+- [ ] `schema.sql` 동기화 + prod 마이그레이션 SQL
+- [ ] Notion API 명세: candidate 응답·PATCH 본문·confirm 동작 변경
+
+### 비기능 요구사항
+- **성능**: confirm은 ACCEPTED candidate × 슬롯 수만큼 schedule INSERT. 평균 3종 약 × 평균 2슬롯 = 6 INSERT. 추가 비용 미미.
+- **신뢰성**: LLM 슬롯 매핑은 보조 신호. 보호자가 모든 schedule을 검수·수정할 수 있어야 한다(Phase 2 schedule CRUD API 그대로 활용).
+- **보안**: 의료정보 슬롯 정보는 일반 데이터로 취급. 로그에 슬롯 노출 OK.
+- **관측성**: LLM 슬롯 추출 성공률(`mealSlots` non-empty 비율) 운영 메트릭으로 추후 검토. 본 PR 범위 외.
+
+## 4) 범위 / 비범위 (중요)
+
+### 포함
+- LLM 프롬프트 확장 + `ExtractedMedicine.mealSlots` 추가
+- candidate 컬럼 2개 신설(suggested/confirmed)
+- candidate 응답·PATCH·confirm API 동작 변경
+- `MedicationScheduleRepository`에 (medicineId, mealSlot) 중복 방지용 조회 메서드 추가
+- 단위 + E2E 테스트 (LLM mock으로 슬롯 후보 주입, confirm 후 schedule 검증)
+- 도메인 문서 + Notion API 명세 동기화
+
+### 제외 (Out of Scope)
+- **`MealSlot` enum 확장 (BEDTIME, FASTING 등)** — 본 spec 범위 외. mealSlots=[]이면 schedule 자동 생성 skip하고 보호자 수동 등록으로 우회.
+- **dosage 자동 보정** — `extractedDosage`가 null이면 schedule 자동 생성 skip. 보호자가 수동 등록.
+- **요일 패턴 자동 매핑(월수금 등)** — daysOfWeek=`DAILY` 고정. 주 단위 패턴은 OCR 데이터 분포 보고 후속.
+- **시작일/종료일 자동 산출(예: "7일분")** — startDate=오늘, endDate=null 고정. 처방 일수 추출은 후속.
+- **자동 적용 (suggestion 없이 강제 생성)** — Safety 위반.
+- **LLM 슬롯 추출 정확도 모니터링 메트릭** — 별도 관측성 spec.
+- **시니어 권한으로 confirm 호출 시 추가 검증** — 기존 `validateMutationAccess` 그대로.
+- **mealTimes 미설정 시 graceful fallback** — 명시 400 반환. 부분 자동 생성 분기 도입 안 함.
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+- 컨텍스트: `prescription` (주) + `medication`(파급)
+- `PrescriptionMedicineCandidate`에 `suggestedMealSlots`(LLM 제안 CSV), `confirmedMealSlots`(보호자 확정 CSV) 추가
+- `MealSlot` enum, `MedicationSchedule`, `MedicationScheduleService.create` 검증 그대로 재사용
+
+### 5-2) API 엔드포인트
+
+| Method | Path | 설명 | 인증 | Req | Res |
+|---|---|---|---|---|---|
+| POST | /api/v1/prescriptions | OCR 생성. candidate 응답에 `suggestedMealSlots` 포함 | 필수 | 기존 | 기존 + 필드 |
+| GET | /api/v1/prescriptions/{id} | candidate 응답 동일 확장 | 필수 | — | 기존 + 필드 |
+| PATCH | /api/v1/prescriptions/{id}/medicines/{candidateId} | candidate 결정/슬롯 갱신 | 필수 | `CandidateDecisionRequest`(확장) | 200 |
+| POST | /api/v1/prescriptions/{id}/medicines | 수동 약 추가. `mealSlots` 선택 입력 | 필수 | `PrescriptionMedicineAddRequest`(확장) | 201 |
+| POST | /api/v1/prescriptions/{id}/confirm | confirm + candidate별 schedule 자동 생성 | 필수 | — | 기존 |
+
+#### CandidateDecisionRequest (확장)
+```json
+{
+  "decision": "ACCEPTED",
+  "chosenItemSeq": null,
+  "confirmedMealSlots": ["BREAKFAST", "LUNCH", "DINNER"]
+}
+```
+- `confirmedMealSlots`: optional. 누락이면 기존 값 유지(첫 PATCH면 null). decision이 ACCEPTED/MANUALLY_CORRECTED일 때만 의미 있음.
+
+#### PrescriptionMedicineCandidateResponse (확장)
+```json
+{
+  "id": 12,
+  "extractedName": "타이레놀정500밀리그람",
+  "extractedDosage": "1정",
+  "extractedSchedule": "1일 3회 식후",
+  "suggestedMealSlots": ["BREAKFAST", "LUNCH", "DINNER"],
+  "confirmedMealSlots": null,
+  "caregiverDecision": "PENDING",
+  ...
+}
+```
+
+#### confirm 동작 변경
+기존: ACCEPTED/MANUALLY_CORRECTED candidate → Medicine 생성.
+신규: 위에 더해, candidate `confirmedMealSlots`가 비어있지 않으면 슬롯별 `MedicationSchedule` 생성:
+- `medicineId` = 방금 생성한 Medicine
+- `mealSlot` = candidate `confirmedMealSlots`의 각 원소
+- `dosage` = candidate `extractedDosage` (null이면 schedule 생성 skip + 응답 메시지로 안내)
+- `daysOfWeek` = "DAILY"
+- `startDate` = 오늘
+- `endDate` = null
+
+#### 에러 응답
+| 상황 | HTTP | code |
+|---|---|---|
+| confirm 시 시니어 mealTimes의 해당 슬롯 미설정 | 400 | `USER_002` (`MEAL_TIMES_NOT_SET`) |
+| `confirmedMealSlots`에 잘못된 enum 값 | 400 | `COMMON_001` |
+| 인증/권한 | 기존 동일 | — |
+
+### 5-3) 외부 연동
+- OpenAI gpt-5.4-nano(text-only). 프롬프트만 확장, 추가 호출 없음.
+
+### 5-4) 데이터 흐름
+```
+[OCR 단계] (변경)
+PrescriptionService.processAndCreate
+  → OpenAiClient.extractMedicines(maskedText)
+       → 응답에 mealSlots 포함
+  → 각 candidate에 suggestedMealSlots 저장 (CSV)
+
+[보호자 검수 단계] (확장)
+PATCH /prescriptions/{id}/medicines/{candidateId}
+  body: { decision, chosenItemSeq, confirmedMealSlots }
+  → candidate.update(decision, chosenItemSeq, confirmedMealSlots)
+
+[confirm 단계] (확장)
+POST /prescriptions/{id}/confirm
+  → 모든 candidate decision=PENDING 아님 검증
+  → ACCEPTED/MANUALLY_CORRECTED candidate 순회
+       → Medicine 생성 (기존)
+       → candidate.confirmedMealSlots 비어있지 않고 dosage 있음:
+            → 각 슬롯에 대해 MedicationSchedule 생성
+                 (시니어 mealTimes 검증 → 미설정 시 400 즉시 throw)
+       → candidate.linkMedicine
+  → prescription.confirm()
+```
+
+### 5-5) DB 마이그레이션
+
+```sql
+-- prod
+ALTER TABLE prescription_medicine_candidates
+    ADD COLUMN suggested_meal_slots VARCHAR(64) NULL,
+    ADD COLUMN confirmed_meal_slots VARCHAR(64) NULL;
+```
+- CSV 형식. 예: `"BREAKFAST,LUNCH,DINNER"`. 길이 64 = 3슬롯 × ~10자 + 여유.
+- `schema.sql` 동기화.
+
+### 5-6) 코드 영향 범위
+| 파일 | 변경 |
+|---|---|
+| `common/ai/OpenAiClient.java` | 시스템 프롬프트에 mealSlots 매핑 규칙. `ExtractedMedicine` record에 `List<MealSlot> mealSlots` 추가. 응답 파싱에 enum 검증 |
+| `prescription/PrescriptionMedicineCandidate.java` | 컬럼 2개 + setter/도메인 메서드 |
+| `prescription/PrescriptionMedicineCandidateResponse.java` | 응답 필드 2개 |
+| `prescription/controller/dto/CandidateDecisionRequest.java` | `confirmedMealSlots` 추가 |
+| `prescription/service/PrescriptionService.java` | OCR 저장 로직에 suggestedMealSlots 저장. confirm에 schedule 생성 분기. mealTime 검증은 `MedicationScheduleService` 또는 동일 패턴으로 인라인 |
+| `medication/repository/MedicationScheduleRepository.java` | (선택) (medicineId, mealSlot) 중복 방지 조회 메서드. 멱등 보장용 |
+| `resources/schema.sql` | 컬럼 2개 추가 |
+| `docs/ai-harness/06-domain-model.md` | §4 유비쿼터스 랭귀지, §5 prescription_medicine_candidates 컬럼 표 |
+| `test/.../PrescriptionServiceTest.java` 또는 `PrescriptionControllerE2ETest.java` | confirm 시 schedule 자동 생성 검증, mealTimes 미설정 400 |
+
+## 6) 작업 분할 (예상 PR 리스트)
+- [ ] PR 1 (`docs(prescription)`): 본 spec
+- [ ] PR 2 (`feat(prescription)`): LLM 프롬프트 + candidate 컬럼 + suggestedMealSlots 응답 노출 + PATCH 갱신
+- [ ] PR 3 (`feat(prescription)`): confirm 시 schedule 자동 생성 + 멱등 보장 + E2E
+
+PR 2/3 분리 이유: PR 2는 prod 동작 변경 없이 데이터/응답만 확장 (사용자 기존 흐름 유지). PR 3는 confirm 동작 변경(schedule 자동 생성). 각각 독립 검증 가능.
+
+## 7) 테스트 전략
+- **단위 테스트**:
+  - `OpenAiClient`: 응답에 mealSlots 누락/잘못된 enum 시 빈 리스트로 정규화
+  - `PrescriptionMedicineCandidate.update*`: confirmedMealSlots 갱신 도메인 검증
+  - `PrescriptionService.confirm`: candidate confirmedMealSlots 기반 schedule 생성 mock
+- **E2E (RestAssured)**:
+  - 처방전 생성 → candidate 응답에 suggestedMealSlots 포함 확인 (LLM mock)
+  - PATCH로 confirmedMealSlots 갱신 → 응답 확인
+  - mealTimes 설정한 시니어 confirm → schedule N건 생성 확인 (DB 직접 조회)
+  - mealTimes 미설정 시니어 confirm → 400 USER_002
+  - confirm 재호출 시 schedule 중복 생성 안 됨 (멱등)
+- LLM 응답은 mock. 실제 OpenAI 호출 안 함.
+
+## 8) 오픈 질문
+| # | 질문 | 선택지 | 담당/기한 |
+|---|---|---|---|
+| Q1 | confirmedMealSlots 입력 시점 | (a) PATCH 본문 (Recommended, 확정) / (b) confirm 본문에 candidate 배열 / (c) 두 개 다 허용 | 결정 — (a) PATCH 본문. confirm은 트리거 단순화 |
+| Q2 | candidate `extractedDosage`가 null인 경우 | (a) schedule 자동 생성 skip + 응답에 안내 (Recommended) / (b) 400으로 confirm 거절 | 결정 — (a). 보호자가 후속 schedule 수동 등록으로 보완 |
+| Q3 | confirm 멱등 보장 방식 | (a) candidate.created_medicine_id 있으면 전체 skip / (b) (medicineId, mealSlot) UNIQUE 인덱스 / (c) 둘 다 | 결정 — (a) 우선. UNIQUE 인덱스는 보강 검토(스키마 변경 별도) |
+| Q4 | LLM 슬롯 매핑 정확도 검증 | (a) 운영 트래픽 보고 추후 / (b) 본 spec에 정확도 메트릭 포함 | (a). 본 spec 외. mismatch 발견 시 프롬프트 튜닝 follow-up |
+
+## 9) 결정 로그
+- 2026-05-07: 초안 작성 (status=draft). 시간대 Phase 3 = 처방전 confirm 자동 schedule 생성 + LLM 슬롯 매핑.
+- 2026-05-07: **매핑 = LLM 프롬프트 확장**. 정규식 휴리스틱 미채택. 이유: OCR이 이미 schedule 텍스트 추출 중이라 nano 추가 호출 없이 같은 응답에 슬롯 포함 가능.
+- 2026-05-07: **suggestion + 보호자 확정**. 자동 적용 미채택. 이유: 잘못 매핑 시 시니어 알림 시각 오류 → 안전 우선. 보호자 검수가 차단막.
+- 2026-05-07: **mealSlots=[] (식사 무관 약)**. schedule 자동 생성 skip + Medicine만 생성. 보호자 수동 schedule 등록으로 보완. BEDTIME 등 enum 확장은 본 spec 외.
+- 2026-05-07: **dosage null이면 schedule skip**. confirm 자체는 성공. 응답에 안내 정보 포함 검토(Q2 후속).
+- 2026-05-07: **confirmedMealSlots 입력 = PATCH**. confirm은 트리거. 흐름 분리 명확. UI는 candidate 검수 화면에서 PATCH 호출.
+- 2026-05-07: **mealTimes 미설정 시 400 즉시**. graceful fallback 없음. 보호자가 시니어 mealTimes 설정 후 재시도.

--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.medication.MealSlot;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -98,7 +99,7 @@ public class OpenAiClient {
                     - 약물이 없으면 빈 배열 반환.
 
                     ## 출력 형식
-                    {"medicines": [{"name": "약물명", "manufacturer": "제약사명", "ingredientName": "성분명", "dosage": "용량", "schedule": "복약주기"}]}
+                    {"medicines": [{"name": "약물명", "manufacturer": "제약사명", "ingredientName": "성분명", "dosage": "용량", "schedule": "복약주기", "mealSlots": ["BREAKFAST","LUNCH","DINNER"]}]}
                     - name: 제품명+제형+용량. 제약사명과 괄호 안 내용은 **제외**.
                       예: "위더스세파클러캡슐250밀리그람" → name: "세파클러캡슐250밀리그람", manufacturer: "위더스"
                       예: "에빅사정(메만틴염산염)_(10mg/1정)" → name: "에빅사정10밀리그램"
@@ -110,6 +111,15 @@ public class OpenAiClient {
                       주의: "(10mg/1정)" 같은 용량 표기는 성분명이 아님. 성분명은 한글 화학명.
                     - dosage: 1회 투약량 (예: "1정", "0.5정", "2캡슐"). 모르면 null.
                     - schedule: 복약주기 (예: "1일 3회 식후 30분"). 모르면 null.
+                    - mealSlots: schedule을 식사 슬롯으로 매핑한 배열. 가능한 값은 "BREAKFAST", "LUNCH", "DINNER"만.
+                      매핑 규칙:
+                      * "1일 3회 식후/식전" → ["BREAKFAST","LUNCH","DINNER"]
+                      * "1일 2회 (아침/저녁 또는 식후)" → ["BREAKFAST","DINNER"]
+                      * "1일 1회 아침" → ["BREAKFAST"]
+                      * "1일 1회 점심/저녁" → ["LUNCH"] / ["DINNER"]
+                      * "취침 전", "공복", "필요시" 등 식사 무관/불명확 → 빈 배열 []
+                      * schedule이 null이거나 슬롯 판단 불가 → 빈 배열 []
+                      * 다른 enum 값(예: "BEDTIME") 추측 금지 — 빈 배열로.
                     - JSON만 반환. 다른 텍스트 없이.
                     """;
 
@@ -154,7 +164,8 @@ public class OpenAiClient {
                         item.path("manufacturer").asText(null),
                         item.path("ingredientName").asText(null),
                         item.path("dosage").asText(null),
-                        item.path("schedule").asText(null)
+                        item.path("schedule").asText(null),
+                        parseMealSlots(item.path("mealSlots"))
                 ));
             }
 
@@ -165,6 +176,28 @@ public class OpenAiClient {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
                     "AI response parse failed: " + e.getMessage());
         }
+    }
+
+    /**
+     * LLM 응답의 mealSlots 배열을 MealSlot 리스트로 정규화.
+     * 누락/null/잘못된 enum 값은 빈 리스트로.
+     */
+    private static List<MealSlot> parseMealSlots(final JsonNode node) {
+        if (node == null || node.isMissingNode() || !node.isArray()) {
+            return List.of();
+        }
+        final List<MealSlot> slots = new ArrayList<>();
+        for (final JsonNode item : node) {
+            if (!item.isTextual()) {
+                continue;
+            }
+            try {
+                slots.add(MealSlot.valueOf(item.asText().trim()));
+            } catch (final IllegalArgumentException ignored) {
+                // 잘못된 enum 값은 무시
+            }
+        }
+        return slots;
     }
 
     /**
@@ -257,7 +290,8 @@ public class OpenAiClient {
             String manufacturer,
             String ingredientName,
             String dosage,
-            String schedule
+            String schedule,
+            List<MealSlot> mealSlots
     ) {
     }
 }

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "User not found"),
+    MEAL_TIMES_NOT_SET(HttpStatus.BAD_REQUEST, "USER_002", "Meal times are not set for the senior"),
 
     // Medicine
     MEDICINE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEDICINE_001", "Medicine not found"),

--- a/src/main/java/com/ppiyaki/common/mcp/MedicationMcpTools.java
+++ b/src/main/java/com/ppiyaki/common/mcp/MedicationMcpTools.java
@@ -4,8 +4,11 @@ import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.ai.tool.annotation.Tool;
@@ -18,18 +21,25 @@ public class MedicationMcpTools {
 
     private final MedicineRepository medicineRepository;
     private final MedicationScheduleRepository scheduleRepository;
+    private final UserRepository userRepository;
 
     public MedicationMcpTools(
             final MedicineRepository medicineRepository,
-            final MedicationScheduleRepository scheduleRepository
+            final MedicationScheduleRepository scheduleRepository,
+            final UserRepository userRepository
     ) {
         this.medicineRepository = medicineRepository;
         this.scheduleRepository = scheduleRepository;
+        this.userRepository = userRepository;
     }
 
-    @Tool(description = "Get today's medication schedule for the user. Returns medicine names, scheduled times, and dosages for today.")
+    @Tool(description = "Get today's medication schedule for the user. Returns medicine names, scheduled times (resolved from the senior's meal times), and dosages for today.")
     public List<ScheduleSummary> getTodaySchedules() {
         final Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final User user = userRepository.findById(userId).orElse(null);
+        if (user == null) {
+            return List.of();
+        }
         final List<Medicine> medicines = medicineRepository.findByOwnerId(userId);
         final LocalDate today = LocalDate.now();
         final String todayDay = dayOfWeekToKorean(today.getDayOfWeek());
@@ -41,9 +51,10 @@ public class MedicationMcpTools {
                 if (!isActiveToday(schedule, today, todayDay)) {
                     continue;
                 }
+                final LocalTime resolved = schedule.getMealSlot().resolveTime(user);
                 result.add(new ScheduleSummary(
                         medicine.getName(),
-                        schedule.getScheduledTime() != null ? schedule.getScheduledTime().toString() : null,
+                        resolved != null ? resolved.toString() : null,
                         schedule.getDosage()
                 ));
             }

--- a/src/main/java/com/ppiyaki/medication/MealSlot.java
+++ b/src/main/java/com/ppiyaki/medication/MealSlot.java
@@ -2,7 +2,10 @@ package com.ppiyaki.medication;
 
 import com.ppiyaki.user.User;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public enum MealSlot {
     BREAKFAST,
@@ -16,5 +19,31 @@ public enum MealSlot {
             case LUNCH -> user.getLunchTime();
             case DINNER -> user.getDinnerTime();
         };
+    }
+
+    public static List<MealSlot> parseCsv(final String csv) {
+        if (csv == null || csv.isBlank()) {
+            return List.of();
+        }
+        final List<MealSlot> result = new ArrayList<>();
+        for (final String token : csv.split(",")) {
+            final String trimmed = token.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            try {
+                result.add(MealSlot.valueOf(trimmed));
+            } catch (final IllegalArgumentException ignored) {
+                // 잘못된 enum 값은 무시 (LLM 응답 정규화)
+            }
+        }
+        return result;
+    }
+
+    public static String toCsv(final List<MealSlot> slots) {
+        if (slots == null || slots.isEmpty()) {
+            return null;
+        }
+        return slots.stream().map(MealSlot::name).collect(Collectors.joining(","));
     }
 }

--- a/src/main/java/com/ppiyaki/medication/MealSlot.java
+++ b/src/main/java/com/ppiyaki/medication/MealSlot.java
@@ -1,0 +1,20 @@
+package com.ppiyaki.medication;
+
+import com.ppiyaki.user.User;
+import java.time.LocalTime;
+import java.util.Objects;
+
+public enum MealSlot {
+    BREAKFAST,
+    LUNCH,
+    DINNER;
+
+    public LocalTime resolveTime(final User user) {
+        Objects.requireNonNull(user, "user must not be null");
+        return switch (this) {
+            case BREAKFAST -> user.getBreakfastTime();
+            case LUNCH -> user.getLunchTime();
+            case DINNER -> user.getDinnerTime();
+        };
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
+++ b/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
@@ -3,12 +3,13 @@ package com.ppiyaki.medication;
 import com.ppiyaki.common.entity.CreatedTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -27,8 +28,9 @@ public class MedicationSchedule extends CreatedTimeEntity {
     @Column(name = "medicine_id")
     private Long medicineId;
 
-    @Column(name = "scheduled_time")
-    private LocalTime scheduledTime;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "meal_slot", nullable = false, length = 16)
+    private MealSlot mealSlot;
 
     @Column(name = "dosage")
     private String dosage;
@@ -44,14 +46,14 @@ public class MedicationSchedule extends CreatedTimeEntity {
 
     public MedicationSchedule(
             final Long medicineId,
-            final LocalTime scheduledTime,
+            final MealSlot mealSlot,
             final String dosage,
             final String daysOfWeek,
             final LocalDate startDate,
             final LocalDate endDate
     ) {
         this.medicineId = Objects.requireNonNull(medicineId, "medicineId must not be null");
-        this.scheduledTime = Objects.requireNonNull(scheduledTime, "scheduledTime must not be null");
+        this.mealSlot = Objects.requireNonNull(mealSlot, "mealSlot must not be null");
         this.dosage = Objects.requireNonNull(dosage, "dosage must not be null");
         this.daysOfWeek = daysOfWeek;
         this.startDate = startDate;
@@ -59,14 +61,14 @@ public class MedicationSchedule extends CreatedTimeEntity {
     }
 
     public void update(
-            final LocalTime scheduledTime,
+            final MealSlot mealSlot,
             final String dosage,
             final String daysOfWeek,
             final LocalDate startDate,
             final LocalDate endDate
     ) {
-        if (scheduledTime != null) {
-            this.scheduledTime = scheduledTime;
+        if (mealSlot != null) {
+            this.mealSlot = mealSlot;
         }
         if (dosage != null) {
             this.dosage = dosage;

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleCreateRequest.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleCreateRequest.java
@@ -1,13 +1,13 @@
 package com.ppiyaki.medication.controller.dto;
 
+import com.ppiyaki.medication.MealSlot;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
-import java.time.LocalTime;
 
 public record ScheduleCreateRequest(
-        @NotNull LocalTime scheduledTime,
+        @NotNull MealSlot mealSlot,
         @NotBlank String dosage,
         @Pattern(
                 regexp = "^(DAILY|(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN))*)$", message = "daysOfWeek must be 'DAILY' or a comma-separated list of MON,TUE,WED,THU,FRI,SAT,SUN"

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleResponse.java
@@ -1,6 +1,8 @@
 package com.ppiyaki.medication.controller.dto;
 
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.user.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -8,6 +10,7 @@ import java.time.LocalTime;
 public record ScheduleResponse(
         Long id,
         Long medicineId,
+        MealSlot mealSlot,
         LocalTime scheduledTime,
         String dosage,
         String daysOfWeek,
@@ -16,11 +19,12 @@ public record ScheduleResponse(
         LocalDateTime createdAt
 ) {
 
-    public static ScheduleResponse from(final MedicationSchedule schedule) {
+    public static ScheduleResponse from(final MedicationSchedule schedule, final User owner) {
         return new ScheduleResponse(
                 schedule.getId(),
                 schedule.getMedicineId(),
-                schedule.getScheduledTime(),
+                schedule.getMealSlot(),
+                schedule.getMealSlot().resolveTime(owner),
                 schedule.getDosage(),
                 schedule.getDaysOfWeek(),
                 schedule.getStartDate(),

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleUpdateRequest.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleUpdateRequest.java
@@ -1,11 +1,11 @@
 package com.ppiyaki.medication.controller.dto;
 
+import com.ppiyaki.medication.MealSlot;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
-import java.time.LocalTime;
 
 public record ScheduleUpdateRequest(
-        LocalTime scheduledTime,
+        MealSlot mealSlot,
         String dosage,
         @Pattern(
                 regexp = "^(DAILY|(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN))*)$", message = "daysOfWeek must be 'DAILY' or a comma-separated list of MON,TUE,WED,THU,FRI,SAT,SUN"

--- a/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
@@ -1,8 +1,8 @@
 package com.ppiyaki.medication.repository;
 
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationSchedule;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,18 +15,18 @@ public interface MedicationScheduleRepository extends JpaRepository<MedicationSc
     int deleteByMedicineId(final Long medicineId);
 
     /**
-     * 같은 시니어가 같은 시각에 복용 예정인 active schedule 전체.
+     * 같은 시니어가 같은 식사 슬롯에 복용 예정인 active schedule 전체.
      * Phase 2 약 개수 검증의 기대 카운트 산출용 (medication-log-phase2 §5-4).
      */
     @Query("""
             SELECT s FROM MedicationSchedule s
             WHERE s.medicineId IN (SELECT m.id FROM Medicine m WHERE m.ownerId = :seniorId)
-              AND s.scheduledTime = :time
+              AND s.mealSlot = :mealSlot
               AND (s.startDate IS NULL OR s.startDate <= :date)
               AND (s.endDate IS NULL OR s.endDate >= :date)
             """)
-    List<MedicationSchedule> findActiveByOwnerAndScheduledTime(
+    List<MedicationSchedule> findActiveByOwnerAndMealSlot(
             @Param("seniorId") final Long seniorId,
             @Param("date") final LocalDate date,
-            @Param("time") final LocalTime time);
+            @Param("mealSlot") final MealSlot mealSlot);
 }

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -121,7 +121,7 @@ public class MedicationLogService {
     }
 
     /**
-     * 동일 시각 schedule들의 dosage 합 vs Vision 추출 개수 비교.
+     * 동일 식사 슬롯 schedule들의 dosage 합 vs Vision 추출 개수 비교.
      * spec medication-log-phase2 §5-4.
      */
     private LogAiStatus verifyPillCount(
@@ -130,8 +130,8 @@ public class MedicationLogService {
             final MedicationLogUpsertRequest request
     ) {
         final List<MedicationSchedule> schedules = medicationScheduleRepository
-                .findActiveByOwnerAndScheduledTime(
-                        seniorId, request.targetDate(), triggerSchedule.getScheduledTime());
+                .findActiveByOwnerAndMealSlot(
+                        seniorId, request.targetDate(), triggerSchedule.getMealSlot());
 
         int expected = 0;
         for (final MedicationSchedule s : schedules) {

--- a/src/main/java/com/ppiyaki/medication/service/MedicationScheduleService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationScheduleService.java
@@ -2,6 +2,7 @@ package com.ppiyaki.medication.service;
 
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.controller.dto.ScheduleCreateRequest;
 import com.ppiyaki.medication.controller.dto.ScheduleResponse;
@@ -9,7 +10,9 @@ import com.ppiyaki.medication.controller.dto.ScheduleUpdateRequest;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -21,15 +24,18 @@ public class MedicationScheduleService {
     private final MedicationScheduleRepository medicationScheduleRepository;
     private final MedicineRepository medicineRepository;
     private final CareRelationRepository careRelationRepository;
+    private final UserRepository userRepository;
 
     public MedicationScheduleService(
             final MedicationScheduleRepository medicationScheduleRepository,
             final MedicineRepository medicineRepository,
-            final CareRelationRepository careRelationRepository
+            final CareRelationRepository careRelationRepository,
+            final UserRepository userRepository
     ) {
         this.medicationScheduleRepository = medicationScheduleRepository;
         this.medicineRepository = medicineRepository;
         this.careRelationRepository = careRelationRepository;
+        this.userRepository = userRepository;
     }
 
     @Transactional
@@ -39,6 +45,8 @@ public class MedicationScheduleService {
             final ScheduleCreateRequest scheduleCreateRequest
     ) {
         final Medicine medicine = findMedicineAndValidateAccess(userId, medicineId);
+        final User owner = findOwner(medicine.getOwnerId());
+        validateMealTimeSet(owner, scheduleCreateRequest.mealSlot());
 
         final String daysOfWeek = scheduleCreateRequest.daysOfWeek() != null
                 ? scheduleCreateRequest.daysOfWeek() : "DAILY";
@@ -47,7 +55,7 @@ public class MedicationScheduleService {
 
         final MedicationSchedule schedule = new MedicationSchedule(
                 medicine.getId(),
-                scheduleCreateRequest.scheduledTime(),
+                scheduleCreateRequest.mealSlot(),
                 scheduleCreateRequest.dosage(),
                 daysOfWeek,
                 startDate,
@@ -55,16 +63,17 @@ public class MedicationScheduleService {
         );
 
         final MedicationSchedule savedSchedule = medicationScheduleRepository.save(schedule);
-        return ScheduleResponse.from(savedSchedule);
+        return ScheduleResponse.from(savedSchedule, owner);
     }
 
     @Transactional(readOnly = true)
     public List<ScheduleResponse> readAll(final Long userId, final Long medicineId) {
-        findMedicineAndValidateAccess(userId, medicineId);
+        final Medicine medicine = findMedicineAndValidateAccess(userId, medicineId);
+        final User owner = findOwner(medicine.getOwnerId());
 
         final List<MedicationSchedule> schedules = medicationScheduleRepository.findByMedicineId(medicineId);
         return schedules.stream()
-                .map(ScheduleResponse::from)
+                .map(schedule -> ScheduleResponse.from(schedule, owner))
                 .toList();
     }
 
@@ -74,10 +83,11 @@ public class MedicationScheduleService {
             final Long medicineId,
             final Long scheduleId
     ) {
-        findMedicineAndValidateAccess(userId, medicineId);
+        final Medicine medicine = findMedicineAndValidateAccess(userId, medicineId);
+        final User owner = findOwner(medicine.getOwnerId());
         final MedicationSchedule schedule = findScheduleAndValidateMedicine(scheduleId, medicineId);
 
-        return ScheduleResponse.from(schedule);
+        return ScheduleResponse.from(schedule, owner);
     }
 
     @Transactional
@@ -87,18 +97,23 @@ public class MedicationScheduleService {
             final Long scheduleId,
             final ScheduleUpdateRequest scheduleUpdateRequest
     ) {
-        findMedicineAndValidateAccess(userId, medicineId);
+        final Medicine medicine = findMedicineAndValidateAccess(userId, medicineId);
+        final User owner = findOwner(medicine.getOwnerId());
         final MedicationSchedule schedule = findScheduleAndValidateMedicine(scheduleId, medicineId);
 
+        if (scheduleUpdateRequest.mealSlot() != null) {
+            validateMealTimeSet(owner, scheduleUpdateRequest.mealSlot());
+        }
+
         schedule.update(
-                scheduleUpdateRequest.scheduledTime(),
+                scheduleUpdateRequest.mealSlot(),
                 scheduleUpdateRequest.dosage(),
                 scheduleUpdateRequest.daysOfWeek(),
                 scheduleUpdateRequest.startDate(),
                 scheduleUpdateRequest.endDate()
         );
 
-        return ScheduleResponse.from(schedule);
+        return ScheduleResponse.from(schedule, owner);
     }
 
     @Transactional
@@ -140,5 +155,17 @@ public class MedicationScheduleService {
         }
 
         return schedule;
+    }
+
+    private User findOwner(final Long ownerId) {
+        return userRepository.findById(ownerId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.USER_NOT_FOUND, "Owner not found: " + ownerId));
+    }
+
+    private void validateMealTimeSet(final User owner, final MealSlot mealSlot) {
+        if (mealSlot.resolveTime(owner) == null) {
+            throw new BusinessException(ErrorCode.MEAL_TIMES_NOT_SET);
+        }
     }
 }

--- a/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
+++ b/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.prescription;
 
 import com.ppiyaki.common.entity.CreatedTimeEntity;
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medicine.service.MatchType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -11,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -67,6 +69,12 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
     @Column(name = "created_medicine_id")
     private Long createdMedicineId;
 
+    @Column(name = "suggested_meal_slots", length = 64)
+    private String suggestedMealSlots;
+
+    @Column(name = "confirmed_meal_slots", length = 64)
+    private String confirmedMealSlots;
+
     private static final String MANUAL_ADD_REASON = "보호자 수동 추가";
     private static final String MANUAL_ADD_RAW_TEXT = "보호자 수동 추가";
 
@@ -79,7 +87,8 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
             final String matchedItemSeq,
             final String matchedItemName,
             final MatchType matchType,
-            final String matchReason
+            final String matchReason,
+            final List<MealSlot> suggestedMealSlots
     ) {
         this.prescriptionId = Objects.requireNonNull(prescriptionId, "prescriptionId must not be null");
         this.ocrRawText = ocrRawText;
@@ -91,6 +100,7 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
         this.matchType = matchType;
         this.matchReason = matchReason;
         this.caregiverDecision = CaregiverDecision.PENDING;
+        this.suggestedMealSlots = MealSlot.toCsv(suggestedMealSlots);
     }
 
     public static PrescriptionMedicineCandidate manualAdd(
@@ -111,7 +121,8 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
                 itemSeq,
                 itemName,
                 MatchType.EXACT,
-                MANUAL_ADD_REASON
+                MANUAL_ADD_REASON,
+                List.of()
         );
         candidate.caregiverDecision = CaregiverDecision.ACCEPTED;
         candidate.caregiverChosenItemSeq = itemSeq;
@@ -137,5 +148,17 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
 
     public void linkMedicine(final Long medicineId) {
         this.createdMedicineId = medicineId;
+    }
+
+    public void updateConfirmedMealSlots(final List<MealSlot> slots) {
+        this.confirmedMealSlots = MealSlot.toCsv(slots);
+    }
+
+    public List<MealSlot> getSuggestedMealSlotsList() {
+        return MealSlot.parseCsv(this.suggestedMealSlots);
+    }
+
+    public List<MealSlot> getConfirmedMealSlotsList() {
+        return MealSlot.parseCsv(this.confirmedMealSlots);
     }
 }

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
@@ -1,10 +1,13 @@
 package com.ppiyaki.prescription.controller.dto;
 
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.prescription.CaregiverDecision;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 public record CandidateDecisionRequest(
         @NotNull CaregiverDecision decision,
-        String chosenItemSeq
+        String chosenItemSeq,
+        List<MealSlot> confirmedMealSlots
 ) {
 }

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineCandidateResponse.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineCandidateResponse.java
@@ -1,6 +1,8 @@
 package com.ppiyaki.prescription.controller.dto;
 
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.prescription.PrescriptionMedicineCandidate;
+import java.util.List;
 
 public record PrescriptionMedicineCandidateResponse(
         Long id,
@@ -14,7 +16,9 @@ public record PrescriptionMedicineCandidateResponse(
         String matchReason,
         String caregiverDecision,
         String caregiverChosenItemSeq,
-        Long createdMedicineId
+        Long createdMedicineId,
+        List<MealSlot> suggestedMealSlots,
+        List<MealSlot> confirmedMealSlots
 ) {
 
     public static PrescriptionMedicineCandidateResponse from(final PrescriptionMedicineCandidate candidate) {
@@ -30,7 +34,9 @@ public record PrescriptionMedicineCandidateResponse(
                 candidate.getMatchReason(),
                 candidate.getCaregiverDecision().name(),
                 candidate.getCaregiverChosenItemSeq(),
-                candidate.getCreatedMedicineId()
+                candidate.getCreatedMedicineId(),
+                candidate.getSuggestedMealSlotsList(),
+                candidate.getConfirmedMealSlotsList()
         );
     }
 }

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -8,6 +8,9 @@ import com.ppiyaki.common.ocr.ClovaOcrClient;
 import com.ppiyaki.common.ocr.ClovaOcrClient.OcrResult;
 import com.ppiyaki.common.ocr.ClovaOcrClient.OcrToken;
 import com.ppiyaki.common.storage.NcpStorageProperties;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.controller.dto.MedicineCandidate;
 import com.ppiyaki.medicine.repository.MedicineRepository;
@@ -33,6 +36,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -59,6 +63,7 @@ public class PrescriptionService {
     private final PrescriptionRepository prescriptionRepository;
     private final PrescriptionMedicineCandidateRepository candidateRepository;
     private final MedicineRepository medicineRepository;
+    private final MedicationScheduleRepository medicationScheduleRepository;
     private final CareRelationRepository careRelationRepository;
     private final UserRepository userRepository;
     private final ClovaOcrClient clovaOcrClient;
@@ -73,6 +78,7 @@ public class PrescriptionService {
             final PrescriptionRepository prescriptionRepository,
             final PrescriptionMedicineCandidateRepository candidateRepository,
             final MedicineRepository medicineRepository,
+            final MedicationScheduleRepository medicationScheduleRepository,
             final CareRelationRepository careRelationRepository,
             final UserRepository userRepository,
             final ClovaOcrClient clovaOcrClient,
@@ -86,6 +92,7 @@ public class PrescriptionService {
         this.prescriptionRepository = prescriptionRepository;
         this.candidateRepository = candidateRepository;
         this.medicineRepository = medicineRepository;
+        this.medicationScheduleRepository = medicationScheduleRepository;
         this.careRelationRepository = careRelationRepository;
         this.userRepository = userRepository;
         this.clovaOcrClient = clovaOcrClient;
@@ -245,27 +252,63 @@ public class PrescriptionService {
                     "All candidates must be decided before confirming.");
         }
 
+        // 시니어 mealTimes 사전 검증: 슬롯 자동 생성 대상 candidate가 있는데
+        // 해당 슬롯의 mealTime이 null이면 트랜잭션 변경 시작 전에 거절 (spec §3, USER_002).
+        final User owner = userRepository.findById(prescription.getOwnerId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         for (final PrescriptionMedicineCandidate candidate : candidates) {
-            if (candidate.getCaregiverDecision() == CaregiverDecision.ACCEPTED
-                    || candidate.getCaregiverDecision() == CaregiverDecision.MANUALLY_CORRECTED) {
+            if (!isAcceptedOrCorrected(candidate) || candidate.getCreatedMedicineId() != null) {
+                continue;
+            }
+            for (final MealSlot slot : candidate.getConfirmedMealSlotsList()) {
+                if (slot.resolveTime(owner) == null) {
+                    throw new BusinessException(ErrorCode.MEAL_TIMES_NOT_SET);
+                }
+            }
+        }
 
-                final String itemSeq = candidate.getCaregiverChosenItemSeq() != null
-                        ? candidate.getCaregiverChosenItemSeq()
-                        : candidate.getMatchedItemSeq();
-                final String name = candidate.getMatchedItemName() != null
-                        ? candidate.getMatchedItemName()
-                        : candidate.getExtractedName();
+        final LocalDate today = LocalDate.now();
+        for (final PrescriptionMedicineCandidate candidate : candidates) {
+            if (!isAcceptedOrCorrected(candidate)) {
+                continue;
+            }
+            // 멱등: 이미 Medicine이 생성된 candidate는 skip (재confirm 시 중복 생성 방지).
+            if (candidate.getCreatedMedicineId() != null) {
+                continue;
+            }
 
-                final Medicine medicine = new Medicine(
-                        prescription.getOwnerId(), prescription.getId(),
-                        name, 0, 0, itemSeq, null);
-                medicineRepository.save(medicine);
-                candidate.linkMedicine(medicine.getId());
+            final String itemSeq = candidate.getCaregiverChosenItemSeq() != null
+                    ? candidate.getCaregiverChosenItemSeq()
+                    : candidate.getMatchedItemSeq();
+            final String name = candidate.getMatchedItemName() != null
+                    ? candidate.getMatchedItemName()
+                    : candidate.getExtractedName();
+
+            final Medicine medicine = new Medicine(
+                    prescription.getOwnerId(), prescription.getId(),
+                    name, 0, 0, itemSeq, null);
+            medicineRepository.save(medicine);
+            candidate.linkMedicine(medicine.getId());
+
+            // dosage가 비어있으면 schedule 자동 생성 skip — Medicine만 등록.
+            // 보호자가 후속으로 schedule CRUD API로 보완 (spec §3 Q2).
+            final String dosage = candidate.getExtractedDosage();
+            if (dosage == null || dosage.isBlank()) {
+                continue;
+            }
+            for (final MealSlot slot : candidate.getConfirmedMealSlotsList()) {
+                medicationScheduleRepository.save(new MedicationSchedule(
+                        medicine.getId(), slot, dosage, "DAILY", today, null));
             }
         }
 
         prescription.confirm();
         return PrescriptionDetailResponse.from(prescription, candidates);
+    }
+
+    private boolean isAcceptedOrCorrected(final PrescriptionMedicineCandidate candidate) {
+        return candidate.getCaregiverDecision() == CaregiverDecision.ACCEPTED
+                || candidate.getCaregiverDecision() == CaregiverDecision.MANUALLY_CORRECTED;
     }
 
     @Transactional

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -142,7 +142,8 @@ public class PrescriptionService {
                         matched != null ? matched.itemSeq() : null,
                         matched != null ? matched.itemName() : null,
                         matchResult.matchType(),
-                        matchResult.reason()
+                        matchResult.reason(),
+                        med.mealSlots()
                 ));
             }
 
@@ -197,6 +198,10 @@ public class PrescriptionService {
             case REJECTED -> candidate.reject();
             case MANUALLY_CORRECTED -> candidate.correctManually(request.chosenItemSeq());
             default -> throw new BusinessException(ErrorCode.INVALID_INPUT, "Invalid decision: " + request.decision());
+        }
+
+        if (request.confirmedMealSlots() != null) {
+            candidate.updateConfirmedMealSlots(request.confirmedMealSlots());
         }
     }
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -79,13 +79,13 @@
 
     create table medication_schedules (
         end_date date,
-        scheduled_time time(6),
         start_date date,
         created_at datetime(6),
         id bigint not null auto_increment,
         medicine_id bigint,
         days_of_week varchar(255),
         dosage varchar(255),
+        meal_slot varchar(16) not null,
         primary key (id)
     ) engine=InnoDB;
 

--- a/src/test/java/com/ppiyaki/medication/MealSlotTest.java
+++ b/src/test/java/com/ppiyaki/medication/MealSlotTest.java
@@ -1,0 +1,82 @@
+package com.ppiyaki.medication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ppiyaki.user.User;
+import java.lang.reflect.Field;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MealSlot.resolveTime: 슬롯별로 시니어 mealTime을 매핑한다")
+class MealSlotTest {
+
+    @Test
+    @DisplayName("BREAKFAST → user.breakfastTime")
+    void breakfast_returnsBreakfastTime() throws Exception {
+        final User user = userWith(LocalTime.of(7, 30), LocalTime.of(12, 0), LocalTime.of(18, 0));
+
+        assertThat(MealSlot.BREAKFAST.resolveTime(user)).isEqualTo(LocalTime.of(7, 30));
+    }
+
+    @Test
+    @DisplayName("LUNCH → user.lunchTime")
+    void lunch_returnsLunchTime() throws Exception {
+        final User user = userWith(LocalTime.of(7, 30), LocalTime.of(12, 0), LocalTime.of(18, 0));
+
+        assertThat(MealSlot.LUNCH.resolveTime(user)).isEqualTo(LocalTime.of(12, 0));
+    }
+
+    @Test
+    @DisplayName("DINNER → user.dinnerTime")
+    void dinner_returnsDinnerTime() throws Exception {
+        final User user = userWith(LocalTime.of(7, 30), LocalTime.of(12, 0), LocalTime.of(18, 0));
+
+        assertThat(MealSlot.DINNER.resolveTime(user)).isEqualTo(LocalTime.of(18, 0));
+    }
+
+    @Test
+    @DisplayName("user.lunchTime이 null이면 LUNCH는 null 반환")
+    void nullMealTime_returnsNull() throws Exception {
+        final User user = userWith(LocalTime.of(7, 30), null, LocalTime.of(18, 0));
+
+        assertThat(MealSlot.LUNCH.resolveTime(user)).isNull();
+    }
+
+    @Test
+    @DisplayName("user가 null이면 NPE")
+    void nullUser_throws() {
+        assertThatThrownBy(() -> MealSlot.BREAKFAST.resolveTime(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    private User userWith(
+            final LocalTime breakfast,
+            final LocalTime lunch,
+            final LocalTime dinner
+    ) throws Exception {
+        final var ctor = User.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final User user = ctor.newInstance();
+        setField(user, "breakfastTime", breakfast);
+        setField(user, "lunchTime", lunch);
+        setField(user, "dinnerTime", dinner);
+        return user;
+    }
+
+    private static void setField(final Object target, final String fieldName, final Object value) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/MealSlotTest.java
+++ b/src/test/java/com/ppiyaki/medication/MealSlotTest.java
@@ -51,6 +51,42 @@ class MealSlotTest {
                 .isInstanceOf(NullPointerException.class);
     }
 
+    @Test
+    @DisplayName("parseCsv: 표준 CSV → 리스트")
+    void parseCsv_standard() {
+        assertThat(MealSlot.parseCsv("BREAKFAST,LUNCH,DINNER"))
+                .containsExactly(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER);
+    }
+
+    @Test
+    @DisplayName("parseCsv: 공백/빈 토큰/잘못된 enum 값 → 무시")
+    void parseCsv_normalizes() {
+        assertThat(MealSlot.parseCsv(" BREAKFAST , ,BEDTIME, LUNCH "))
+                .containsExactly(MealSlot.BREAKFAST, MealSlot.LUNCH);
+    }
+
+    @Test
+    @DisplayName("parseCsv: null/blank → 빈 리스트")
+    void parseCsv_blank() {
+        assertThat(MealSlot.parseCsv(null)).isEmpty();
+        assertThat(MealSlot.parseCsv("")).isEmpty();
+        assertThat(MealSlot.parseCsv("   ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("toCsv: 표준 리스트 → CSV")
+    void toCsv_standard() {
+        assertThat(MealSlot.toCsv(java.util.List.of(MealSlot.BREAKFAST, MealSlot.DINNER)))
+                .isEqualTo("BREAKFAST,DINNER");
+    }
+
+    @Test
+    @DisplayName("toCsv: null/empty → null (DB에 null 저장)")
+    void toCsv_empty_returnsNull() {
+        assertThat(MealSlot.toCsv(null)).isNull();
+        assertThat(MealSlot.toCsv(java.util.List.of())).isNull();
+    }
+
     private User userWith(
             final LocalTime breakfast,
             final LocalTime lunch,

--- a/src/test/java/com/ppiyaki/medication/MedicationScheduleTest.java
+++ b/src/test/java/com/ppiyaki/medication/MedicationScheduleTest.java
@@ -1,0 +1,43 @@
+package com.ppiyaki.medication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MedicationSchedule 생성자/update 도메인 검증")
+class MedicationScheduleTest {
+
+    @Test
+    @DisplayName("mealSlot null이면 NPE")
+    void nullMealSlot_throws() {
+        assertThatThrownBy(() -> new MedicationSchedule(
+                1L, null, "1정", "DAILY", LocalDate.now(), null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("update에 mealSlot null이면 기존 값 유지")
+    void update_keepsMealSlotWhenNull() {
+        final MedicationSchedule schedule = new MedicationSchedule(
+                1L, MealSlot.BREAKFAST, "1정", "DAILY", LocalDate.now(), null);
+
+        schedule.update(null, "2정", null, null, null);
+
+        assertThat(schedule.getMealSlot()).isEqualTo(MealSlot.BREAKFAST);
+        assertThat(schedule.getDosage()).isEqualTo("2정");
+    }
+
+    @Test
+    @DisplayName("update로 슬롯 변경 가능")
+    void update_changesMealSlot() {
+        final MedicationSchedule schedule = new MedicationSchedule(
+                1L, MealSlot.BREAKFAST, "1정", "DAILY", LocalDate.now(), null);
+
+        schedule.update(MealSlot.DINNER, null, null, null, null);
+
+        assertThat(schedule.getMealSlot()).isEqualTo(MealSlot.DINNER);
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
@@ -17,7 +18,6 @@ import io.restassured.http.ContentType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -256,7 +256,7 @@ class MedicationLogControllerE2ETest {
         ctor.setAccessible(true);
         final MedicationSchedule schedule = ctor.newInstance();
         setField(schedule, "medicineId", medicineId);
-        setField(schedule, "scheduledTime", LocalTime.of(9, 0));
+        setField(schedule, "mealSlot", MealSlot.BREAKFAST);
         setField(schedule, "dosage", "1정");
         setField(schedule, "daysOfWeek", "DAILY");
         setField(schedule, "startDate", LocalDate.of(2026, 4, 1));

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
@@ -41,6 +41,7 @@ class MedicationScheduleControllerE2ETest {
     void create_success() {
         // given
         final String token = loginAsNewUser("일정등록유저");
+        setDefaultMealTimes(token);
         final Integer medicineId = createMedicine(token, "타이레놀정", 30, 25);
 
         // when & then
@@ -49,7 +50,7 @@ class MedicationScheduleControllerE2ETest {
                 .header("Authorization", "Bearer " + token)
                 .body("""
                         {
-                            "scheduledTime": "08:00",
+                            "mealSlot": "BREAKFAST",
                             "dosage": "1정",
                             "daysOfWeek": "DAILY",
                             "startDate": "2026-04-11"
@@ -61,9 +62,81 @@ class MedicationScheduleControllerE2ETest {
                 .statusCode(201)
                 .body("id", notNullValue())
                 .body("medicineId", is(medicineId))
+                .body("mealSlot", is("BREAKFAST"))
                 .body("scheduledTime", is("08:00:00"))
                 .body("dosage", is("1정"))
                 .body("daysOfWeek", is("DAILY"));
+    }
+
+    @Test
+    @DisplayName("시니어 mealTimes 미설정 상태에서 schedule 등록 시 400 USER_002")
+    void create_mealTimesNotSet_returns400() {
+        // given
+        final String token = loginAsNewUser("미설정유저");
+        final Integer medicineId = createMedicine(token, "약", 30, 25);
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body("""
+                        {
+                            "mealSlot": "LUNCH",
+                            "dosage": "1정"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/medicines/" + medicineId + "/schedules")
+                .then()
+                .statusCode(400)
+                .body("error.code", is("USER_002"));
+    }
+
+    @Test
+    @DisplayName("잘못된 mealSlot 값이면 400")
+    void create_invalidMealSlot_returns400() {
+        // given
+        final String token = loginAsNewUser("잘못된슬롯유저");
+        setDefaultMealTimes(token);
+        final Integer medicineId = createMedicine(token, "약", 30, 25);
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body("""
+                        {
+                            "mealSlot": "MIDNIGHT",
+                            "dosage": "1정"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/medicines/" + medicineId + "/schedules")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("mealTimes 변경 시 schedule 응답의 scheduledTime이 새 값으로 반영된다")
+    void scheduledTime_reflectsUpdatedMealTimes() {
+        // given
+        final String token = loginAsNewUser("시간변경유저");
+        setMealTimes(token, "08:00:00", "12:30:00", "18:30:00");
+        final Integer medicineId = createMedicine(token, "약", 30, 25);
+        final Integer scheduleId = createSchedule(token, medicineId, "LUNCH", "1정");
+
+        // when: mealTimes 변경
+        setMealTimes(token, "08:00:00", "13:15:00", "18:30:00");
+
+        // then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/medicines/" + medicineId + "/schedules/" + scheduleId)
+                .then()
+                .statusCode(200)
+                .body("mealSlot", is("LUNCH"))
+                .body("scheduledTime", is("13:15:00"));
     }
 
     @Test
@@ -71,9 +144,10 @@ class MedicationScheduleControllerE2ETest {
     void readAll_success() {
         // given
         final String token = loginAsNewUser("목록유저");
+        setDefaultMealTimes(token);
         final Integer medicineId = createMedicine(token, "비타민C", 60, 50);
-        createSchedule(token, medicineId, "08:00", "1정");
-        createSchedule(token, medicineId, "20:00", "1정");
+        createSchedule(token, medicineId, "BREAKFAST", "1정");
+        createSchedule(token, medicineId, "DINNER", "1정");
 
         // when & then
         RestAssured.given()
@@ -90,8 +164,9 @@ class MedicationScheduleControllerE2ETest {
     void readById_success() {
         // given
         final String token = loginAsNewUser("상세유저");
+        setDefaultMealTimes(token);
         final Integer medicineId = createMedicine(token, "오메가3", 90, 80);
-        final Integer scheduleId = createSchedule(token, medicineId, "09:00", "2정");
+        final Integer scheduleId = createSchedule(token, medicineId, "LUNCH", "2정");
 
         // when & then
         RestAssured.given()
@@ -101,7 +176,8 @@ class MedicationScheduleControllerE2ETest {
                 .then()
                 .statusCode(200)
                 .body("dosage", is("2정"))
-                .body("scheduledTime", is("09:00:00"));
+                .body("mealSlot", is("LUNCH"))
+                .body("scheduledTime", is("12:30:00"));
     }
 
     @Test
@@ -109,8 +185,9 @@ class MedicationScheduleControllerE2ETest {
     void update_success() {
         // given
         final String token = loginAsNewUser("수정유저");
+        setDefaultMealTimes(token);
         final Integer medicineId = createMedicine(token, "아스피린", 20, 15);
-        final Integer scheduleId = createSchedule(token, medicineId, "08:00", "1정");
+        final Integer scheduleId = createSchedule(token, medicineId, "BREAKFAST", "1정");
 
         // when & then
         RestAssured.given()
@@ -118,7 +195,7 @@ class MedicationScheduleControllerE2ETest {
                 .header("Authorization", "Bearer " + token)
                 .body("""
                         {
-                            "scheduledTime": "09:30",
+                            "mealSlot": "DINNER",
                             "dosage": "2정"
                         }
                         """)
@@ -126,7 +203,8 @@ class MedicationScheduleControllerE2ETest {
                 .patch("/api/v1/medicines/" + medicineId + "/schedules/" + scheduleId)
                 .then()
                 .statusCode(200)
-                .body("scheduledTime", is("09:30:00"))
+                .body("mealSlot", is("DINNER"))
+                .body("scheduledTime", is("18:30:00"))
                 .body("dosage", is("2정"));
     }
 
@@ -135,8 +213,9 @@ class MedicationScheduleControllerE2ETest {
     void delete_success() {
         // given
         final String token = loginAsNewUser("삭제유저");
+        setDefaultMealTimes(token);
         final Integer medicineId = createMedicine(token, "삭제약", 10, 5);
-        final Integer scheduleId = createSchedule(token, medicineId, "12:00", "1정");
+        final Integer scheduleId = createSchedule(token, medicineId, "LUNCH", "1정");
 
         // when & then
         RestAssured.given()
@@ -152,6 +231,7 @@ class MedicationScheduleControllerE2ETest {
     void caregiver_canAccessSeniorSchedules() {
         // given
         final String seniorToken = loginAsNewUser("시니어");
+        setDefaultMealTimes(seniorToken);
         final Long seniorUserId = readUserId(seniorToken);
         final Integer medicineId = createMedicine(seniorToken, "시니어약", 30, 20);
 
@@ -166,7 +246,7 @@ class MedicationScheduleControllerE2ETest {
                 .header("Authorization", "Bearer " + caregiverToken)
                 .body("""
                         {
-                            "scheduledTime": "07:30",
+                            "mealSlot": "BREAKFAST",
                             "dosage": "1정",
                             "daysOfWeek": "DAILY"
                         }
@@ -186,7 +266,8 @@ class MedicationScheduleControllerE2ETest {
                 .get("/api/v1/medicines/" + medicineId + "/schedules/" + scheduleId)
                 .then()
                 .statusCode(200)
-                .body("dosage", is("1정"));
+                .body("dosage", is("1정"))
+                .body("scheduledTime", is("08:00:00"));
     }
 
     @Test
@@ -194,9 +275,11 @@ class MedicationScheduleControllerE2ETest {
     void create_forbidden() {
         // given
         final String ownerToken = loginAsNewUser("소유자");
+        setDefaultMealTimes(ownerToken);
         final Integer medicineId = createMedicine(ownerToken, "소유자약", 10, 5);
 
         final String otherToken = loginAsNewUser("다른유저");
+        setDefaultMealTimes(otherToken);
 
         // when & then
         RestAssured.given()
@@ -204,7 +287,7 @@ class MedicationScheduleControllerE2ETest {
                 .header("Authorization", "Bearer " + otherToken)
                 .body("""
                         {
-                            "scheduledTime": "08:00",
+                            "mealSlot": "BREAKFAST",
                             "dosage": "1정"
                         }
                         """)
@@ -232,6 +315,32 @@ class MedicationScheduleControllerE2ETest {
                 .path("accessToken");
     }
 
+    private void setDefaultMealTimes(final String token) {
+        setMealTimes(token, "08:00:00", "12:30:00", "18:30:00");
+    }
+
+    private void setMealTimes(
+            final String token,
+            final String breakfast,
+            final String lunch,
+            final String dinner
+    ) {
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body("""
+                        {
+                            "breakfast": "%s",
+                            "lunch": "%s",
+                            "dinner": "%s"
+                        }
+                        """.formatted(breakfast, lunch, dinner))
+                .when()
+                .put("/api/v1/users/me/meal-times")
+                .then()
+                .statusCode(200);
+    }
+
     private Integer createMedicine(final String token, final String name,
             final int totalAmount, final int remainingAmount) {
         final Long userId = readUserId(token);
@@ -255,7 +364,7 @@ class MedicationScheduleControllerE2ETest {
     private Integer createSchedule(
             final String token,
             final Integer medicineId,
-            final String time,
+            final String mealSlot,
             final String dosage
     ) {
         return RestAssured.given()
@@ -263,10 +372,10 @@ class MedicationScheduleControllerE2ETest {
                 .header("Authorization", "Bearer " + token)
                 .body("""
                         {
-                            "scheduledTime": "%s",
+                            "mealSlot": "%s",
                             "dosage": "%s"
                         }
-                        """.formatted(time, dosage))
+                        """.formatted(mealSlot, dosage))
                 .when()
                 .post("/api/v1/medicines/" + medicineId + "/schedules")
                 .then()

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -12,6 +12,7 @@ import com.ppiyaki.common.storage.NcpStorageProperties;
 import com.ppiyaki.common.storage.PhotoUrlAssembler;
 import com.ppiyaki.medication.LogAiStatus;
 import com.ppiyaki.medication.LogStatus;
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationLog;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.controller.dto.MedicationLogUpsertRequest;
@@ -22,7 +23,6 @@ import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -65,7 +65,7 @@ class MedicationLogServicePhase2Test {
     private static final Long SCHEDULE_ID = 1L;
     private static final Long MEDICINE_ID = 10L;
     private static final LocalDate TARGET_DATE = LocalDate.of(2026, 4, 30);
-    private static final LocalTime SCHEDULED_TIME = LocalTime.of(8, 0);
+    private static final MealSlot MEAL_SLOT = MealSlot.BREAKFAST;
     private static final String VALID_OBJECT_KEY = "medication-log/100/9b3e7a1c-8d55-4f0a-b2e1-5f9a7b3d8c21.jpg";
 
     @Test
@@ -184,8 +184,8 @@ class MedicationLogServicePhase2Test {
     }
 
     private void givenSiblingSchedules(final List<MedicationSchedule> schedules) {
-        when(medicationScheduleRepository.findActiveByOwnerAndScheduledTime(
-                eq(SENIOR_ID), eq(TARGET_DATE), eq(SCHEDULED_TIME))).thenReturn(schedules);
+        when(medicationScheduleRepository.findActiveByOwnerAndMealSlot(
+                eq(SENIOR_ID), eq(TARGET_DATE), eq(MEAL_SLOT))).thenReturn(schedules);
     }
 
     private void givenUpsertSucceeds() {
@@ -219,7 +219,7 @@ class MedicationLogServicePhase2Test {
         setField(s, "id", id);
         setField(s, "medicineId", MEDICINE_ID);
         setField(s, "dosage", dosage);
-        setField(s, "scheduledTime", SCHEDULED_TIME);
+        setField(s, "mealSlot", MEAL_SLOT);
         return s;
     }
 

--- a/src/test/java/com/ppiyaki/medicine/controller/MedicineControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medicine/controller/MedicineControllerE2ETest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.user.CareRelation;
@@ -11,7 +12,6 @@ import com.ppiyaki.user.repository.CareRelationRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -175,10 +175,10 @@ class MedicineControllerE2ETest {
         final Integer medicineId = createMedicine(token, "캐스케이드약", 30, 20);
 
         medicationScheduleRepository.save(
-                new MedicationSchedule(Long.valueOf(medicineId), LocalTime.of(8, 0),
+                new MedicationSchedule(Long.valueOf(medicineId), MealSlot.BREAKFAST,
                         "1정", "DAILY", LocalDate.now(), null));
         medicationScheduleRepository.save(
-                new MedicationSchedule(Long.valueOf(medicineId), LocalTime.of(20, 0),
+                new MedicationSchedule(Long.valueOf(medicineId), MealSlot.DINNER,
                         "1정", "DAILY", LocalDate.now(), null));
 
         // when & then

--- a/src/test/java/com/ppiyaki/prescription/PrescriptionMedicineCandidateMealSlotsTest.java
+++ b/src/test/java/com/ppiyaki/prescription/PrescriptionMedicineCandidateMealSlotsTest.java
@@ -1,0 +1,87 @@
+package com.ppiyaki.prescription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medicine.service.MatchType;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PrescriptionMedicineCandidate mealSlots 도메인 동작")
+class PrescriptionMedicineCandidateMealSlotsTest {
+
+    @Test
+    @DisplayName("생성 시 suggestedMealSlots는 CSV로 직렬화되고, 리스트 게터로 복원된다")
+    void constructor_persistsSuggestedSlotsAsCsv() {
+        final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                1L, "raw", "타이레놀정", "1정", "1일 3회 식후",
+                "ITEM-1", "타이레놀", MatchType.EXACT, "matched",
+                List.of(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER)
+        );
+
+        assertThat(candidate.getSuggestedMealSlots()).isEqualTo("BREAKFAST,LUNCH,DINNER");
+        assertThat(candidate.getSuggestedMealSlotsList())
+                .containsExactly(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER);
+        assertThat(candidate.getConfirmedMealSlotsList()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("suggestedMealSlots null/empty → CSV는 null, 리스트 게터는 빈 리스트")
+    void constructor_emptySuggestedSlots() {
+        final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                1L, "raw", "약", "1정", "취침 전",
+                null, null, MatchType.NO_MATCH, "no match",
+                List.of()
+        );
+
+        assertThat(candidate.getSuggestedMealSlots()).isNull();
+        assertThat(candidate.getSuggestedMealSlotsList()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("updateConfirmedMealSlots: 리스트 → CSV 저장")
+    void updateConfirmedMealSlots_persistsCsv() {
+        final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                1L, "raw", "약", "1정", "1일 2회",
+                null, null, MatchType.NO_MATCH, null,
+                List.of(MealSlot.BREAKFAST, MealSlot.DINNER)
+        );
+
+        candidate.updateConfirmedMealSlots(List.of(MealSlot.LUNCH, MealSlot.DINNER));
+
+        assertThat(candidate.getConfirmedMealSlots()).isEqualTo("LUNCH,DINNER");
+        assertThat(candidate.getConfirmedMealSlotsList())
+                .containsExactly(MealSlot.LUNCH, MealSlot.DINNER);
+    }
+
+    @Test
+    @DisplayName("updateConfirmedMealSlots: 빈 리스트 → null로 초기화")
+    void updateConfirmedMealSlots_emptyClearsField() {
+        final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                1L, "raw", "약", "1정", "1일 2회",
+                null, null, MatchType.NO_MATCH, null,
+                List.of(MealSlot.BREAKFAST)
+        );
+        candidate.updateConfirmedMealSlots(List.of(MealSlot.BREAKFAST));
+        assertThat(candidate.getConfirmedMealSlots()).isEqualTo("BREAKFAST");
+
+        candidate.updateConfirmedMealSlots(List.of());
+
+        assertThat(candidate.getConfirmedMealSlots()).isNull();
+        assertThat(candidate.getConfirmedMealSlotsList()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("manualAdd factory: suggestedMealSlots는 비어있음")
+    void manualAdd_emptySuggestedSlots() {
+        final PrescriptionMedicineCandidate candidate = PrescriptionMedicineCandidate.manualAdd(
+                1L, "ITEM-1", "타이레놀정", "1정", "1일 3회"
+        );
+
+        assertThat(candidate.getSuggestedMealSlots()).isNull();
+        assertThat(candidate.getSuggestedMealSlotsList()).isEmpty();
+        assertThat(candidate.getConfirmedMealSlotsList()).isEmpty();
+        assertThat(candidate.getCaregiverDecision()).isEqualTo(CaregiverDecision.ACCEPTED);
+    }
+}

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
@@ -1,0 +1,319 @@
+package com.ppiyaki.prescription.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.medicine.service.MatchType;
+import com.ppiyaki.prescription.Prescription;
+import com.ppiyaki.prescription.PrescriptionMedicineCandidate;
+import com.ppiyaki.prescription.PrescriptionStatus;
+import com.ppiyaki.prescription.repository.PrescriptionMedicineCandidateRepository;
+import com.ppiyaki.prescription.repository.PrescriptionRepository;
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.lang.reflect.Field;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("POST /prescriptions/{id}/confirm 시 슬롯별 schedule 자동 생성 E2E")
+class PrescriptionConfirmAutoScheduleE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PrescriptionRepository prescriptionRepository;
+
+    @Autowired
+    private PrescriptionMedicineCandidateRepository candidateRepository;
+
+    @Autowired
+    private MedicineRepository medicineRepository;
+
+    @Autowired
+    private MedicationScheduleRepository medicationScheduleRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 600000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("ACCEPTED + confirmedMealSlots=[BREAKFAST,LUNCH,DINNER] → schedule 3건 생성")
+    void confirm_createsSchedulesForEachSlot() {
+        // given
+        final SignupResult senior = signup("정상시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        setMealTimes(senior.userId(),
+                LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedAcceptedCandidate(prescriptionId, "1정",
+                List.of(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER));
+
+        // when
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(200)
+                .body("status", is("CONFIRMED"));
+
+        // then — Medicine 1건 + schedule 3건
+        final List<Medicine> medicines = medicineRepository.findByOwnerId(senior.userId());
+        assertThat(medicines).hasSize(1);
+        final Long medicineId = medicines.get(0).getId();
+
+        final List<MedicationSchedule> schedules = medicationScheduleRepository.findByMedicineId(medicineId);
+        assertThat(schedules).extracting(MedicationSchedule::getMealSlot)
+                .containsExactlyInAnyOrder(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER);
+        assertThat(schedules).allMatch(s -> "1정".equals(s.getDosage()));
+        assertThat(schedules).allMatch(s -> "DAILY".equals(s.getDaysOfWeek()));
+
+        // candidate에 created_medicine_id 채워짐
+        final PrescriptionMedicineCandidate after = candidateRepository.findById(candidateId).orElseThrow();
+        assertThat(after.getCreatedMedicineId()).isEqualTo(medicineId);
+    }
+
+    @Test
+    @DisplayName("confirmedMealSlots에 mealTime 미설정 슬롯 포함 → 400 USER_002, 트랜잭션 롤백")
+    void confirm_mealTimesNotSet_returns400_andRollsBack() {
+        // given — lunchTime만 null
+        final SignupResult senior = signup("미설정시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        setMealTimes(senior.userId(), LocalTime.of(8, 0), null, LocalTime.of(18, 30));
+        final Long prescriptionId = seedPrescription(senior.userId());
+        seedAcceptedCandidate(prescriptionId, "1정",
+                List.of(MealSlot.LUNCH)); // lunchTime null이라 거절돼야 함
+
+        // when
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(400)
+                .body("error.code", is("USER_002"));
+
+        // then — Medicine/Schedule 모두 생성되지 않음, prescription status도 CONFIRMED 아님
+        assertThat(medicineRepository.findByOwnerId(senior.userId())).isEmpty();
+        final Prescription after = prescriptionRepository.findById(prescriptionId).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(PrescriptionStatus.PENDING_REVIEW);
+    }
+
+    @Test
+    @DisplayName("dosage가 null이면 schedule skip — Medicine만 생성")
+    void confirm_dosageNull_skipsScheduleCreation() {
+        // given
+        final SignupResult senior = signup("도세지없음시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        setMealTimes(senior.userId(),
+                LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final Long prescriptionId = seedPrescription(senior.userId());
+        seedAcceptedCandidate(prescriptionId, null,
+                List.of(MealSlot.BREAKFAST));
+
+        // when
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(200);
+
+        // then — Medicine 1건, schedule 0건
+        final List<Medicine> medicines = medicineRepository.findByOwnerId(senior.userId());
+        assertThat(medicines).hasSize(1);
+        assertThat(medicationScheduleRepository.findByMedicineId(medicines.get(0).getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("confirmedMealSlots empty면 Medicine만 생성, schedule 0건")
+    void confirm_emptyMealSlots_onlyMedicine() {
+        // given
+        final SignupResult senior = signup("슬롯없음시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        setMealTimes(senior.userId(),
+                LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final Long prescriptionId = seedPrescription(senior.userId());
+        seedAcceptedCandidate(prescriptionId, "1정", List.of());
+
+        // when
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(200);
+
+        // then — Medicine 1건, schedule 0건
+        final List<Medicine> medicines = medicineRepository.findByOwnerId(senior.userId());
+        assertThat(medicines).hasSize(1);
+        assertThat(medicationScheduleRepository.findByMedicineId(medicines.get(0).getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("confirm 두 번째 호출은 멱등 — Medicine/schedule 중복 생성 안 됨")
+    void confirm_idempotent_secondCallNoOp() {
+        // given
+        final SignupResult senior = signup("멱등시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        setMealTimes(senior.userId(),
+                LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final Long prescriptionId = seedPrescription(senior.userId());
+        seedAcceptedCandidate(prescriptionId, "1정",
+                List.of(MealSlot.BREAKFAST, MealSlot.DINNER));
+
+        // when — 1차 confirm
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(200);
+        final List<Medicine> afterFirst = medicineRepository.findByOwnerId(senior.userId());
+        assertThat(afterFirst).hasSize(1);
+        final Long medicineId = afterFirst.get(0).getId();
+        assertThat(medicationScheduleRepository.findByMedicineId(medicineId)).hasSize(2);
+
+        // when — 2차 confirm (이미 CONFIRMED라 동일 호출)
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
+                .then()
+                .statusCode(200);
+
+        // then — Medicine·schedule 카운트 그대로
+        assertThat(medicineRepository.findByOwnerId(senior.userId())).hasSize(1);
+        assertThat(medicationScheduleRepository.findByMedicineId(medicineId)).hasSize(2);
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "presauto" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private void setSeniorMode(final Long seniorId, final CareMode mode) {
+        transactionTemplate.executeWithoutResult(status -> {
+            final User user = userRepository.findById(seniorId).orElseThrow();
+            user.changeCareMode(mode);
+            userRepository.save(user);
+        });
+    }
+
+    private void setMealTimes(
+            final Long userId,
+            final LocalTime breakfast,
+            final LocalTime lunch,
+            final LocalTime dinner
+    ) {
+        transactionTemplate.executeWithoutResult(status -> {
+            final User user = userRepository.findById(userId).orElseThrow();
+            setHierarchicalField(user, "breakfastTime", breakfast);
+            setHierarchicalField(user, "lunchTime", lunch);
+            setHierarchicalField(user, "dinnerTime", dinner);
+            userRepository.save(user);
+        });
+    }
+
+    private Long seedPrescription(final Long seniorId) {
+        return transactionTemplate.execute(status -> {
+            final Prescription prescription = new Prescription(seniorId);
+            setHierarchicalField(prescription, "status", PrescriptionStatus.PENDING_REVIEW);
+            return prescriptionRepository.save(prescription).getId();
+        });
+    }
+
+    private Long seedAcceptedCandidate(
+            final Long prescriptionId,
+            final String dosage,
+            final List<MealSlot> confirmedSlots
+    ) {
+        return transactionTemplate.execute(status -> {
+            final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                    prescriptionId, "raw", "타이레놀정", dosage, "1일 3회 식후",
+                    "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
+                    confirmedSlots
+            );
+            candidate.accept();
+            candidate.updateConfirmedMealSlots(confirmedSlots);
+            return candidateRepository.save(candidate).getId();
+        });
+    }
+
+    private static void setHierarchicalField(final Object target, final String fieldName, final Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Field not found: " + fieldName);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
@@ -1,0 +1,242 @@
+package com.ppiyaki.prescription.controller;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import com.ppiyaki.medicine.service.MatchType;
+import com.ppiyaki.prescription.Prescription;
+import com.ppiyaki.prescription.PrescriptionMedicineCandidate;
+import com.ppiyaki.prescription.PrescriptionStatus;
+import com.ppiyaki.prescription.repository.PrescriptionMedicineCandidateRepository;
+import com.ppiyaki.prescription.repository.PrescriptionRepository;
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("PATCH /prescriptions/{id}/medicines/{candidateId} confirmedMealSlots E2E")
+class PrescriptionConfirmedMealSlotsE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PrescriptionRepository prescriptionRepository;
+
+    @Autowired
+    private PrescriptionMedicineCandidateRepository candidateRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 700000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("PATCH로 confirmedMealSlots 갱신 후 GET 응답에 노출된다")
+    void patch_persists_and_exposes_confirmedMealSlots() {
+        // given — 자율형 시니어 + 처방전 + candidate 1건 (suggestedMealSlots 포함)
+        final SignupResult senior = signup("자율시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedCandidate(prescriptionId,
+                List.of(com.ppiyaki.medication.MealSlot.BREAKFAST,
+                        com.ppiyaki.medication.MealSlot.LUNCH,
+                        com.ppiyaki.medication.MealSlot.DINNER));
+
+        // when — 보호자 검수: ACCEPTED + confirmedMealSlots = [LUNCH, DINNER]
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {
+                            "decision": "ACCEPTED",
+                            "confirmedMealSlots": ["LUNCH", "DINNER"]
+                        }
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // then — GET 응답에 suggested/confirmed 둘 다 노출
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/prescriptions/" + prescriptionId)
+                .then()
+                .statusCode(200)
+                .body("candidates", hasSize(1))
+                .body("candidates[0].caregiverDecision", is("ACCEPTED"))
+                .body("candidates[0].suggestedMealSlots", contains("BREAKFAST", "LUNCH", "DINNER"))
+                .body("candidates[0].confirmedMealSlots", contains("LUNCH", "DINNER"));
+    }
+
+    @Test
+    @DisplayName("PATCH 본문에 confirmedMealSlots 미포함이면 기존 값 유지 (decision만 갱신)")
+    void patch_without_slots_keepsExistingConfirmedSlots() {
+        // given
+        final SignupResult senior = signup("기존유지시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedCandidate(prescriptionId, List.of());
+
+        // 1차 PATCH: 슬롯 확정
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {"decision": "ACCEPTED", "confirmedMealSlots": ["BREAKFAST"]}
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // 2차 PATCH: 결정만 다시(슬롯 필드 미포함)
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {"decision": "ACCEPTED"}
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // then — 슬롯은 1차 값 유지
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/prescriptions/" + prescriptionId)
+                .then()
+                .statusCode(200)
+                .body("candidates[0].confirmedMealSlots", contains("BREAKFAST"));
+    }
+
+    @Test
+    @DisplayName("잘못된 enum 값이면 400")
+    void patch_invalidEnum_returns400() {
+        final SignupResult senior = signup("잘못된슬롯시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedCandidate(prescriptionId, List.of());
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {"decision": "ACCEPTED", "confirmedMealSlots": ["BEDTIME"]}
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(400);
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "presslot" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private void setSeniorMode(final Long seniorId, final CareMode mode) {
+        transactionTemplate.executeWithoutResult(status -> {
+            final User user = userRepository.findById(seniorId).orElseThrow();
+            user.changeCareMode(mode);
+            userRepository.save(user);
+        });
+    }
+
+    private Long seedPrescription(final Long seniorId) {
+        return transactionTemplate.execute(status -> {
+            final Prescription prescription = new Prescription(seniorId);
+            setHierarchicalField(prescription, "status", PrescriptionStatus.PENDING_REVIEW);
+            return prescriptionRepository.save(prescription).getId();
+        });
+    }
+
+    private Long seedCandidate(
+            final Long prescriptionId,
+            final List<com.ppiyaki.medication.MealSlot> suggestedSlots
+    ) {
+        return transactionTemplate.execute(status -> {
+            final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                    prescriptionId, "raw", "타이레놀정", "1정", "1일 3회 식후",
+                    "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
+                    suggestedSlots
+            );
+            return candidateRepository.save(candidate).getId();
+        });
+    }
+
+    private static void setHierarchicalField(final Object target, final String fieldName, final Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Field not found: " + fieldName);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}


### PR DESCRIPTION
## Summary
v0.9.0 — 식사 슬롯 모델 도입 + 처방전 confirm 시 슬롯별 복약 일정 자동 생성.

### feat
- **#226** `feat(medication)`: 복약 일정 시각을 식사 슬롯으로 전환 — `MedicationSchedule.scheduled_time` 제거, `meal_slot ENUM(BREAKFAST/LUNCH/DINNER) NOT NULL`로 대체. 실제 시각은 시니어 mealTimes 동적 계산. (시간대 Phase 2)
- **#229** `feat(prescription)`: 처방전 후보에 식사 슬롯 제안/확정 필드 — `OpenAiClient`가 `mealSlots` 함께 추출, `prescription_medicine_candidates`에 `suggested_meal_slots`/`confirmed_meal_slots` 컬럼 신설, PATCH 본문에 `confirmedMealSlots` 추가. (시간대 Phase 3 PR 2)
- **#230** `feat(prescription)`: confirm 시 슬롯별 schedule 자동 생성 — confirmedMealSlots 기반 `MedicationSchedule` 자동 생성. mealTimes 미설정 슬롯이면 트랜잭션 롤백(`USER_002`). `created_medicine_id` 기반 멱등 보장. (시간대 Phase 3 PR 3, 완결)

### docs
- **#228** `docs(prescription)`: 시간대 Phase 3 spec (`prescription-schedule-auto-suggest.md`)

## prod 마이그레이션 (필수, 머지 직전 적용)

### 1) `medication_schedules` 컬럼 교체 (#226)
```sql
DELETE FROM medication_logs WHERE schedule_id IN (SELECT id FROM medication_schedules);
DELETE FROM medication_reminders WHERE schedule_id IN (SELECT id FROM medication_schedules);
DELETE FROM medication_schedules;

ALTER TABLE medication_schedules
    DROP COLUMN scheduled_time,
    ADD COLUMN meal_slot VARCHAR(16) NOT NULL;
```

### 2) `prescription_medicine_candidates` 컬럼 추가 (#229)
```sql
ALTER TABLE prescription_medicine_candidates
    ADD COLUMN suggested_meal_slots VARCHAR(64) NULL,
    ADD COLUMN confirmed_meal_slots VARCHAR(64) NULL;
```

> 운영 schedule 데이터 없음 가정으로 DELETE 채택 (PR #225 결정 로그 §9 참조). 운영 데이터 존재 시 사전 백업·치환 필요.

## Test plan
- [ ] 마이그레이션 SQL 1·2 적용 (NCP MySQL)
- [ ] `git tag -a v0.9.0 -m "..." && git push origin v0.9.0 && gh release create v0.9.0 --generate-notes`
- [ ] CD 자동 배포 완료 확인 (backend-cd.yml)
- [ ] 컨테이너 재시작 후 JPA validate 통과 확인 (`sudo docker logs ppiyaki-server`)
- [ ] prod 시나리오 검증:
  - 시니어 mealTimes 설정 후 `POST /api/v1/medicines/{id}/schedules` (mealSlot=BREAKFAST) → 201 + 동적 scheduledTime
  - 처방전 confirm 흐름: candidate에 `suggestedMealSlots` 채워지는지, PATCH 후 `confirmedMealSlots` 갱신, confirm 시 `medication_schedules`에 슬롯별 row 생성 확인
  - mealTimes 미설정 시 confirm → 400 USER_002

## 머지 방식
**Merge commit** (CLAUDE.md §8). Squash 금지. develop 히스토리 main에 보존.

🤖 Generated with [Claude Code](https://claude.com/claude-code)