### PR TITLE
feat(chat): 채팅 사진 첨부 — 단발/세션 + 약/비약 자동 분기

### DIFF
--- a/src/main/java/com/ppiyaki/chat/controller/ChatController.java
+++ b/src/main/java/com/ppiyaki/chat/controller/ChatController.java
@@ -4,11 +4,13 @@ import com.ppiyaki.chat.controller.dto.ChatMessageRequest;
 import com.ppiyaki.chat.domain.ChatSession;
 import com.ppiyaki.chat.service.ChatSessionPersistenceService;
 import com.ppiyaki.chat.service.ChatSessionService;
+import com.ppiyaki.chat.service.PhotoMessageValidator;
 import com.ppiyaki.chat.service.SttService;
 import com.ppiyaki.chat.service.TtsService;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -64,5 +66,22 @@ public class ChatController {
         final String transcribedText = sttService.transcribe(file.getResource(), language);
         final ChatSession session = persistenceService.createSession(userId);
         return chatSessionService.sendVoiceMessageStream(userId, session.getId(), transcribedText, ttsService);
+    }
+
+    @PostMapping(value = "/photo-messages", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public SseEmitter quickPhotoMessage(
+            @AuthenticationPrincipal final Long userId,
+            @RequestParam("file") final MultipartFile file,
+            @RequestParam(value = "message", required = false) final String message) {
+        PhotoMessageValidator.validate(file);
+        final byte[] bytes;
+        try {
+            bytes = file.getBytes();
+        } catch (final IOException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "Failed to read photo bytes");
+        }
+        final ChatSession session = persistenceService.createSession(userId);
+        return chatSessionService.sendPhotoMessageStream(
+                userId, session.getId(), bytes, file.getContentType(), message);
     }
 }

--- a/src/main/java/com/ppiyaki/chat/controller/ChatSessionController.java
+++ b/src/main/java/com/ppiyaki/chat/controller/ChatSessionController.java
@@ -5,11 +5,13 @@ import com.ppiyaki.chat.controller.dto.ChatSessionResponse;
 import com.ppiyaki.chat.domain.ChatSession;
 import com.ppiyaki.chat.service.ChatSessionPersistenceService;
 import com.ppiyaki.chat.service.ChatSessionService;
+import com.ppiyaki.chat.service.PhotoMessageValidator;
 import com.ppiyaki.chat.service.SttService;
 import com.ppiyaki.chat.service.TtsService;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -63,5 +65,23 @@ public class ChatSessionController {
         persistenceService.validateSession(userId, sessionId);
         final String transcribedText = sttService.transcribe(file.getResource(), language);
         return chatSessionService.sendVoiceMessageStream(userId, sessionId, transcribedText, ttsService);
+    }
+
+    @PostMapping(value = "/{sessionId}/photo-messages", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public SseEmitter sendPhotoMessage(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long sessionId,
+            @RequestParam("file") final MultipartFile file,
+            @RequestParam(value = "message", required = false) final String message) {
+        PhotoMessageValidator.validate(file);
+        persistenceService.validateSession(userId, sessionId);
+        final byte[] bytes;
+        try {
+            bytes = file.getBytes();
+        } catch (final IOException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "Failed to read photo bytes");
+        }
+        return chatSessionService.sendPhotoMessageStream(
+                userId, sessionId, bytes, file.getContentType(), message);
     }
 }

--- a/src/main/java/com/ppiyaki/chat/service/ChatSessionService.java
+++ b/src/main/java/com/ppiyaki/chat/service/ChatSessionService.java
@@ -1,5 +1,6 @@
 package com.ppiyaki.chat.service;
 
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -7,8 +8,13 @@ import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.stereotype.Service;
+import org.springframework.util.MimeType;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import reactor.core.Disposable;
 
