### PR TITLE
fix(prescription): GET /prescriptions에 ?seniorId= 지원 — list API 일관성 갭

### DIFF
--- a/src/main/java/com/ppiyaki/prescription/controller/PrescriptionController.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/PrescriptionController.java
@@ -52,9 +52,10 @@ public class PrescriptionController {
     @GetMapping
     public ResponseEntity<PrescriptionListResponse> list(
             @AuthenticationPrincipal final Long userId,
+            @RequestParam(required = false) final Long seniorId,
             @RequestParam(required = false) final PrescriptionStatus status
     ) {
-        return ResponseEntity.ok(prescriptionService.listByOwner(userId, status));
+        return ResponseEntity.ok(prescriptionService.listByOwner(userId, seniorId, status));
     }
 
     @PatchMapping("/{prescriptionId}/medicines/{candidateId}")

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -177,12 +177,22 @@ public class PrescriptionService {
     }
 
     @Transactional(readOnly = true)
-    public PrescriptionListResponse listByOwner(final Long userId, final PrescriptionStatus status) {
+    public PrescriptionListResponse listByOwner(
+            final Long userId,
+            final Long seniorIdParam,
+            final PrescriptionStatus status
+    ) {
+        final Long ownerId = seniorIdParam != null ? seniorIdParam : userId;
+        if (!userId.equals(ownerId)) {
+            careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(userId, ownerId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+        }
+
         final List<Prescription> prescriptions;
         if (status != null) {
-            prescriptions = prescriptionRepository.findByOwnerIdAndStatusOrderByCreatedAtDesc(userId, status);
+            prescriptions = prescriptionRepository.findByOwnerIdAndStatusOrderByCreatedAtDesc(ownerId, status);
         } else {
-            prescriptions = prescriptionRepository.findByOwnerIdOrderByCreatedAtDesc(userId);
+            prescriptions = prescriptionRepository.findByOwnerIdOrderByCreatedAtDesc(ownerId);
         }
         return PrescriptionListResponse.from(prescriptions);
     }

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionListControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionListControllerE2ETest.java
@@ -1,0 +1,194 @@
+package com.ppiyaki.prescription.controller;
+
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import com.ppiyaki.prescription.Prescription;
+import com.ppiyaki.prescription.PrescriptionStatus;
+import com.ppiyaki.prescription.repository.PrescriptionRepository;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("GET /api/v1/prescriptions ?seniorId= E2E")
+class PrescriptionListControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CareRelationRepository careRelationRepository;
+
+    @Autowired
+    private PrescriptionRepository prescriptionRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 500000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("seniorId 미지정 → 호출자 본인 처방전만 반환")
+    void list_noSeniorId_returnsOwnPrescriptions() {
+        final SignupResult senior = signup("본인유저");
+        seedPrescription(senior.userId(), PrescriptionStatus.PENDING_REVIEW);
+        seedPrescription(senior.userId(), PrescriptionStatus.CONFIRMED);
+
+        // 다른 시니어의 처방전은 안 나와야 함
+        final SignupResult other = signup("타인");
+        seedPrescription(other.userId(), PrescriptionStatus.PENDING_REVIEW);
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/prescriptions")
+                .then()
+                .statusCode(200)
+                .body("responses", hasSize(2));
+    }
+
+    @Test
+    @DisplayName("연동 보호자 ?seniorId=senior → 시니어 처방전 목록 반환")
+    void list_caregiver_withSeniorId_returnsSeniorPrescriptions() {
+        final SignupResult senior = signup("시니어A");
+        seedPrescription(senior.userId(), PrescriptionStatus.PENDING_REVIEW);
+        seedPrescription(senior.userId(), PrescriptionStatus.CONFIRMED);
+
+        final SignupResult caregiver = signup("보호자A");
+        seedCareRelation(senior.userId(), caregiver.userId());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .when()
+                .get("/api/v1/prescriptions?seniorId=" + senior.userId())
+                .then()
+                .statusCode(200)
+                .body("responses", hasSize(2));
+    }
+
+    @Test
+    @DisplayName("미연동 보호자 ?seniorId=senior → 403 CARE_001")
+    void list_unrelated_withSeniorId_returns403() {
+        final SignupResult senior = signup("시니어B");
+        seedPrescription(senior.userId(), PrescriptionStatus.PENDING_REVIEW);
+
+        final SignupResult stranger = signup("타인B");
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + stranger.accessToken())
+                .when()
+                .get("/api/v1/prescriptions?seniorId=" + senior.userId())
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    @Test
+    @DisplayName("status 필터 + seniorId 결합 → 해당 status인 시니어 처방전만 반환")
+    void list_caregiver_withSeniorIdAndStatus_filters() {
+        final SignupResult senior = signup("시니어C");
+        seedPrescription(senior.userId(), PrescriptionStatus.PENDING_REVIEW);
+        seedPrescription(senior.userId(), PrescriptionStatus.CONFIRMED);
+        seedPrescription(senior.userId(), PrescriptionStatus.CONFIRMED);
+
+        final SignupResult caregiver = signup("보호자C");
+        seedCareRelation(senior.userId(), caregiver.userId());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .when()
+                .get("/api/v1/prescriptions?seniorId=" + senior.userId() + "&status=CONFIRMED")
+                .then()
+                .statusCode(200)
+                .body("responses", hasSize(2))
+                .body("responses.status", everyItem(is("CONFIRMED")));
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "preslist" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private void seedCareRelation(final Long seniorId, final Long caregiverId) {
+        careRelationRepository.save(new CareRelation(seniorId, caregiverId, "INV-" + seniorId + "-" + caregiverId));
+    }
+
+    private void seedPrescription(final Long ownerId, final PrescriptionStatus status) {
+        transactionTemplate.executeWithoutResult(tx -> {
+            final Prescription prescription = new Prescription(ownerId);
+            setHierarchicalField(prescription, "status", status);
+            prescriptionRepository.save(prescription);
+        });
+    }
+
+    private static void setHierarchicalField(final Object target, final String fieldName, final Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Field not found: " + fieldName);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}


### PR DESCRIPTION
## Summary
보호자가 시니어 처방전 목록을 조회할 수단이 현재 없어서 다른 list API와 일관성을 맞춥니다.

| 엔드포인트 | seniorId 쿼리 |
|---|---|
| GET /api/v1/medicines | ✅ |
| GET /api/v1/medication-logs | ✅ |
| GET /api/v1/prescriptions | ❌ → ✅ (본 PR) |

## 변경
- `PrescriptionController.list` 시그니처에 `@RequestParam(required=false) Long seniorId` 추가
- `PrescriptionService.listByOwner`: seniorIdParam null이면 본인, 있으면 careRelations 검증 후 시니어 ownerId 사용. 미연동이면 `CARE_RELATION_NOT_FOUND` (403)
- `PrescriptionListControllerE2ETest` 신규 4 케이스
  - 본인 호출 → 본인 처방전만 반환
  - 연동 보호자 `?seniorId=senior` → 시니어 처방전 반환
  - 미연동 보호자 `?seniorId=senior` → 403 CARE_001
  - status 필터 + seniorId 결합

## prod 영향
- 마이그레이션 SQL 없음
- 기존 호출자(seniorId 미지정)는 동작 변경 없음 — 본인 처방전만 그대로

## Test plan
- [ ] 머지 후 prod 검증: 보호자 token으로 `GET /prescriptions?seniorId=16` → 시니어 처방전 목록 반환 확인
- [ ] Notion API 명세 동기화 (사용자 사이클)

🤖 Generated with [Claude Code](https://claude.com/claude-code)