### PR TITLE
chore(chat): 알약 식별 도구 호출 INFO 로그 추가 — 운영 진단

### DIFF
--- a/src/main/java/com/ppiyaki/common/mcp/PillIdentificationMcpTools.java
+++ b/src/main/java/com/ppiyaki/common/mcp/PillIdentificationMcpTools.java
@@ -4,6 +4,8 @@ import com.ppiyaki.medicine.PillIdentification;
 import com.ppiyaki.medicine.repository.PillIdentificationRepository;
 import com.ppiyaki.medicine.repository.PillIdentificationSpecifications;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -22,6 +24,8 @@ import org.springframework.stereotype.Component;
 @Component
 @ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
 public class PillIdentificationMcpTools {
+
+    private static final Logger log = LoggerFactory.getLogger(PillIdentificationMcpTools.class);
 
     private static final int LIMIT = 10;
 
@@ -46,6 +50,8 @@ public class PillIdentificationMcpTools {
             @ToolParam(description = "Primary color (예: '하양', '노랑', '빨강', '파랑', '초록', '주황', '분홍', '자주', '갈색', '검정'). null if uncertain.") final String colorClass1,
             @ToolParam(description = "Front split line ('+형', '-형'). null if none.") final String lineFront
     ) {
+        log.info("identifyPillByAppearance called: printFront={} printBack={} drugShape={} colorClass1={} lineFront={}",
+                printFront, printBack, drugShape, colorClass1, lineFront);
         final Page<PillIdentification> page = repository.findAll(
                 PillIdentificationSpecifications.byAppearance(
                         printFront, printBack, drugShape, colorClass1, lineFront),
@@ -53,6 +59,8 @@ public class PillIdentificationMcpTools {
         );
         final List<PillCandidate> candidates = page.getContent().stream()
                 .map(PillCandidate::from).toList();
+        log.info("identifyPillByAppearance result: totalMatches={} candidatesReturned={}",
+                page.getTotalElements(), candidates.size());
         return new PillIdentifyResult(page.getTotalElements(), candidates);
     }
 


### PR DESCRIPTION
## AS-IS
v0.9.6 prod 검증 중 같은 사진 5회 호출에서 80% 응답이 "외형으로 일치하는 약을 찾지 못했어요" — 그러나 prod DB 직접 query 결과 흰색+타원형은 **2,176건**(흰색+장방형 1,866건). 즉 결과가 0건일 수 없는 외형인데도 0건 분기 응답이 나옴.

추정: LLM이 \`identifyPillByAppearance\` 도구 호출 자체를 skip하고 시스템 프롬프트의 "0건 분기" 응답을 hallucinate.

INFO 로그에 도구 호출 흔적이 없어 (도구 진입 로그 부재 + 자체 DB 쿼리는 SQL DEBUG 필요) **호출/skip 구분이 prod에서 불가능**.

## TO-BE
\`PillIdentificationMcpTools.identifyPillByAppearance\` 진입 시 INFO 로그:
- 입력: \`printFront / printBack / drugShape / colorClass1 / lineFront\`
- 결과: \`totalMatches / candidatesReturned\`

## 효과
- 운영에서 "도구 호출했는가" 즉시 확인 가능
- false-match 사고 발생 시 vision이 어떤 외형/각인을 추출했는지 trace
- 후속 PR (tool_choice 강제) 변경의 효과를 비교 측정 가능

## Test plan
- [x] \`./gradlew test\` 전체 통과
- [x] \`./gradlew checkstyleMain spotlessCheck\` 통과
- [ ] prod 머지 후 동일 사진 호출 → 도구 호출 흔적 INFO에 찍히는지 확인

## 보호 영역 변경 여부
없음.

## AI 보조 작성 여부
- [x] AI 보조

Refs #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 약품 식별 기능의 내부 모니터링 및 진단 기능이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->