### PR TITLE
release: v0.9.2

### DIFF
--- a/docs/features/care-relation-invite.md
+++ b/docs/features/care-relation-invite.md
@@ -1,0 +1,81 @@
+---
+feature: 보호자 연동 초대 코드
+slug: care-relation-invite
+status: approved
+owner: @qkrehgus02
+scope: user
+related_issues: [170]
+related_prs: []
+last_reviewed: 2026-04-17
+---
+
+# 보호자 연동 초대 코드
+
+## 1) 개요 (What / Why)
+- 시니어가 1회용 초대 코드를 발급하고, 보호자가 해당 코드를 입력하여 보호자-시니어 연동(CareRelation)을 생성하는 기능.
+- 현재 CareRelation 엔티티/테이블은 존재하나 생성 API가 없어 연동을 맺을 수 없다.
+
+## 2) 사용자 시나리오
+1. 시니어가 앱에서 "초대 코드 발급" 버튼을 누르면 6자리 영숫자 코드가 생성된다.
+2. 시니어가 보호자에게 코드를 구두/메시지로 전달한다.
+3. 보호자가 앱에서 코드를 입력하면 연동이 완료되고, 코드는 즉시 폐기된다.
+
+## 3) 요구사항
+### 기능 요구사항
+- [ ] 시니어가 초대 코드를 발급할 수 있다 (6자리 영숫자, 5분 만료, 1회용)
+- [ ] 보호자가 초대 코드를 입력하여 연동을 생성할 수 있다
+- [ ] 연동 생성 시 초대 코드는 즉시 폐기된다
+- [ ] 이미 활성 연동이 존재하는 보호자-시니어 쌍은 중복 연동 에러를 반환한다
+- [ ] 만료된 코드로 연동 시도 시 에러를 반환한다
+- [ ] 시니어만 코드를 발급할 수 있고, 보호자만 코드를 수락할 수 있다
+
+### 비기능 요구사항
+- 초대 코드는 충돌 확률이 낮아야 한다 (6자리 영숫자 = 2,176,782,336 조합)
+
+## 4) 범위 / 비범위 (중요)
+### 포함
+- 초대 코드 발급 API
+- 초대 코드 수락 API
+- CareRelationService, CareRelationController, DTO 신설
+- 서비스 단위 테스트 + E2E 테스트
+- 도메인 문서 갱신
+
+### 제외 (Out of Scope)
+- 연동 해제(soft delete) API
+- 연동 목록 조회 API
+- 초대 코드 재발급 정책 (기존 미사용 코드 자동 폐기 등)
+
+## 5) 설계
+### 5-1) 도메인 모델
+- `CareRelation` 엔티티에 `expiresAt` 필드 추가 (초대 코드 만료 시각)
+- `caregiverId`를 nullable로 변경 (코드 발급 시점에는 보호자 미정)
+- 연동 수락 시 `caregiverId`를 채우고 `inviteCode`/`expiresAt`를 null 처리(폐기)
+
+### 5-2) API 엔드포인트
+| Method | Path | 설명 | 인증 | Req | Res |
+|---|---|---|---|---|---|
+| POST | /api/v1/care-relations/invite | 시니어가 초대 코드 발급 | 필수 (SENIOR) | - | `InviteCodeResponse` |
+| POST | /api/v1/care-relations/accept | 보호자가 초대 코드로 연동 | 필수 (CAREGIVER) | `AcceptInviteRequest` | `AcceptInviteResponse` |
+
+### 5-3) 외부 연동
+- 없음
+
+### 5-4) 데이터 흐름
+1. **발급**: 시니어 인증 확인 → 6자리 코드 생성 → CareRelation(seniorId, inviteCode, expiresAt) 저장 → 코드 응답
+2. **수락**: 보호자 인증 확인 → inviteCode로 CareRelation 조회 → 만료/중복 검증 → caregiverId 세팅, 코드 폐기 → 연동 완료 응답
+
+### 5-5) DB 마이그레이션
+- `care_relations` 테이블에 `expires_at datetime(6)` 컬럼 추가
+
+## 6) 작업 분할 (예상 PR 리스트)
+- [ ] PR 1: 초대 코드 발급 + 수락 API 전체 (단일 PR)
+
+## 7) 테스트 전략
+- CareRelationService 단위 테스트 (Mockito)
+- E2E 테스트 (RestAssured) — 발급 성공, 수락 성공
+
+## 8) 오픈 질문
+없음 (모두 합의됨)
+
+## 9) 결정 로그
+- 2026-04-17: 초안 작성 및 합의 완료 (status=approved). 코드 형식 6자리 영숫자, 만료 5분, 1회용 폐기 방식 확정.

