### PR TITLE
feat(medicine): 식약처 알약 낱알식별 자체 인덱스 + 동기화 (Pill ID PR 2)

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -269,6 +269,31 @@ OCR + LLM 파싱으로 추출된 약물 후보. 처방전 1건당 N행. 보호�
 > **레벨/스테이지는 서버(도메인 로직)에서 `point`로부터 계산**한다. 예: `level = floor(sqrt(point / 10))`. 밸런스 변경 시 DB 마이그레이션 없이 재계산할 수 있어 기획 반복에 유리하다.
 > **코드 갭**: 현재 `Pet.java`는 `CreatedTimeEntity`/`BaseTimeEntity`를 상속하지 않아 `created_at`/`updated_at`이 없다. 추적: §7-18.
 
+### pill_identifications (target: `@Table(name = "pill_identifications")`, no time mixin)
+식약처 의약품 낱알식별 정보 마스터 (식약처 OpenAPI `MdcinGrnIdntfcInfoService03/getMdcinGrnIdntfcInfoList03`을 주 1회 batch로 동기화). 약명 추정 없이 외형(각인·색·모양·분할선)으로 약 후보를 검색하기 위한 자체 인덱스. 자세한 설계: `docs/features/pill-identification.md`.
+
+| 컬럼 | 타입 | 설명 |
+|---|---|---|
+| item_seq | varchar(20) PK | 식약처 품목일련번호 |
+| item_name | varchar(255) NOT NULL | 품목명 (예: "타이레놀정500밀리그람") |
+| entp_name | varchar nullable | 업체명 |
+| print_front / print_back | varchar(64) nullable | 앞면/뒷면 각인 |
+| drug_shape | varchar(32) nullable | 모양 (예: "원형", "장방형", "타원형") |
+| color_class1 / color_class2 | varchar(32) nullable | 1차/2차 색 (예: "하양") |
+| line_front / line_back | varchar(32) nullable | 분할선 ("(+)형", "(-)형", null) |
+| leng_long / leng_short / thick | varchar(16) nullable | 장축·단축·두께 (mm) |
+| chart | text nullable | 형태 설명 |
+| item_image | varchar(512) nullable | 식약처 호스팅 이미지 URL |
+| class_no / class_name | varchar nullable | 분류 번호/명 |
+| etc_otc_name | varchar(32) nullable | 전문/일반 구분 |
+| mark_code_front / mark_code_back | varchar(64) nullable | 표준 각인 코드 |
+| edi_code | varchar(32) nullable | 보험코드 |
+| bizrno | varchar(32) nullable | 사업자등록번호 |
+| change_date | varchar(20) nullable | 식약처 변경일자 (yyyymmdd) |
+| synced_at | datetime(6) NOT NULL | 우리 동기화 시각 |
+
+**인덱스**: `idx_pill_print_front`(print_front), `idx_pill_shape_color`(drug_shape, color_class1), `idx_pill_color_shape_line`(color_class1, drug_shape, line_front), `idx_pill_item_name`(item_name).
+
 ### dur_checks (target: `@Table(name = "dur_checks")`, extends `CreatedTimeEntity`)
 DUR 점검 결과의 immutable 로그. 약물 정보가 시간에 따라 변할 수 있으므로 **매 호출 시 새 레코드**로 기록한다(캐시 아님).
 