@@ -17,6 +23,32 @@ import reactor.core.Disposable;
 public class ChatSessionService {
 
     private static final long SSE_TIMEOUT = 60_000L;
+
+    /**
+     * 사진 메시지 전용 시스템 프롬프트. spec chat-photo-messages.md §5-3.
+     * 약/비약 자동 분기를 LLM 자율 결정으로 위임.
+     */
+    private static final String PHOTO_SYSTEM_PROMPT = """
+            당신은 시니어를 돕는 복약 관리 비서입니다.
+            사용자가 사진을 보내면 다음 규칙을 따르세요:
+
+            1. 사진을 보고 약(알약/캡슐/약병/약 봉투/처방전 등)인지 먼저 판단하세요.
+
+            2. 약이면:
+               - 첫 문장에 사진 속 약을 짧게 묘사하세요 (색·모양·각인 등). 후속 질의에서 컨텍스트로 활용됩니다.
+               - 식별이 명확하면 약 이름을 알려주고, 필요한 경우 도구(searchMedicine, getDrugInfo, checkDur)를 사용해 정보를 보강하세요.
+               - 식별이 불확실하면 추측 금지 — "사진에서 식별이 어렵습니다. 약 봉투/처방전과 함께 보여주시거나 약사에게 문의해 주세요."로 안내하세요.
+
+            3. 약이 아니면:
+               - 약 관련 도구는 호출하지 마세요.
+               - 사진 속 대상을 짧게 묘사하고, 사용자 질문에 자유롭게 답하세요.
+               - 의료·건강 조언이 필요한 영역(예: 발진·상처 등)이면 "사진만으로는 정확한 판단이 어렵습니다. 의료기관·약사 상담을 권합니다." 한계를 명시하세요.
+
+            4. 진단·처방 같은 의료 결정은 하지 마세요.
+            5. 한국어 존댓말, 시니어가 이해하기 쉬운 짧은 문장으로.
+            """;
+
+    private static final String DEFAULT_PHOTO_PROMPT = "이 사진 속 약을 식별해줘";
 
     private final ChatSessionPersistenceService persistenceService;
     private final ChatClient chatClient;
@@ -92,6 +124,74 @@ public class ChatSessionService {
                             sentenceBuffer.flush()
                                     .ifPresent(sentence -> sendVoiceEvent(emitter, ttsService, sentence));
                             persistenceService.saveMessages(sessionId, transcribedText, fullResponse.toString());
+                            emitter.send(SseEmitter.event().data("[DONE]"));
+                            emitter.complete();
+                        } catch (final Exception e) {
+                            emitter.completeWithError(e);
+                        }
+                    })
+                    .doOnError(emitter::completeWithError)
+                    .subscribe();
+
+            emitter.onTimeout(subscription::dispose);
+            emitter.onCompletion(subscription::dispose);
+            emitter.onError(error -> subscription.dispose());
+        });
+
+        return emitter;
+    }
+
+    /**
+     * 사진 첨부 채팅 메시지 SSE 스트림. spec chat-photo-messages.md §5-4.
+     * - 시스템 프롬프트로 약/비약 자동 분기 + 묘사 포함 응답 유도
+     * - 기존 세션 히스토리 + 새 user message(텍스트 + image media)
+     * - 도구 chain: ToolContext에 userId 전달 (PR #232 패턴)
+     * - 메시지 히스토리: USER에 placeholder만 저장(이미지 자체 X)
+     */
+    public SseEmitter sendPhotoMessageStream(
+            final Long userId,
+            final Long sessionId,
+            final byte[] imageBytes,
+            final String mediaType,
+            final String userMessageText) {
+        final String effectiveText = (userMessageText == null || userMessageText.isBlank())
+                ? DEFAULT_PHOTO_PROMPT : userMessageText;
+        final String placeholder = "[이미지 첨부] " + effectiveText;
+
+        // 기존 세션 히스토리는 placeholder만 들어가지만, 새 turn은 실제 이미지가 LLM에 전달돼야
+        // 분기·묘사 가능. 따라서 history 기반 prompt를 빌드한 뒤 마지막 user turn을
+        // 이미지 첨부 UserMessage로 교체한다.
+        final List<Message> historyPrompt = persistenceService.loadSessionAndBuildPrompt(
+                userId, sessionId, placeholder);
+        final List<Message> promptMessages = new ArrayList<>();
+        promptMessages.add(new SystemMessage(PHOTO_SYSTEM_PROMPT));
+        for (int i = 0; i < historyPrompt.size() - 1; i++) {
+            promptMessages.add(historyPrompt.get(i));
+        }
+        promptMessages.add(UserMessage.builder()
+                .text(effectiveText)
+                .media(new Media(MimeType.valueOf(mediaType), new ByteArrayResource(imageBytes)))
+                .build());
+
+        final SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);
+        final StringBuilder fullResponse = new StringBuilder();
+
+        chatStreamExecutor.execute(() -> {
+            final Disposable subscription = chatClient.prompt(new Prompt(promptMessages))
+                    .toolContext(Map.of("userId", userId))
+                    .stream()
+                    .content()
+                    .doOnNext(token -> {
+                        try {
+                            fullResponse.append(token);
+                            emitter.send(SseEmitter.event().data(token));
+                        } catch (final Exception e) {
+                            emitter.completeWithError(e);
+                        }
+                    })
+                    .doOnComplete(() -> {
+                        try {
+                            persistenceService.saveMessages(sessionId, placeholder, fullResponse.toString());
                             emitter.send(SseEmitter.event().data("[DONE]"));
                             emitter.complete();
                         } catch (final Exception e) {

--- a/src/main/java/com/ppiyaki/chat/service/PhotoMessageValidator.java
+++ b/src/main/java/com/ppiyaki/chat/service/PhotoMessageValidator.java
@@ -1,0 +1,33 @@
+package com.ppiyaki.chat.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import java.util.Set;
+import org.springframework.web.multipart.MultipartFile;
+
+public final class PhotoMessageValidator {
+
+    public static final long MAX_BYTES = 10L * 1024 * 1024;
+    public static final Set<String> ALLOWED_MIME_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/webp");
+
+    private PhotoMessageValidator() {
+    }
+
+    /**
+     * 채팅 사진 메시지 multipart 파일 검증.
+     * spec chat-photo-messages.md §3 입력 검증 규칙.
+     */
+    public static void validate(final MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(ErrorCode.CHAT_PHOTO_FILE_EMPTY);
+        }
+        if (file.getSize() > MAX_BYTES) {
+            throw new BusinessException(ErrorCode.CHAT_PHOTO_TOO_LARGE);
+        }
+        final String mimeType = file.getContentType();
+        if (mimeType == null || !ALLOWED_MIME_TYPES.contains(mimeType.toLowerCase())) {
+            throw new BusinessException(ErrorCode.CHAT_PHOTO_TYPE_NOT_SUPPORTED);
+        }
+    }
+}

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -46,7 +46,11 @@ public enum ErrorCode {
     CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_001", "Chat session not found"),
     CHAT_SESSION_EXPIRED(HttpStatus.GONE, "CHAT_002", "Chat session expired"),
     CHAT_SESSION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CHAT_003", "Chat session access denied"),
-    CHAT_VOICE_FILE_EMPTY(HttpStatus.BAD_REQUEST, "CHAT_004", "Voice file is empty");
+    CHAT_VOICE_FILE_EMPTY(HttpStatus.BAD_REQUEST, "CHAT_004", "Voice file is empty"),
+    CHAT_PHOTO_FILE_EMPTY(HttpStatus.BAD_REQUEST, "CHAT_005", "Photo file is empty"),
+    CHAT_PHOTO_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "CHAT_006",
+            "Photo file type not supported (jpeg/png/webp only)"),
+    CHAT_PHOTO_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "CHAT_007", "Photo file exceeds 10MB limit");
 
     private final HttpStatus status;
     private final String code;

--- a/src/test/java/com/ppiyaki/chat/ChatPhotoE2ETest.java
+++ b/src/test/java/com/ppiyaki/chat/ChatPhotoE2ETest.java
@@ -1,0 +1,209 @@
+package com.ppiyaki.chat;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.chat.domain.ChatMessage;
+import com.ppiyaki.chat.domain.ChatSession;
+import com.ppiyaki.chat.repository.ChatMessageRepository;
+import com.ppiyaki.chat.service.ChatSessionPersistenceService;
+import com.ppiyaki.common.auth.JwtProvider;
+import io.restassured.RestAssured;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.TestPropertySource;
+import reactor.core.publisher.Flux;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = "spring.ai.openai.api-key=test-dummy-key")
+@Import(ChatPhotoE2ETest.MockChatClientConfig.class)
+@DisplayName("채팅 사진 첨부 (/chat/photo-messages, /chat/sessions/{id}/photo-messages) E2E")
+class ChatPhotoE2ETest {
+
+    @TestConfiguration
+    static class MockChatClientConfig {
+
+        @Bean
+        @Primary
+        public ChatClient mockChatClient() {
+            final ChatClient chatClient = mock(ChatClient.class);
+            final ChatClient.ChatClientRequestSpec requestSpec = mock(ChatClient.ChatClientRequestSpec.class);
+            final ChatClient.StreamResponseSpec streamResponseSpec = mock(ChatClient.StreamResponseSpec.class);
+
+            when(chatClient.prompt(any(Prompt.class))).thenReturn(requestSpec);
+            when(requestSpec.toolContext(anyMap())).thenReturn(requestSpec);
+            when(requestSpec.stream()).thenReturn(streamResponseSpec);
+            when(streamResponseSpec.content()).thenReturn(
+                    Flux.just("흰색 원형, 'T' 각인 — ", "타이레놀로 보입니다."));
+            return chatClient;
+        }
+    }
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ChatSessionPersistenceService persistenceService;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        accessToken = jwtProvider.createAccessToken(1L);
+    }
+
+    @Test
+    @DisplayName("단발 사진 메시지 — 임시 세션 자동 생성 + USER placeholder + ASSISTANT 묘사 응답 저장")
+    void quick_photo_persists() throws Exception {
+        final long before = chatMessageRepository.count();
+
+        try {
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .multiPart("file", "p.jpg", new byte[]{1, 2, 3}, "image/jpeg")
+                    .queryParam("message", "이거 뭐야?")
+                    .when()
+                    .post("/api/v1/chat/photo-messages");
+        } catch (final Exception ignored) {
+            // SSE 종료 chunk 파서 예외 — 무시
+        }
+
+        long after = chatMessageRepository.count();
+        for (int i = 0; i < 20 && after - before < 2; i++) {
+            Thread.sleep(100);
+            after = chatMessageRepository.count();
+        }
+        assertThat(after - before).isEqualTo(2L);
+
+        final List<ChatMessage> all = chatMessageRepository.findAll();
+        final ChatMessage user = all.get(all.size() - 2);
+        final ChatMessage assistant = all.get(all.size() - 1);
+        assertThat(user.getContent()).startsWith("[이미지 첨부] ").contains("이거 뭐야?");
+        assertThat(assistant.getContent()).contains("타이레놀");
+    }
+
+    @Test
+    @DisplayName("단발 — message 미지정 시 default placeholder")
+    void quick_photo_default_prompt() throws Exception {
+        final long before = chatMessageRepository.count();
+
+        try {
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .multiPart("file", "p.jpg", new byte[]{1}, "image/jpeg")
+                    .when()
+                    .post("/api/v1/chat/photo-messages");
+        } catch (final Exception ignored) {
+        }
+
+        long after = chatMessageRepository.count();
+        for (int i = 0; i < 20 && after - before < 2; i++) {
+            Thread.sleep(100);
+            after = chatMessageRepository.count();
+        }
+
+        final List<ChatMessage> all = chatMessageRepository.findAll();
+        final ChatMessage user = all.get(all.size() - 2);
+        assertThat(user.getContent()).startsWith("[이미지 첨부] 이 사진 속 약을 식별해줘");
+    }
+
+    @Test
+    @DisplayName("세션 사진 메시지 — 기존 세션에 USER placeholder + ASSISTANT 응답 저장")
+    void session_photo_persists() throws Exception {
+        final ChatSession session = persistenceService.createSession(1L);
+        final long before = chatMessageRepository.count();
+
+        try {
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .multiPart("file", "p.jpg", new byte[]{1}, "image/jpeg")
+                    .queryParam("message", "이거 뭐야?")
+                    .when()
+                    .post("/api/v1/chat/sessions/" + session.getId() + "/photo-messages");
+        } catch (final Exception ignored) {
+        }
+
+        long after = chatMessageRepository.count();
+        for (int i = 0; i < 20 && after - before < 2; i++) {
+            Thread.sleep(100);
+            after = chatMessageRepository.count();
+        }
+
+        final List<ChatMessage> all = chatMessageRepository.findAll();
+        assertThat(all).extracting(ChatMessage::getContent)
+                .anyMatch(c -> c.startsWith("[이미지 첨부] ") && c.contains("이거 뭐야?"));
+    }
+
+    @Test
+    @DisplayName("빈 파일 → 400 CHAT_005")
+    void empty_file_returns400() {
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+                .multiPart("file", "p.jpg", new byte[]{}, "image/jpeg")
+                .when()
+                .post("/api/v1/chat/photo-messages")
+                .then()
+                .statusCode(400)
+                .body("error.code", is("CHAT_005"));
+    }
+
+    @Test
+    @DisplayName("잘못된 MIME(image/gif) → 400 CHAT_006")
+    void unsupported_mime_returns400() {
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+                .multiPart("file", "p.gif", new byte[]{1}, "image/gif")
+                .when()
+                .post("/api/v1/chat/photo-messages")
+                .then()
+                .statusCode(400)
+                .body("error.code", is("CHAT_006"));
+    }
+
+    @Test
+    @DisplayName("인증 없으면 401")
+    void unauthenticated_returns401() {
+        given()
+                .multiPart("file", "p.jpg", new byte[]{1}, "image/jpeg")
+                .when()
+                .post("/api/v1/chat/photo-messages")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @DisplayName("Content-Type 변경 — application/pdf → 400 CHAT_006")
+    void pdf_returns400() {
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+                .multiPart("file", "p.pdf", new byte[]{1}, "application/pdf")
+                .when()
+                .post("/api/v1/chat/photo-messages")
+                .then()
+                .statusCode(400)
+                .body("error.code", is("CHAT_006"));
+    }
+}

--- a/src/test/java/com/ppiyaki/chat/service/PhotoMessageValidatorTest.java
+++ b/src/test/java/com/ppiyaki/chat/service/PhotoMessageValidatorTest.java
@@ -1,0 +1,99 @@
+package com.ppiyaki.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+@DisplayName("PhotoMessageValidator: MIME/사이즈/빈 파일 검증")
+class PhotoMessageValidatorTest {
+
+    @Test
+    @DisplayName("정상 jpeg 파일 통과")
+    void valid_jpeg() {
+        final MockMultipartFile file = new MockMultipartFile(
+                "file", "p.jpg", "image/jpeg", new byte[]{1, 2, 3});
+
+        assertThatCode(() -> PhotoMessageValidator.validate(file)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("정상 png 파일 통과")
+    void valid_png() {
+        final MockMultipartFile file = new MockMultipartFile(
+                "file", "p.png", "image/png", new byte[]{1});
+
+        assertThatCode(() -> PhotoMessageValidator.validate(file)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("정상 webp 파일 통과")
+    void valid_webp() {
+        final MockMultipartFile file = new MockMultipartFile(
+                "file", "p.webp", "image/webp", new byte[]{1});
+
+        assertThatCode(() -> PhotoMessageValidator.validate(file)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("빈 파일 → CHAT_PHOTO_FILE_EMPTY")
+    void empty_file_throws() {
+        final MockMultipartFile file = new MockMultipartFile(
+                "file", "p.jpg", "image/jpeg", new byte[]{});
+
+        assertThatThrownBy(() -> PhotoMessageValidator.validate(file))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CHAT_PHOTO_FILE_EMPTY);
+    }
+
+    @Test
+    @DisplayName("null → CHAT_PHOTO_FILE_EMPTY")
+    void null_file_throws() {
+        assertThatThrownBy(() -> PhotoMessageValidator.validate(null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CHAT_PHOTO_FILE_EMPTY);
+    }
+
+    @Test
+    @DisplayName("image/gif 거절 → CHAT_PHOTO_TYPE_NOT_SUPPORTED")
+    void unsupported_mime_throws() {
+        final MockMultipartFile file = new MockMultipartFile(
+                "file", "p.gif", "image/gif", new byte[]{1});
+
+        assertThatThrownBy(() -> PhotoMessageValidator.validate(file))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CHAT_PHOTO_TYPE_NOT_SUPPORTED);
+    }
+
+    @Test
+    @DisplayName("contentType null → CHAT_PHOTO_TYPE_NOT_SUPPORTED")
+    void null_contentType_throws() {
+        final MockMultipartFile file = new MockMultipartFile(
+                "file", "p.jpg", null, new byte[]{1});
+
+        assertThatThrownBy(() -> PhotoMessageValidator.validate(file))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CHAT_PHOTO_TYPE_NOT_SUPPORTED);
+    }
+
+    @Test
+    @DisplayName("10MB 초과 → CHAT_PHOTO_TOO_LARGE")
+    void oversize_throws() {
+        final byte[] big = new byte[(int) PhotoMessageValidator.MAX_BYTES + 1];
+        final MockMultipartFile file = new MockMultipartFile(
+                "file", "p.jpg", "image/jpeg", big);
+
+        assertThatThrownBy(() -> PhotoMessageValidator.validate(file))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CHAT_PHOTO_TOO_LARGE);
+    }
+}


### PR DESCRIPTION
## Summary
spec PR #236 (`docs/features/chat-photo-messages.md`) 구현.
- 단발 + 세션 photo 엔드포인트(multipart)
- 시스템 프롬프트로 약/비약 자동 분기 (LLM 자율 결정)
- 이미지는 메모리에서만 처리, S3 저장 X
- 메시지 히스토리에 USER placeholder + ASSISTANT 묘사 응답 저장

## 변경 파일
- `ChatController` / `ChatSessionController`: photo 엔드포인트 추가 (multipart)
- `ChatSessionService.sendPhotoMessageStream`: vision 호출 + 도구 chain + 시스템 프롬프트 + 히스토리 저장
- `PhotoMessageValidator`: MIME(jpeg/png/webp)/사이즈(10MB)/빈 파일 검증
- `ErrorCode`: CHAT_005(empty)/CHAT_006(type)/CHAT_007(too-large)
- `PhotoMessageValidatorTest` 8 케이스, `ChatPhotoE2ETest` 7 케이스

## prod 영향
- 마이그레이션 SQL 없음 (코드만)
- ChatClient/ChatSession은 기존 흐름 그대로, 신규 엔드포인트만 추가

## 시스템 프롬프트 핵심 규칙
1. 사진 보고 약(알약/캡슐/약병/약 봉투/처방전) 여부 자체 판단
2. 약 → 묘사 + searchMedicine/getDrugInfo/checkDur 도구 chain
3. 약 외 → 도구 호출 없이 자유 답변, 의료·건강 영역만 한계 명시
4. 진단·처방 금지, 한국어 존댓말, 시니어가 이해하기 쉬운 짧은 문장

## Test plan
- [ ] 머지 후 prod 배포 (v0.9.3)
- [ ] 시니어 token으로 알약 사진 + "이거 뭐야?" → 약 식별 + 도구 응답
- [ ] 비약 사진 (꽃 등) + 질의 → 도구 호출 없이 자유 답변
- [ ] 세션 흐름: 같은 세션에 사진 메시지 후 후속 텍스트 질의 → ASSISTANT 묘사 컨텍스트 재참조 확인
- [ ] Notion API 명세 동기화 (사용자 사이클)

## 알려진 제한
- RestAssured multipart 한글 인코딩 한계로 테스트는 `message`를 queryParam으로 전달. Spring `@RequestParam`이 multipart text part와 query 둘 다 받으므로 운영 흐름(multipart) 호환성 영향 없음. 클라이언트는 multipart text part `charset=UTF-8` 명시 권장.

## 선행 / 후속
- 선행: PR #236 (spec), PR #232 (ToolContext)
- 후속: 이미지 보존(B 옵션, presigned URL + objectKey)이 필요해지면 별도 spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 채팅에 사진 메시지 전송 기능 추가
  * 사진 업로드 지원 (JPEG, PNG, WEBP, 최대 10MB)
  * 빠른 사진 전송 및 세션 기반 사진 전송 두 가지 엔드포인트 제공
  * 사진 메시지에 대한 실시간 스트리밍 응답 지원

* **Tests**
  * 사진 메시지 기능에 대한 E2E 테스트 추가
  * 사진 검증 로직 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->