### PR TITLE
release: v0.9.1

### DIFF
--- a/src/main/java/com/ppiyaki/chat/service/ChatSessionService.java
+++ b/src/main/java/com/ppiyaki/chat/service/ChatSessionService.java
@@ -2,6 +2,7 @@ package com.ppiyaki.chat.service;
 
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
@@ -29,6 +30,7 @@ public class ChatSessionService {
 
         chatStreamExecutor.execute(() -> {
             final Disposable subscription = chatClient.prompt(new Prompt(promptMessages))
+                    .toolContext(Map.of("userId", userId))
                     .stream()
                     .content()
                     .doOnNext(token -> {
@@ -73,6 +75,7 @@ public class ChatSessionService {
 
         chatStreamExecutor.execute(() -> {
             final Disposable subscription = chatClient.prompt(new Prompt(promptMessages))
+                    .toolContext(Map.of("userId", userId))
                     .stream()
                     .content()
                     .doOnNext(token -> {

--- a/src/main/java/com/ppiyaki/common/mcp/DurMcpTools.java
+++ b/src/main/java/com/ppiyaki/common/mcp/DurMcpTools.java
@@ -1,11 +1,13 @@
 package com.ppiyaki.common.mcp;
 
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.health.controller.dto.DurCheckResponse;
 import com.ppiyaki.health.service.DurCheckService;
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,10 +23,26 @@ public class DurMcpTools {
     @Tool(description = "Run a DUR (Drug Utilization Review) safety check on a medicine. Checks drug interactions, elderly warnings, and therapeutic duplicates against the senior's active medications.")
     public DurCheckResponse checkDur(
             @ToolParam(description = "Medicine ID to check") final Long medicineId,
-            @ToolParam(description = "Bypass 24h cache if true") final Boolean forceRefresh
+            @ToolParam(description = "Bypass 24h cache if true") final Boolean forceRefresh,
+            final ToolContext toolContext
     ) {
-        final Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final Long userId = resolveUserId(toolContext);
         final boolean refresh = forceRefresh != null && forceRefresh;
         return durCheckService.check(userId, medicineId, refresh);
+    }
+
+    /**
+     * Spring AI 도구 호출 thread는 Reactor BoundedElastic이라 SecurityContextHolder가 비어있다.
+     * ChatSessionService가 .toolContext(Map.of("userId", userId))로 전달한 값을 사용한다.
+     */
+    private static Long resolveUserId(final ToolContext toolContext) {
+        if (toolContext == null) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN, "ToolContext is missing userId");
+        }
+        final Object value = toolContext.getContext().get("userId");
+        if (!(value instanceof Long userId)) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN, "ToolContext userId is missing or not a Long");
+        }
+        return userId;
     }
 }

--- a/src/main/java/com/ppiyaki/common/mcp/MedicationMcpTools.java
+++ b/src/main/java/com/ppiyaki/common/mcp/MedicationMcpTools.java
@@ -1,5 +1,7 @@
 package com.ppiyaki.common.mcp;
 
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
@@ -11,9 +13,9 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,8 +36,8 @@ public class MedicationMcpTools {
     }
 
     @Tool(description = "Get today's medication schedule for the user. Returns medicine names, scheduled times (resolved from the senior's meal times), and dosages for today.")
-    public List<ScheduleSummary> getTodaySchedules() {
-        final Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    public List<ScheduleSummary> getTodaySchedules(final ToolContext toolContext) {
+        final Long userId = resolveUserId(toolContext);
         final User user = userRepository.findById(userId).orElse(null);
         if (user == null) {
             return List.of();
@@ -64,9 +66,10 @@ public class MedicationMcpTools {
 
     @Tool(description = "Get remaining amount of medicines for the user. Returns medicine names with remaining and total amounts.")
     public List<MedicineRemainingInfo> getMedicineRemaining(
-            @ToolParam(description = "Optional medicine name filter. If null, returns all medicines.") final String medicineName
+            @ToolParam(description = "Optional medicine name filter. If null, returns all medicines.") final String medicineName,
+            final ToolContext toolContext
     ) {
-        final Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final Long userId = resolveUserId(toolContext);
         final List<Medicine> medicines = medicineRepository.findByOwnerId(userId);
 
         return medicines.stream()
@@ -77,6 +80,22 @@ public class MedicationMcpTools {
                         m.getRemainingAmount(),
                         m.getTotalAmount()))
                 .toList();
+    }
+
+    /**
+     * Spring AI 도구 호출은 Reactor BoundedElastic 풀에서 실행되어 SecurityContextHolder의
+     * ThreadLocal 인증이 비어있다 (`spring.reactor.context-propagation: auto`로도 복원되지 않음).
+     * ChatSessionService가 prompt 빌드 시 .toolContext(Map.of("userId", userId))로 명시 전달하는 값을 사용한다.
+     */
+    private static Long resolveUserId(final ToolContext toolContext) {
+        if (toolContext == null) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN, "ToolContext is missing userId");
+        }
+        final Object value = toolContext.getContext().get("userId");
+        if (!(value instanceof Long userId)) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN, "ToolContext userId is missing or not a Long");
+        }
+        return userId;
     }
 
     private boolean isActiveToday(

--- a/src/test/java/com/ppiyaki/chat/ChatQuickE2ETest.java
+++ b/src/test/java/com/ppiyaki/chat/ChatQuickE2ETest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,6 +44,7 @@ class ChatQuickE2ETest {
             final ChatClient.StreamResponseSpec streamResponseSpec = mock(ChatClient.StreamResponseSpec.class);
 
             when(chatClient.prompt(any(Prompt.class))).thenReturn(requestSpec);
+            when(requestSpec.toolContext(anyMap())).thenReturn(requestSpec);
             when(requestSpec.stream()).thenReturn(streamResponseSpec);
             when(streamResponseSpec.content()).thenReturn(Flux.just("타이레놀은 ", "식후에 드세요."));
 

--- a/src/test/java/com/ppiyaki/chat/ChatSessionServiceTest.java
+++ b/src/test/java/com/ppiyaki/chat/ChatSessionServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -85,6 +86,7 @@ class ChatSessionServiceTest {
         final ChatClient.StreamResponseSpec streamResponseSpec = mock(ChatClient.StreamResponseSpec.class);
 
         when(chatClient.prompt(any(Prompt.class))).thenReturn(requestSpec);
+        when(requestSpec.toolContext(anyMap())).thenReturn(requestSpec);
         when(requestSpec.stream()).thenReturn(streamResponseSpec);
         when(streamResponseSpec.content()).thenReturn(Flux.just("아스피린은 ", "공복에 복용을 피하세요."));
 

--- a/src/test/java/com/ppiyaki/chat/VoiceMessageE2ETest.java
+++ b/src/test/java/com/ppiyaki/chat/VoiceMessageE2ETest.java
@@ -3,6 +3,7 @@ package com.ppiyaki.chat;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,6 +45,7 @@ class VoiceMessageE2ETest {
             final ChatClient.StreamResponseSpec streamResponseSpec = mock(ChatClient.StreamResponseSpec.class);
 
             when(chatClient.prompt(any(Prompt.class))).thenReturn(requestSpec);
+            when(requestSpec.toolContext(anyMap())).thenReturn(requestSpec);
             when(requestSpec.stream()).thenReturn(streamResponseSpec);
             when(streamResponseSpec.content())
                     .thenReturn(Flux.just("아스피린은 공복에 복용을 피하세요."));


### PR DESCRIPTION
## Summary
v0.9.1 — chat MCP 도구 호출 회귀 hotfix.

### fix
- **#232** `fix(chat)`: MCP 도구 호출 시 `SecurityContext` 누락 → `ToolContext`로 `userId` 명시 전달.
  - prod에서 \`POST /chat/messages\`가 LLM tool fallback("…문제가 발생했습니다")만 응답하던 회귀 수정
  - `MedicationMcpTools.getTodaySchedules / getMedicineRemaining`, `DurMcpTools.checkDur` 시그니처에 `ToolContext` 추가, `SecurityContextHolder` 의존 제거
  - `ChatSessionService`가 `chatClient.prompt(...).toolContext(Map.of("userId", userId))`로 controller thread의 userId 명시 전달
  - 로컬 재현 + fix 후 슬롯→시각 매핑(`BREAKFAST→"08:00"`) 정상 응답 확인

## prod 마이그레이션
**없음** (코드 변경만).

## 머지 방식
**Merge commit** (CLAUDE.md §8). Squash 금지.

## Test plan
- [ ] git tag v0.9.1 + GitHub Release
- [ ] CD 자동 배포 완료 확인
- [ ] 컨테이너 재시작 후 prod chat 호출로 도구 응답 검증 (시니어 token: "오늘 약 일정 알려줘")

🤖 Generated with [Claude Code](https://claude.com/claude-code)