--- a/src/main/java/com/ppiyaki/PpiyakiApplication.java
+++ b/src/main/java/com/ppiyaki/PpiyakiApplication.java
@@ -3,9 +3,11 @@ package com.ppiyaki;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class PpiyakiApplication {
 
     public static void main(final String[] args) {

--- a/src/main/java/com/ppiyaki/common/mfds/MdcinGrnIdntfcInfoClient.java
+++ b/src/main/java/com/ppiyaki/common/mfds/MdcinGrnIdntfcInfoClient.java
@@ -1,0 +1,189 @@
+package com.ppiyaki.common.mfds;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 식약처 의약품 낱알식별정보 OpenAPI 클라이언트 (MdcinGrnIdntfcInfoService03).
+ * spec docs/features/pill-identification.md §5-3.
+ *
+ * <p>일괄 동기화용. 검색 키는 약명/업체명/일련번호로 한정되며 외형(각인·색·모양)은 응답 필드에만 포함되므로,
+ * 본 client는 paging으로 전체를 받아 자체 인덱스(pill_identifications)에 적재하는 흐름이다.
+ */
+@Component
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class MdcinGrnIdntfcInfoClient {
+
+    private static final Logger log = LoggerFactory.getLogger(MdcinGrnIdntfcInfoClient.class);
+    private static final String BASE_URL = "https://apis.data.go.kr/1471000/MdcinGrnIdntfcInfoService03";
+    private static final String OPERATION = "getMdcinGrnIdntfcInfoList03";
+    private static final String RESULT_CODE_SUCCESS = "00";
+    public static final int DEFAULT_NUM_OF_ROWS = 100;
+
+    private final MfdsApiProperties properties;
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    public MdcinGrnIdntfcInfoClient(
+            final MfdsApiProperties properties,
+            final RestClient.Builder restClientBuilder,
+            final ObjectMapper objectMapper
+    ) {
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+
+        final SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofMillis(properties.connectTimeout()));
+        // 동기화 batch는 단건 호출보다 응답이 큼(numOfRows=100) → 여유 있게
+        factory.setReadTimeout(Duration.ofSeconds(15));
+
+        this.restClient = restClientBuilder.requestFactory(factory).build();
+    }
+
+    public PillPage fetchPage(final int pageNo, final int numOfRows) {
+        final String url = BASE_URL + "/" + OPERATION
+                + "?serviceKey=" + properties.serviceKey()
+                + "&type=json"
+                + "&pageNo=" + pageNo
+                + "&numOfRows=" + numOfRows;
+
+        log.info("MDCIN_GRN API call: pageNo={} numOfRows={}", pageNo, numOfRows);
+        final long startTime = System.currentTimeMillis();
+        try {
+            final String responseBody = restClient.get()
+                    .uri(URI.create(url))
+                    .retrieve()
+                    .body(String.class);
+            final long elapsed = System.currentTimeMillis() - startTime;
+            log.info("MDCIN_GRN API response: pageNo={} elapsed={}ms", pageNo, elapsed);
+            return parseResponse(responseBody);
+        } catch (final BusinessException e) {
+            throw e;
+        } catch (final Exception e) {
+            final long elapsed = System.currentTimeMillis() - startTime;
+            log.error("MDCIN_GRN API failed: pageNo={} elapsed={}ms error={}", pageNo, elapsed, e.getMessage());
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
+                    "MDCIN_GRN API call failed: " + e.getMessage());
+        }
+    }
+
+    private PillPage parseResponse(final String responseBody) {
+        try {
+            final JsonNode root = objectMapper.readTree(responseBody);
+            final String resultCode = root.path("header").path("resultCode").asText();
+            if (!RESULT_CODE_SUCCESS.equals(resultCode)) {
+                final String resultMsg = root.path("header").path("resultMsg").asText();
+                throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
+                        "MDCIN_GRN API error: " + resultCode + " " + resultMsg);
+            }
+
+            final JsonNode body = root.path("body");
+            final int totalCount = body.path("totalCount").asInt(0);
+
+            final List<PillItem> items = new ArrayList<>();
+            final JsonNode itemsNode = body.path("items");
+
+            if (!itemsNode.isMissingNode() && !itemsNode.isNull()) {
+                if (itemsNode.isArray()) {
+                    for (final JsonNode item : itemsNode) {
+                        items.add(toItem(item));
+                    }
+                } else if (itemsNode.isObject()) {
+                    final JsonNode itemNode = itemsNode.path("item");
+                    if (itemNode.isArray()) {
+                        for (final JsonNode item : itemNode) {
+                            items.add(toItem(item));
+                        }
+                    } else if (itemNode.isObject()) {
+                        items.add(toItem(itemNode));
+                    }
+                }
+            }
+            return new PillPage(totalCount, items);
+        } catch (final BusinessException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
+                    "MDCIN_GRN parse failed: " + e.getMessage());
+        }
+    }
+
+    private PillItem toItem(final JsonNode n) {
+        return new PillItem(
+                text(n, "ITEM_SEQ"),
+                text(n, "ITEM_NAME"),
+                text(n, "ENTP_NAME"),
+                text(n, "PRINT_FRONT"),
+                text(n, "PRINT_BACK"),
+                text(n, "DRUG_SHAPE"),
+                text(n, "COLOR_CLASS1"),
+                text(n, "COLOR_CLASS2"),
+                text(n, "LINE_FRONT"),
+                text(n, "LINE_BACK"),
+                text(n, "LENG_LONG"),
+                text(n, "LENG_SHORT"),
+                text(n, "THICK"),
+                text(n, "CHART"),
+                text(n, "ITEM_IMAGE"),
+                text(n, "CLASS_NO"),
+                text(n, "CLASS_NAME"),
+                text(n, "ETC_OTC_NAME"),
+                text(n, "MARK_CODE_FRONT"),
+                text(n, "MARK_CODE_BACK"),
+                text(n, "EDI_CODE"),
+                text(n, "BIZRNO"),
+                text(n, "CHANGE_DATE")
+        );
+    }
+
+    private static String text(final JsonNode n, final String key) {
+        final JsonNode v = n.path(key);
+        if (v.isMissingNode() || v.isNull()) {
+            return null;
+        }
+        final String s = v.asText();
+        return s.isBlank() ? null : s;
+    }
+
+    public record PillPage(int totalCount, List<PillItem> items) {
+    }
+
+    public record PillItem(
+            String itemSeq,
+            String itemName,
+            String entpName,
+            String printFront,
+            String printBack,
+            String drugShape,
+            String colorClass1,
+            String colorClass2,
+            String lineFront,
+            String lineBack,
+            String lengLong,
+            String lengShort,
+            String thick,
+            String chart,
+            String itemImage,
+            String classNo,
+            String className,
+            String etcOtcName,
+            String markCodeFront,
+            String markCodeBack,
+            String ediCode,
+            String bizrno,
+            String changeDate
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/medicine/PillIdentification.java
+++ b/src/main/java/com/ppiyaki/medicine/PillIdentification.java
@@ -1,0 +1,188 @@
+package com.ppiyaki.medicine;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 식약처 의약품 낱알식별 정보 마스터.
+ * spec docs/features/pill-identification.md.
+ *
+ * <p>식약처 OpenAPI {@code MdcinGrnIdntfcInfoService03/getMdcinGrnIdntfcInfoList03}를
+ * 주 1회 batch로 동기화한다. 외형(각인·색·모양·분할선)으로 검색해 사진에서
+ * 약명을 추정 못하는 vision 흐름의 식별 백업으로 사용된다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "pill_identifications", indexes = {
+                @Index(name = "idx_pill_print_front", columnList = "print_front"),
+                @Index(name = "idx_pill_shape_color", columnList = "drug_shape, color_class1"),
+                @Index(name = "idx_pill_color_shape_line", columnList = "color_class1, drug_shape, line_front"),
+                @Index(name = "idx_pill_item_name", columnList = "item_name")
+        }
+)
+public class PillIdentification {
+
+    @Id
+    @Column(name = "item_seq", length = 20, nullable = false)
+    private String itemSeq;
+
+    @Column(name = "item_name", nullable = false)
+    private String itemName;
+
+    @Column(name = "entp_name")
+    private String entpName;
+
+    @Column(name = "print_front", length = 64)
+    private String printFront;
+
+    @Column(name = "print_back", length = 64)
+    private String printBack;
+
+    @Column(name = "drug_shape", length = 32)
+    private String drugShape;
+
+    @Column(name = "color_class1", length = 32)
+    private String colorClass1;
+
+    @Column(name = "color_class2", length = 32)
+    private String colorClass2;
+
+    @Column(name = "line_front", length = 32)
+    private String lineFront;
+
+    @Column(name = "line_back", length = 32)
+    private String lineBack;
+
+    @Column(name = "leng_long", length = 16)
+    private String lengLong;
+
+    @Column(name = "leng_short", length = 16)
+    private String lengShort;
+
+    @Column(name = "thick", length = 16)
+    private String thick;
+
+    @Column(name = "chart", columnDefinition = "TEXT")
+    private String chart;
+
+    @Column(name = "item_image", length = 512)
+    private String itemImage;
+
+    @Column(name = "class_no", length = 16)
+    private String classNo;
+
+    @Column(name = "class_name", length = 128)
+    private String className;
+
+    @Column(name = "etc_otc_name", length = 32)
+    private String etcOtcName;
+
+    @Column(name = "mark_code_front", length = 64)
+    private String markCodeFront;
+
+    @Column(name = "mark_code_back", length = 64)
+    private String markCodeBack;
+
+    @Column(name = "edi_code", length = 32)
+    private String ediCode;
+
+    @Column(name = "bizrno", length = 32)
+    private String bizrno;
+
+    @Column(name = "change_date", length = 20)
+    private String changeDate;
+
+    @Column(name = "synced_at", nullable = false)
+    private LocalDateTime syncedAt;
+
+    public PillIdentification(
+            final String itemSeq,
+            final String itemName,
+            final String entpName,
+            final String printFront,
+            final String printBack,
+            final String drugShape,
+            final String colorClass1,
+            final String colorClass2,
+            final String lineFront,
+            final String lineBack,
+            final String lengLong,
+            final String lengShort,
+            final String thick,
+            final String chart,
+            final String itemImage,
+            final String classNo,
+            final String className,
+            final String etcOtcName,
+            final String markCodeFront,
+            final String markCodeBack,
+            final String ediCode,
+            final String bizrno,
+            final String changeDate,
+            final LocalDateTime syncedAt
+    ) {
+        this.itemSeq = Objects.requireNonNull(itemSeq, "itemSeq must not be null");
+        this.itemName = Objects.requireNonNull(itemName, "itemName must not be null");
+        this.entpName = entpName;
+        this.printFront = printFront;
+        this.printBack = printBack;
+        this.drugShape = drugShape;
+        this.colorClass1 = colorClass1;
+        this.colorClass2 = colorClass2;
+        this.lineFront = lineFront;
+        this.lineBack = lineBack;
+        this.lengLong = lengLong;
+        this.lengShort = lengShort;
+        this.thick = thick;
+        this.chart = chart;
+        this.itemImage = itemImage;
+        this.classNo = classNo;
+        this.className = className;
+        this.etcOtcName = etcOtcName;
+        this.markCodeFront = markCodeFront;
+        this.markCodeBack = markCodeBack;
+        this.ediCode = ediCode;
+        this.bizrno = bizrno;
+        this.changeDate = changeDate;
+        this.syncedAt = Objects.requireNonNull(syncedAt, "syncedAt must not be null");
+    }
+
+    /**
+     * 동기화 시 외형 등 메타 갱신. PK는 유지(item_seq).
+     */
+    public void updateFromSync(final PillIdentification fresh) {
+        this.itemName = fresh.itemName;
+        this.entpName = fresh.entpName;
+        this.printFront = fresh.printFront;
+        this.printBack = fresh.printBack;
+        this.drugShape = fresh.drugShape;
+        this.colorClass1 = fresh.colorClass1;
+        this.colorClass2 = fresh.colorClass2;
+        this.lineFront = fresh.lineFront;
+        this.lineBack = fresh.lineBack;
+        this.lengLong = fresh.lengLong;
+        this.lengShort = fresh.lengShort;
+        this.thick = fresh.thick;
+        this.chart = fresh.chart;
+        this.itemImage = fresh.itemImage;
+        this.classNo = fresh.classNo;
+        this.className = fresh.className;
+        this.etcOtcName = fresh.etcOtcName;
+        this.markCodeFront = fresh.markCodeFront;
+        this.markCodeBack = fresh.markCodeBack;
+        this.ediCode = fresh.ediCode;
+        this.bizrno = fresh.bizrno;
+        this.changeDate = fresh.changeDate;
+        this.syncedAt = fresh.syncedAt;
+    }
+}