--- a/src/main/java/com/ppiyaki/prescription/controller/PrescriptionController.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/PrescriptionController.java
@@ -52,9 +52,10 @@ public class PrescriptionController {
     @GetMapping
     public ResponseEntity<PrescriptionListResponse> list(
             @AuthenticationPrincipal final Long userId,
+            @RequestParam(required = false) final Long seniorId,
             @RequestParam(required = false) final PrescriptionStatus status
     ) {
-        return ResponseEntity.ok(prescriptionService.listByOwner(userId, status));
+        return ResponseEntity.ok(prescriptionService.listByOwner(userId, seniorId, status));
     }
 
     @PatchMapping("/{prescriptionId}/medicines/{candidateId}")

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -177,12 +177,22 @@ public class PrescriptionService {
     }
 
     @Transactional(readOnly = true)
-    public PrescriptionListResponse listByOwner(final Long userId, final PrescriptionStatus status) {
+    public PrescriptionListResponse listByOwner(
+            final Long userId,
+            final Long seniorIdParam,
+            final PrescriptionStatus status
+    ) {
+        final Long ownerId = seniorIdParam != null ? seniorIdParam : userId;
+        if (!userId.equals(ownerId)) {
+            careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(userId, ownerId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+        }
+
         final List<Prescription> prescriptions;
         if (status != null) {
-            prescriptions = prescriptionRepository.findByOwnerIdAndStatusOrderByCreatedAtDesc(userId, status);
+            prescriptions = prescriptionRepository.findByOwnerIdAndStatusOrderByCreatedAtDesc(ownerId, status);
         } else {
-            prescriptions = prescriptionRepository.findByOwnerIdOrderByCreatedAtDesc(userId);
+            prescriptions = prescriptionRepository.findByOwnerIdOrderByCreatedAtDesc(ownerId);
         }
         return PrescriptionListResponse.from(prescriptions);
     }

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionListControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionListControllerE2ETest.java
@@ -1,0 +1,194 @@
+package com.ppiyaki.prescription.controller;
+
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import com.ppiyaki.prescription.Prescription;
+import com.ppiyaki.prescription.PrescriptionStatus;
+import com.ppiyaki.prescription.repository.PrescriptionRepository;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("GET /api/v1/prescriptions ?seniorId= E2E")
+class PrescriptionListControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CareRelationRepository careRelationRepository;
+
+    @Autowired
+    private PrescriptionRepository prescriptionRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 500000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("seniorId 미지정 → 호출자 본인 처방전만 반환")
+    void list_noSeniorId_returnsOwnPrescriptions() {
+        final SignupResult senior = signup("본인유저");
+        seedPrescription(senior.userId(), PrescriptionStatus.PENDING_REVIEW);
+        seedPrescription(senior.userId(), PrescriptionStatus.CONFIRMED);
+
+        // 다른 시니어의 처방전은 안 나와야 함
+        final SignupResult other = signup("타인");
+        seedPrescription(other.userId(), PrescriptionStatus.PENDING_REVIEW);
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/prescriptions")
+                .then()
+                .statusCode(200)
+                .body("responses", hasSize(2));
+    }
+
+    @Test
+    @DisplayName("연동 보호자 ?seniorId=senior → 시니어 처방전 목록 반환")
+    void list_caregiver_withSeniorId_returnsSeniorPrescriptions() {
+        final SignupResult senior = signup("시니어A");
+        seedPrescription(senior.userId(), PrescriptionStatus.PENDING_REVIEW);
+        seedPrescription(senior.userId(), PrescriptionStatus.CONFIRMED);
+
+        final SignupResult caregiver = signup("보호자A");
+        seedCareRelation(senior.userId(), caregiver.userId());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .when()
+                .get("/api/v1/prescriptions?seniorId=" + senior.userId())
+                .then()
+                .statusCode(200)
+                .body("responses", hasSize(2));
+    }
+
+    @Test
+    @DisplayName("미연동 보호자 ?seniorId=senior → 403 CARE_001")
+    void list_unrelated_withSeniorId_returns403() {
+        final SignupResult senior = signup("시니어B");
+        seedPrescription(senior.userId(), PrescriptionStatus.PENDING_REVIEW);
+
+        final SignupResult stranger = signup("타인B");
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + stranger.accessToken())
+                .when()
+                .get("/api/v1/prescriptions?seniorId=" + senior.userId())
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    @Test
+    @DisplayName("status 필터 + seniorId 결합 → 해당 status인 시니어 처방전만 반환")
+    void list_caregiver_withSeniorIdAndStatus_filters() {
+        final SignupResult senior = signup("시니어C");
+        seedPrescription(senior.userId(), PrescriptionStatus.PENDING_REVIEW);
+        seedPrescription(senior.userId(), PrescriptionStatus.CONFIRMED);
+        seedPrescription(senior.userId(), PrescriptionStatus.CONFIRMED);
+
+        final SignupResult caregiver = signup("보호자C");
+        seedCareRelation(senior.userId(), caregiver.userId());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .when()
+                .get("/api/v1/prescriptions?seniorId=" + senior.userId() + "&status=CONFIRMED")
+                .then()
+                .statusCode(200)
+                .body("responses", hasSize(2))
+                .body("responses.status", everyItem(is("CONFIRMED")));
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "preslist" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private void seedCareRelation(final Long seniorId, final Long caregiverId) {
+        careRelationRepository.save(new CareRelation(seniorId, caregiverId, "INV-" + seniorId + "-" + caregiverId));
+    }
+
+    private void seedPrescription(final Long ownerId, final PrescriptionStatus status) {
+        transactionTemplate.executeWithoutResult(tx -> {
+            final Prescription prescription = new Prescription(ownerId);
+            setHierarchicalField(prescription, "status", status);
+            prescriptionRepository.save(prescription);
+        });
+    }
+
+    private static void setHierarchicalField(final Object target, final String fieldName, final Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Field not found: " + fieldName);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}


### PR DESCRIPTION
## Summary
v0.9.2 — `GET /prescriptions` 보호자 시니어 조회 일관성 fix + 보호자 연동 초대 코드 spec.

### fix
- **#234** `fix(prescription)`: `GET /prescriptions`에 `?seniorId=` 지원. medicines/medication-logs와 동일 패턴(careRelations 검증). 보호자가 시니어 처방전 목록을 조회 가능. E2E 4 케이스.

### docs
- **#171** `docs(user)`: 보호자 연동 초대 코드 Feature Spec 작성 (박도현 님)

## prod 마이그레이션
**없음** (코드 변경 + docs).

## 머지 방식
**Merge commit** (CLAUDE.md §8). Squash 금지.

## Test plan
- [ ] git tag v0.9.2 + GitHub Release
- [ ] CD 자동 배포 확인
- [ ] prod에서 보호자 token으로 `GET /api/v1/prescriptions?seniorId=16` 호출 → 시니어 처방전 목록 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)