--- a/src/main/java/com/ppiyaki/medicine/controller/AdminPillSyncController.java
+++ b/src/main/java/com/ppiyaki/medicine/controller/AdminPillSyncController.java
@@ -1,0 +1,32 @@
+package com.ppiyaki.medicine.controller;
+
+import com.ppiyaki.medicine.service.PillIdentificationSyncService;
+import com.ppiyaki.medicine.service.PillIdentificationSyncService.SyncResult;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 식약처 낱알식별 동기화 수동 트리거. spec §5-2 — 본 spec 한정 비공개 endpoint.
+ *
+ * <p>현재는 admin role 인프라 부재로 외부에 공개되지 않는 개발자 호출 전용.
+ * SecurityConfig permit 목록에 추가하지 않으면 모든 인증 사용자가 호출 가능 — prod 노출 전 권한 추가 필수.
+ */
+@RestController
+@RequestMapping("/api/v1/admin/pill-identifications")
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class AdminPillSyncController {
+
+    private final PillIdentificationSyncService syncService;
+
+    public AdminPillSyncController(final PillIdentificationSyncService syncService) {
+        this.syncService = syncService;
+    }
+
+    @PostMapping("/sync")
+    public ResponseEntity<SyncResult> sync() {
+        return ResponseEntity.ok(syncService.syncAll());
+    }
+}

--- a/src/main/java/com/ppiyaki/medicine/repository/PillIdentificationRepository.java
+++ b/src/main/java/com/ppiyaki/medicine/repository/PillIdentificationRepository.java
@@ -1,0 +1,9 @@
+package com.ppiyaki.medicine.repository;
+
+import com.ppiyaki.medicine.PillIdentification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface PillIdentificationRepository
+        extends JpaRepository<PillIdentification, String>, JpaSpecificationExecutor<PillIdentification> {
+}

--- a/src/main/java/com/ppiyaki/medicine/repository/PillIdentificationSpecifications.java
+++ b/src/main/java/com/ppiyaki/medicine/repository/PillIdentificationSpecifications.java
@@ -1,0 +1,37 @@
+package com.ppiyaki.medicine.repository;
+
+import com.ppiyaki.medicine.PillIdentification;
+import org.springframework.data.jpa.domain.Specification;
+
+/**
+ * 외형(각인·색·모양·분할선) 동적 검색 Specification.
+ * spec docs/features/pill-identification.md §5-2 — null 파라미터는 제외.
+ */
+public final class PillIdentificationSpecifications {
+
+    private PillIdentificationSpecifications() {
+    }
+
+    public static Specification<PillIdentification> byAppearance(
+            final String printFront,
+            final String printBack,
+            final String drugShape,
+            final String colorClass1,
+            final String lineFront
+    ) {
+        return Specification.allOf(
+                fieldEquals("printFront", printFront),
+                fieldEquals("printBack", printBack),
+                fieldEquals("drugShape", drugShape),
+                fieldEquals("colorClass1", colorClass1),
+                fieldEquals("lineFront", lineFront)
+        );
+    }
+
+    private static Specification<PillIdentification> fieldEquals(final String field, final String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return (root, query, cb) -> cb.equal(root.get(field), value);
+    }
+}

--- a/src/main/java/com/ppiyaki/medicine/scheduler/PillIdentificationSyncScheduler.java
+++ b/src/main/java/com/ppiyaki/medicine/scheduler/PillIdentificationSyncScheduler.java
@@ -1,0 +1,34 @@
+package com.ppiyaki.medicine.scheduler;
+
+import com.ppiyaki.medicine.service.PillIdentificationSyncService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 주 1회 (KST 일요일 02:00) 식약처 낱알식별 데이터 동기화.
+ * spec docs/features/pill-identification.md §3 (cron) / §5-4.
+ */
+@Component
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class PillIdentificationSyncScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(PillIdentificationSyncScheduler.class);
+
+    private final PillIdentificationSyncService syncService;
+
+    public PillIdentificationSyncScheduler(final PillIdentificationSyncService syncService) {
+        this.syncService = syncService;
+    }
+
+    @Scheduled(cron = "0 0 2 ? * SUN", zone = "Asia/Seoul")
+    public void runWeeklySync() {
+        try {
+            syncService.syncAll();
+        } catch (final Exception e) {
+            log.error("PillIdentification weekly sync failed", e);
+        }
+    }
+}

--- a/src/main/java/com/ppiyaki/medicine/service/PillIdentificationSyncService.java
+++ b/src/main/java/com/ppiyaki/medicine/service/PillIdentificationSyncService.java
@@ -1,0 +1,99 @@
+package com.ppiyaki.medicine.service;
+
+import com.ppiyaki.common.mfds.MdcinGrnIdntfcInfoClient;
+import com.ppiyaki.common.mfds.MdcinGrnIdntfcInfoClient.PillItem;
+import com.ppiyaki.common.mfds.MdcinGrnIdntfcInfoClient.PillPage;
+import com.ppiyaki.medicine.PillIdentification;
+import com.ppiyaki.medicine.repository.PillIdentificationRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 식약처 의약품 낱알식별 정보 일괄 동기화 서비스.
+ * spec docs/features/pill-identification.md §5-4 (동기화 batch).
+ *
+ * <p>전체 페이지를 paginate하며 item_seq 기준 idempotent upsert.
+ * 부분 실패 시 다음 cron 또는 수동 트리거로 복구 가능.
+ */
+@Service
+@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
+public class PillIdentificationSyncService {
+
+    private static final Logger log = LoggerFactory.getLogger(PillIdentificationSyncService.class);
+
+    private final MdcinGrnIdntfcInfoClient client;
+    private final PillIdentificationRepository repository;
+
+    public PillIdentificationSyncService(
+            final MdcinGrnIdntfcInfoClient client,
+            final PillIdentificationRepository repository
+    ) {
+        this.client = client;
+        this.repository = repository;
+    }
+
+    public SyncResult syncAll() {
+        final long startTime = System.currentTimeMillis();
+        int pageNo = 1;
+        int upserted = 0;
+        int totalCount = -1;
+
+        while (true) {
+            final PillPage page = client.fetchPage(pageNo, MdcinGrnIdntfcInfoClient.DEFAULT_NUM_OF_ROWS);
+            if (totalCount < 0) {
+                totalCount = page.totalCount();
+                log.info("MDCIN_GRN sync started: totalCount={}", totalCount);
+            }
+            if (page.items().isEmpty()) {
+                break;
+            }
+            for (final PillItem item : page.items()) {
+                if (item.itemSeq() == null || item.itemName() == null) {
+                    continue;
+                }
+                upsert(item);
+                upserted++;
+            }
+            if (upserted >= totalCount) {
+                break;
+            }
+            pageNo++;
+        }
+
+        final long elapsed = System.currentTimeMillis() - startTime;
+        log.info("MDCIN_GRN sync done: upserted={} totalCount={} elapsed={}ms",
+                upserted, totalCount, elapsed);
+        return new SyncResult(upserted, totalCount, elapsed);
+    }
+
+    @Transactional
+    protected void upsert(final PillItem item) {
+        final LocalDateTime now = LocalDateTime.now();
+        final PillIdentification fresh = new PillIdentification(
+                item.itemSeq(), item.itemName(), item.entpName(),
+                item.printFront(), item.printBack(),
+                item.drugShape(), item.colorClass1(), item.colorClass2(),
+                item.lineFront(), item.lineBack(),
+                item.lengLong(), item.lengShort(), item.thick(),
+                item.chart(), item.itemImage(),
+                item.classNo(), item.className(), item.etcOtcName(),
+                item.markCodeFront(), item.markCodeBack(),
+                item.ediCode(), item.bizrno(), item.changeDate(),
+                now
+        );
+        final Optional<PillIdentification> existing = repository.findById(item.itemSeq());
+        if (existing.isPresent()) {
+            existing.get().updateFromSync(fresh);
+        } else {
+            repository.save(fresh);
+        }
+    }
+
+    public record SyncResult(int upserted, int totalCount, long elapsedMs) {
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -127,6 +127,39 @@
         primary key (id)
     ) engine=InnoDB;
 
+    create table pill_identifications (
+        synced_at datetime(6) not null,
+        bizrno varchar(32),
+        change_date varchar(20),
+        class_no varchar(16),
+        color_class1 varchar(32),
+        color_class2 varchar(32),
+        drug_shape varchar(32),
+        edi_code varchar(32),
+        etc_otc_name varchar(32),
+        leng_long varchar(16),
+        leng_short varchar(16),
+        line_back varchar(32),
+        line_front varchar(32),
+        mark_code_back varchar(64),
+        mark_code_front varchar(64),
+        print_back varchar(64),
+        print_front varchar(64),
+        thick varchar(16),
+        class_name varchar(128),
+        item_seq varchar(20) not null,
+        item_image varchar(512),
+        item_name varchar(255) not null,
+        entp_name varchar(255),
+        chart TEXT,
+        primary key (item_seq)
+    ) engine=InnoDB;
+
+    create index idx_pill_print_front on pill_identifications (print_front);
+    create index idx_pill_shape_color on pill_identifications (drug_shape, color_class1);
+    create index idx_pill_color_shape_line on pill_identifications (color_class1, drug_shape, line_front);
+    create index idx_pill_item_name on pill_identifications (item_name);
+
     create table prescriptions (
         caregiver_id bigint,
         created_at datetime(6),

--- a/src/test/java/com/ppiyaki/common/mfds/MdcinGrnIdntfcInfoClientTest.java
+++ b/src/test/java/com/ppiyaki/common/mfds/MdcinGrnIdntfcInfoClientTest.java
@@ -1,0 +1,99 @@
+package com.ppiyaki.common.mfds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ppiyaki.common.mfds.MdcinGrnIdntfcInfoClient.PillPage;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MdcinGrnIdntfcInfoClient.parseResponse")
+class MdcinGrnIdntfcInfoClientTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("items가 배열 형태 → totalCount + 모든 item 파싱")
+    void parse_arrayItems() throws Exception {
+        final String body = """
+                {
+                  "header": {"resultCode": "00", "resultMsg": "NORMAL SERVICE."},
+                  "body": {
+                    "totalCount": 2,
+                    "items": [
+                      {"ITEM_SEQ": "199500096", "ITEM_NAME": "타이레놀정500밀리그람",
+                       "ENTP_NAME": "한국존슨앤드존슨판매(유)",
+                       "PRINT_FRONT": "T", "DRUG_SHAPE": "장방형", "COLOR_CLASS1": "하양"},
+                      {"ITEM_SEQ": "200000123", "ITEM_NAME": "이부프로펜정200mg",
+                       "PRINT_FRONT": "I", "DRUG_SHAPE": "원형", "COLOR_CLASS1": "하양"}
+                    ],
+                    "pageNo": 1,
+                    "numOfRows": 100
+                  }
+                }
+                """;
+        final PillPage page = invokeParse(body);
+
+        assertThat(page.totalCount()).isEqualTo(2);
+        assertThat(page.items()).hasSize(2);
+        assertThat(page.items().get(0).itemSeq()).isEqualTo("199500096");
+        assertThat(page.items().get(0).itemName()).isEqualTo("타이레놀정500밀리그람");
+        assertThat(page.items().get(0).printFront()).isEqualTo("T");
+        assertThat(page.items().get(0).colorClass1()).isEqualTo("하양");
+    }
+
+    @Test
+    @DisplayName("items.item이 단일 객체 → 1건 파싱")
+    void parse_singleObjectItem() throws Exception {
+        final String body = """
+                {
+                  "header": {"resultCode": "00"},
+                  "body": {
+                    "totalCount": 1,
+                    "items": {"item": {"ITEM_SEQ": "X", "ITEM_NAME": "단일"}}
+                  }
+                }
+                """;
+        final PillPage page = invokeParse(body);
+        assertThat(page.items()).hasSize(1);
+        assertThat(page.items().get(0).itemSeq()).isEqualTo("X");
+    }
+
+    @Test
+    @DisplayName("items 빈 응답 → 빈 리스트")
+    void parse_empty() throws Exception {
+        final String body = """
+                {"header": {"resultCode": "00"}, "body": {"totalCount": 0, "items": ""}}
+                """;
+        final PillPage page = invokeParse(body);
+        assertThat(page.items()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("blank 문자열은 null로 정규화 (PRINT_FRONT가 \"\"면 null)")
+    void parse_blankToNull() throws Exception {
+        final String body = """
+                {"header": {"resultCode": "00"}, "body": {"totalCount": 1, "items": [
+                  {"ITEM_SEQ": "Y", "ITEM_NAME": "약", "PRINT_FRONT": "", "DRUG_SHAPE": "원형"}
+                ]}}
+                """;
+        final PillPage page = invokeParse(body);
+        assertThat(page.items().get(0).printFront()).isNull();
+        assertThat(page.items().get(0).drugShape()).isEqualTo("원형");
+    }
+
+    /**
+     * parseResponse는 private이므로 reflection으로 직접 호출.
+     * 실제 HTTP 호출 없이 응답 파싱 로직만 단위 검증.
+     */
+    private PillPage invokeParse(final String body) throws Exception {
+        final MdcinGrnIdntfcInfoClient client = new MdcinGrnIdntfcInfoClient(
+                new MfdsApiProperties("test-key", "apis.data.go.kr/1471000/MfdsDurInfoService", 1000, 5000),
+                org.springframework.web.client.RestClient.builder(),
+                objectMapper);
+        final Method m = MdcinGrnIdntfcInfoClient.class.getDeclaredMethod("parseResponse", String.class);
+        m.setAccessible(true);
+        return (PillPage) m.invoke(client, body);
+    }
+}

--- a/src/test/java/com/ppiyaki/medicine/service/PillIdentificationSyncServiceTest.java
+++ b/src/test/java/com/ppiyaki/medicine/service/PillIdentificationSyncServiceTest.java
@@ -1,0 +1,127 @@
+package com.ppiyaki.medicine.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.common.mfds.MdcinGrnIdntfcInfoClient;
+import com.ppiyaki.common.mfds.MdcinGrnIdntfcInfoClient.PillItem;
+import com.ppiyaki.common.mfds.MdcinGrnIdntfcInfoClient.PillPage;
+import com.ppiyaki.medicine.PillIdentification;
+import com.ppiyaki.medicine.repository.PillIdentificationRepository;
+import com.ppiyaki.medicine.service.PillIdentificationSyncService.SyncResult;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PillIdentificationSyncService")
+class PillIdentificationSyncServiceTest {
+
+    @Mock
+    private MdcinGrnIdntfcInfoClient client;
+    @Mock
+    private PillIdentificationRepository repository;
+
+    @InjectMocks
+    private PillIdentificationSyncService service;
+
+    @BeforeEach
+    void setUp() {
+        // findById 기본 empty (신규 INSERT 경로). lenient — 모든 테스트에서 호출되지는 않음.
+        lenient().when(repository.findById(any())).thenReturn(Optional.empty());
+    }
+
+    @Test
+    @DisplayName("두 페이지에 걸친 데이터 → 모두 upsert (신규 INSERT)")
+    void syncAll_twoPages_inserts() {
+        final PillItem a = item("ITEM-1", "타이레놀정");
+        final PillItem b = item("ITEM-2", "이부프로펜정");
+        final PillItem c = item("ITEM-3", "아스피린정");
+        when(client.fetchPage(eq(1), anyInt())).thenReturn(new PillPage(3, List.of(a, b)));
+        when(client.fetchPage(eq(2), anyInt())).thenReturn(new PillPage(3, List.of(c)));
+
+        final SyncResult result = service.syncAll();
+
+        assertThat(result.upserted()).isEqualTo(3);
+        assertThat(result.totalCount()).isEqualTo(3);
+
+        final ArgumentCaptor<PillIdentification> captor = ArgumentCaptor.forClass(PillIdentification.class);
+        verify(repository, times(3)).save(captor.capture());
+        assertThat(captor.getAllValues()).extracting(PillIdentification::getItemSeq)
+                .containsExactly("ITEM-1", "ITEM-2", "ITEM-3");
+    }
+
+    @Test
+    @DisplayName("기존 row 있으면 update 경로 (save 미호출)")
+    void syncAll_existing_updates() {
+        final PillItem a = item("ITEM-1", "타이레놀정");
+        when(client.fetchPage(eq(1), anyInt())).thenReturn(new PillPage(1, List.of(a)));
+
+        final PillIdentification existing = pill("ITEM-1", "old name");
+        when(repository.findById("ITEM-1")).thenReturn(Optional.of(existing));
+
+        final SyncResult result = service.syncAll();
+
+        assertThat(result.upserted()).isEqualTo(1);
+        // save 호출 안 됨 — JPA dirty checking으로 update
+        verify(repository, times(0)).save(any());
+        assertThat(existing.getItemName()).isEqualTo("타이레놀정");
+    }
+
+    @Test
+    @DisplayName("itemSeq 또는 itemName이 null인 row는 skip")
+    void syncAll_skipsInvalid() {
+        final PillItem valid = item("ITEM-1", "정상");
+        final PillItem nullSeq = new PillItem(
+                null, "약명", null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null, null, null);
+        final PillItem nullName = new PillItem(
+                "ITEM-X", null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null, null, null);
+        // totalCount는 valid 1건 기준 — invalid skip 후 loop 종료 보장
+        when(client.fetchPage(eq(1), anyInt())).thenReturn(new PillPage(1, List.of(valid, nullSeq, nullName)));
+
+        final SyncResult result = service.syncAll();
+
+        assertThat(result.upserted()).isEqualTo(1);
+        verify(repository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("빈 페이지 응답이면 즉시 종료")
+    void syncAll_emptyPage_breaks() {
+        when(client.fetchPage(eq(1), anyInt())).thenReturn(new PillPage(0, List.of()));
+
+        final SyncResult result = service.syncAll();
+
+        assertThat(result.upserted()).isEqualTo(0);
+        verify(repository, times(0)).save(any());
+        verify(client, times(1)).fetchPage(anyInt(), anyInt());
+    }
+
+    private PillItem item(final String seq, final String name) {
+        return new PillItem(
+                seq, name, "업체", "T", null, "원형", "하양", null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null, null, null);
+    }
+
+    private PillIdentification pill(final String seq, final String name) {
+        return new PillIdentification(
+                seq, name, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null, null, null,
+                java.time.LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
## Summary
spec PR #239 (`docs/features/pill-identification.md`) §6 PR 2 범위. **prod 동작 무변** — 도구 등록·시스템 프롬프트는 PR 3로 분리.

- `pill_identifications` 테이블 + 4 indexes
- 식약처 OpenAPI client (`MdcinGrnIdntfcInfoClient`)
- Sync service + cron(SUN 02:00 KST) + 수동 endpoint(비공개)

## 변경 파일
- `medicine/PillIdentification.java` 신규 엔티티
- `medicine/repository/{PillIdentificationRepository,PillIdentificationSpecifications}.java`
- `common/mfds/MdcinGrnIdntfcInfoClient.java`
- `medicine/service/PillIdentificationSyncService.java` (idempotent upsert)
- `medicine/scheduler/PillIdentificationSyncScheduler.java`
- `medicine/controller/AdminPillSyncController.java` (비공개 endpoint)
- `PpiyakiApplication`에 `@EnableScheduling`
- `schema.sql` + `06-domain-model.md §5 pill_identifications` 등재
- `PillIdentificationSyncServiceTest` 4 케이스 + `MdcinGrnIdntfcInfoClientTest` 4 케이스

## prod 마이그레이션 (필수)
```sql
CREATE TABLE pill_identifications (
    item_seq VARCHAR(20) NOT NULL,
    item_name VARCHAR(255) NOT NULL,
    entp_name VARCHAR(255),
    print_front VARCHAR(64), print_back VARCHAR(64),
    drug_shape VARCHAR(32), color_class1 VARCHAR(32), color_class2 VARCHAR(32),
    line_front VARCHAR(32), line_back VARCHAR(32),
    leng_long VARCHAR(16), leng_short VARCHAR(16), thick VARCHAR(16),
    chart TEXT, item_image VARCHAR(512),
    class_no VARCHAR(16), class_name VARCHAR(128),
    etc_otc_name VARCHAR(32),
    mark_code_front VARCHAR(64), mark_code_back VARCHAR(64),
    edi_code VARCHAR(32), bizrno VARCHAR(32), change_date VARCHAR(20),
    synced_at DATETIME(6) NOT NULL,
    PRIMARY KEY (item_seq)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
CREATE INDEX idx_pill_print_front ON pill_identifications (print_front);
CREATE INDEX idx_pill_shape_color ON pill_identifications (drug_shape, color_class1);
CREATE INDEX idx_pill_color_shape_line ON pill_identifications (color_class1, drug_shape, line_front);
CREATE INDEX idx_pill_item_name ON pill_identifications (item_name);
```

## Test plan
- [ ] prod 마이그레이션 SQL 적용
- [ ] 머지 후 CD 배포
- [ ] PoC: 운영에서 `POST /api/v1/admin/pill-identifications/sync` 1회 호출 → 약 2~3만 건 적재 확인
  - 식약처 응답 시간 / numOfRows max(Q8) / MFDS_API_SERVICE_KEY로 동일 service group 호출 가능 여부(Q1) 함께 검증
- [ ] DB count 확인 (`SELECT COUNT(*) FROM pill_identifications`)
- [ ] 데이터 적재 후 PR 3(도구+프롬프트) 진행

## 비공개 endpoint 보호 노트
`AdminPillSyncController.POST /api/v1/admin/pill-identifications/sync`는 SecurityConfig permit 목록에 추가되지 않아 인증 사용자라면 호출 가능. admin role 인프라 도입 전까지 외부에 알리지 않을 것 (spec §3 §5-2).

## 후속 (PR 3 = `feat(chat)`)
- `PillIdentificationMcpTools.identifyPillByAppearance` 신설
- `ChatToolCallbackConfig` 등록
- `ChatSessionService.PHOTO_SYSTEM_PROMPT` 갱신 (외형 묘사 추출 + 도구 호출)
- E2E 보강

🤖 Generated with [Claude Code](https://claude.com/claude-code)