### PR TITLE
feat(user): 보호자 온보딩 API 구현 — 닉네임 + 시니어 N명 + 알림 모드 (#248)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ docs/_import/
 
 ### Claude Code ###
 .claude/settings.local.json
+.mcp.json
 
 ### 환경변수 / 시크릿 ###
 .env

--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -108,6 +108,7 @@
 | breakfast_time | time nullable | 시니어 식사 시간대(아침). Java는 `LocalTime`. 미설정 가능. Phase 1: 클라이언트가 schedule 등록 시 활용. Phase 2~3: 슬롯 매핑/자동 생성 (별도 spec) |
 | lunch_time | time nullable | 시니어 식사 시간대(점심). 동일 |
 | dinner_time | time nullable | 시니어 식사 시간대(저녁). 동일 |
+| notification_mode | varchar nullable | 알림 프리셋. Java는 `NotificationMode` enum(`BASIC_ALERT`/`INTENSIVE_CARE`). 시니어에만 적용. 온보딩 시 설정, 이후 개별 조정 가능 |
 | created_at / updated_at | timestamp | `BaseTimeEntity` |
 
 > **코드 갭(현재 HEAD 기준)**: 코드의 `User.java`는 `nickname`, `gender`, `dob`가 없고 `pet` 대신 `ppiyaki bigint` 컬럼명을 사용하며 `password`가 non-null. 이 문서는 **타깃 스키마**를 기술하며, 코드 갱신은 별도 PR로 진행한다. 추적: §7-16.

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -1,0 +1,129 @@
+---
+feature: 보호자 온보딩 API
+slug: onboarding
+status: draft
+owner: @qkrehgus02
+scope: user
+related_issues: [248]
+related_prs: []
+last_reviewed: 2026-05-08
+---
+
+# 보호자 온보딩 API
+
+## 1) 개요 (What / Why)
+- 보호자 회원가입 후 온보딩 플로우(닉네임 입력 → 시니어 등록 → 알림 모드 선택)를 단일 API로 처리한다.
+- 프론트엔드 온보딩 화면과 1:1 매핑되는 API를 제공하여 클라이언트 호출을 최소화한다.
+- 현재 시니어 등록(`POST /api/v1/seniors`)은 존재하지만, 닉네임 변경 + 시니어 N명 + 알림 모드를 한 번에 처리하는 API가 없다.
+
+## 2) 사용자 시나리오
+1. 보호자가 카카오 또는 로컬 로그인으로 회원가입한다.
+2. 온보딩 화면에서 닉네임을 입력한다.
+3. 관리할 시니어의 이름과 성별(남/여/비공개)을 입력한다. 여러 명 추가 가능.
+4. 각 시니어에 대한 돌봄 모드를 선택한다.
+   - 기본 건강 알림: 복약 확인 알림 + 일간/월간 리포트
+   - 집중 안심: 복약 완료 즉시 알림 + 30분 지연 경고 + 일간/주간/월간 리포트
+5. 완료 버튼을 누르면 온보딩이 끝나고 메인 화면으로 이동한다.
+
+## 3) 요구사항
+### 기능 요구사항
+- [ ] 보호자 닉네임을 변경할 수 있다
+- [ ] 시니어를 1명 이상 등록할 수 있다 (이름, 성별 필수)
+- [ ] 성별은 MALE / FEMALE / UNKNOWN(비공개) 중 선택
+- [ ] 각 시니어마다 알림 모드(BASIC_ALERT / INTENSIVE_CARE)를 선택할 수 있다
+- [ ] 시니어 등록 시 User(SENIOR) + CareRelation + Pet이 자동 생성된다
+- [ ] 알림 모드는 시니어 엔티티에 저장된다 (이후 알림 설정에서 개별 조정 가능)
+- [ ] 온보딩은 단일 API(`POST /api/v1/onboarding`)로 처리된다
+
+### 비기능 요구사항
+- 시니어 등록 실패 시 전체 롤백 (트랜잭션 보장)
+
+## 4) 범위 / 비범위 (중요)
+### 포함
+- `POST /api/v1/onboarding` API
+- `NotificationMode` enum 신설
+- User 엔티티에 `notificationMode` 필드 추가
+- `User.createSenior()` 팩토리에 gender, notificationMode 반영
+- 단위 테스트 + E2E 테스트
+
+### 제외 (Out of Scope)
+- 알림 모드에 따른 실제 알림 발송 로직 (알림 기능 구현 시 연동)
+- 알림 설정 개별 조정 API
+- 온보딩 완료 여부 추적 (isOnboarded 플래그)
+
+## 5) 설계
+### 5-1) 도메인 모델
+- `NotificationMode` enum: `BASIC_ALERT` / `INTENSIVE_CARE`
+- `User` 엔티티에 `notificationMode` 필드 추가 (시니어에만 적용)
+- `User.createSenior()` 팩토리에 gender, notificationMode 파라미터 추가
+
+### 5-2) API 엔드포인트
+
+| Method | Path | 설명 | 인증 | Req | Res |
+|---|---|---|---|---|---|
+| POST | /api/v1/onboarding | 보호자 온보딩 완료 | 필수 (CAREGIVER) | `OnboardingRequest` | `OnboardingResponse` |
+
+### 5-3) 요청/응답 예시
+
+**Request:**
+```json
+{
+  "nickname": "보호자닉네임",
+  "seniors": [
+    {
+      "nickname": "할머니",
+      "gender": "FEMALE",
+      "notificationMode": "BASIC_ALERT"
+    },
+    {
+      "nickname": "할아버지",
+      "gender": "MALE",
+      "notificationMode": "INTENSIVE_CARE"
+    }
+  ]
+}
+```
+
+**Response (201):**
+```json
+{
+  "caregiverNickname": "보호자닉네임",
+  "seniors": [
+    {
+      "seniorId": 2,
+      "nickname": "할머니",
+      "petId": 1
+    },
+    {
+      "seniorId": 3,
+      "nickname": "할아버지",
+      "petId": 2
+    }
+  ]
+}
+```
+
+### 5-4) 데이터 흐름
+1. 보호자 인증 확인 (CAREGIVER role)
+2. 보호자 닉네임 업데이트
+3. 각 시니어에 대해:
+   - User(role=SENIOR, gender, notificationMode) 생성
+   - CareRelation 생성
+   - Pet 생성 + User에 연결
+4. 전체 결과 응답
+
+### 5-5) DB 마이그레이션
+- `users` 테이블에 `notification_mode` enum 컬럼 추가 (nullable, 시니어에만 사용)
+
+## 6) 작업 분할 (예상 PR 리스트)
+- [ ] PR 1: NotificationMode + 온보딩 API + 테스트
+
+## 7) 테스트 전략
+- OnboardingService 단위 테스트 (닉네임 변경 + 시니어 N명 생성)
+- E2E 테스트 (전체 온보딩 플로우)
+
+## 8) 오픈 질문
+없음 (모두 합의됨)
+
+## 9) 결정 로그
+- 2026-05-08: 초안 작성. 단일 API, 알림 모드는 프리셋(나중에 개별 조정 가능), 성별 비공개=UNKNOWN.

--- a/src/main/java/com/ppiyaki/user/NotificationMode.java
+++ b/src/main/java/com/ppiyaki/user/NotificationMode.java
@@ -1,0 +1,6 @@
+package com.ppiyaki.user;
+
+public enum NotificationMode {
+    BASIC_ALERT,
+    INTENSIVE_CARE
+}

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -101,6 +101,9 @@ public class User extends BaseTimeEntity {
             final Gender gender,
             final NotificationMode notificationMode
     ) {
+        Objects.requireNonNull(nickname, "nickname must not be null");
+        Objects.requireNonNull(gender, "gender must not be null");
+        Objects.requireNonNull(notificationMode, "notificationMode must not be null");
         final User user = new User(null, null, UserRole.SENIOR, AuthProvider.INVITE_ONLY,
                 nickname, gender, null, null);
         user.notificationMode = notificationMode;

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -57,6 +57,10 @@ public class User extends BaseTimeEntity {
     @Column(name = "care_mode", nullable = false)
     private CareMode careMode;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_mode")
+    private NotificationMode notificationMode;
+
     @Column(name = "breakfast_time")
     private LocalTime breakfastTime;
 
@@ -90,6 +94,21 @@ public class User extends BaseTimeEntity {
     public static User createSenior(final String nickname, final LocalDate dob) {
         return new User(null, null, UserRole.SENIOR, AuthProvider.INVITE_ONLY,
                 nickname, null, dob, null);
+    }
+
+    public static User createSenior(
+            final String nickname,
+            final Gender gender,
+            final NotificationMode notificationMode
+    ) {
+        final User user = new User(null, null, UserRole.SENIOR, AuthProvider.INVITE_ONLY,
+                nickname, gender, null, null);
+        user.notificationMode = notificationMode;
+        return user;
+    }
+
+    public void updateNickname(final String nickname) {
+        this.nickname = Objects.requireNonNull(nickname, "nickname must not be null");
     }
 
     public void assignPet(final Long petId) {

--- a/src/main/java/com/ppiyaki/user/controller/OnboardingController.java
+++ b/src/main/java/com/ppiyaki/user/controller/OnboardingController.java
@@ -1,0 +1,33 @@
+package com.ppiyaki.user.controller;
+
+import com.ppiyaki.user.controller.dto.OnboardingRequest;
+import com.ppiyaki.user.controller.dto.OnboardingResponse;
+import com.ppiyaki.user.service.OnboardingService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class OnboardingController {
+
+    private final OnboardingService onboardingService;
+
+    public OnboardingController(final OnboardingService onboardingService) {
+        this.onboardingService = onboardingService;
+    }
+
+    @PostMapping("/onboarding")
+    public ResponseEntity<OnboardingResponse> onboard(
+            @AuthenticationPrincipal final Long userId,
+            @Valid @RequestBody final OnboardingRequest onboardingRequest
+    ) {
+        final OnboardingResponse onboardingResponse = onboardingService.onboard(userId, onboardingRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(onboardingResponse);
+    }
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/OnboardingRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/OnboardingRequest.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public record OnboardingRequest(
         @NotBlank String nickname,
-        @NotEmpty @Valid List<SeniorEntry> seniors
+        @Valid @NotEmpty List<SeniorEntry> seniors
 ) {
 
     public record SeniorEntry(

--- a/src/main/java/com/ppiyaki/user/controller/dto/OnboardingRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/OnboardingRequest.java
@@ -1,0 +1,22 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.ppiyaki.user.Gender;
+import com.ppiyaki.user.NotificationMode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record OnboardingRequest(
+        @NotBlank String nickname,
+        @NotEmpty @Valid List<SeniorEntry> seniors
+) {
+
+    public record SeniorEntry(
+            @NotBlank String nickname,
+            @NotNull Gender gender,
+            @NotNull NotificationMode notificationMode
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/user/controller/dto/OnboardingResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/OnboardingResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public record OnboardingResponse(
         String caregiverNickname,
-        List<SeniorResult> seniors
+        List<SeniorResult> responses
 ) {
 
     public record SeniorResult(

--- a/src/main/java/com/ppiyaki/user/controller/dto/OnboardingResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/OnboardingResponse.java
@@ -1,0 +1,16 @@
+package com.ppiyaki.user.controller.dto;
+
+import java.util.List;
+
+public record OnboardingResponse(
+        String caregiverNickname,
+        List<SeniorResult> seniors
+) {
+
+    public record SeniorResult(
+            Long seniorId,
+            String nickname,
+            Long petId
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/user/service/OnboardingService.java
+++ b/src/main/java/com/ppiyaki/user/service/OnboardingService.java
@@ -1,0 +1,64 @@
+package com.ppiyaki.user.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.pet.Pet;
+import com.ppiyaki.pet.repository.PetRepository;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
+import com.ppiyaki.user.controller.dto.OnboardingRequest;
+import com.ppiyaki.user.controller.dto.OnboardingResponse;
+import com.ppiyaki.user.controller.dto.OnboardingResponse.SeniorResult;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OnboardingService {
+
+    private final UserRepository userRepository;
+    private final CareRelationRepository careRelationRepository;
+    private final PetRepository petRepository;
+
+    public OnboardingService(
+            final UserRepository userRepository,
+            final CareRelationRepository careRelationRepository,
+            final PetRepository petRepository
+    ) {
+        this.userRepository = userRepository;
+        this.careRelationRepository = careRelationRepository;
+        this.petRepository = petRepository;
+    }
+
+    @Transactional
+    public OnboardingResponse onboard(final Long caregiverId, final OnboardingRequest onboardingRequest) {
+        final User caregiver = userRepository.findById(caregiverId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (caregiver.getRole() != UserRole.CAREGIVER) {
+            throw new BusinessException(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
+        }
+
+        caregiver.updateNickname(onboardingRequest.nickname());
+
+        final List<SeniorResult> seniorResults = new ArrayList<>();
+
+        for (final OnboardingRequest.SeniorEntry seniorEntry : onboardingRequest.seniors()) {
+            final User senior = userRepository.save(
+                    User.createSenior(seniorEntry.nickname(), seniorEntry.gender(), seniorEntry.notificationMode()));
+
+            final Pet pet = petRepository.save(Pet.create());
+            senior.assignPet(pet.getId());
+
+            careRelationRepository.save(CareRelation.createLinked(senior.getId(), caregiverId));
+
+            seniorResults.add(new SeniorResult(senior.getId(), senior.getNickname(), pet.getId()));
+        }
+
+        return new OnboardingResponse(caregiver.getNickname(), seniorResults);
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -200,6 +200,7 @@
         auth_provider enum ('INVITE_ONLY','KAKAO','LOCAL') not null,
         care_mode enum ('AUTONOMOUS','MANAGED') not null,
         gender enum ('FEMALE','MALE','OTHER','UNKNOWN'),
+        notification_mode enum ('BASIC_ALERT','INTENSIVE_CARE'),
         role enum ('CAREGIVER','SENIOR'),
         primary key (id)
     ) engine=InnoDB;

--- a/src/test/java/com/ppiyaki/user/controller/OnboardingControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/OnboardingControllerE2ETest.java
@@ -82,12 +82,12 @@ class OnboardingControllerE2ETest {
                 .then()
                 .statusCode(201)
                 .body("caregiverNickname", is("보호자온보딩"))
-                .body("seniors", hasSize(2))
-                .body("seniors[0].nickname", is("온보딩할머니"))
-                .body("seniors[0].seniorId", notNullValue())
-                .body("seniors[0].petId", notNullValue())
-                .body("seniors[1].nickname", is("온보딩할아버지"))
-                .body("seniors[1].seniorId", notNullValue())
-                .body("seniors[1].petId", notNullValue());
+                .body("responses", hasSize(2))
+                .body("responses[0].nickname", is("온보딩할머니"))
+                .body("responses[0].seniorId", notNullValue())
+                .body("responses[0].petId", notNullValue())
+                .body("responses[1].nickname", is("온보딩할아버지"))
+                .body("responses[1].seniorId", notNullValue())
+                .body("responses[1].petId", notNullValue());
     }
 }

--- a/src/test/java/com/ppiyaki/user/controller/OnboardingControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/OnboardingControllerE2ETest.java
@@ -1,0 +1,93 @@
+package com.ppiyaki.user.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class OnboardingControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        jdbcTemplate.update("DELETE FROM care_relations WHERE caregiver_id IN "
+                + "(SELECT id FROM users WHERE login_id = 'onboard_e2e')");
+        jdbcTemplate.update("DELETE FROM pets WHERE id IN "
+                + "(SELECT pet FROM users WHERE nickname IN ('온보딩할머니', '온보딩할아버지') AND pet IS NOT NULL)");
+        jdbcTemplate.update("DELETE FROM refresh_tokens WHERE user_id IN "
+                + "(SELECT id FROM users WHERE login_id = 'onboard_e2e')");
+        jdbcTemplate.update("DELETE FROM users WHERE nickname IN ('온보딩할머니', '온보딩할아버지')");
+        jdbcTemplate.update("DELETE FROM users WHERE login_id = 'onboard_e2e'");
+    }
+
+    @Test
+    @DisplayName("보호자 온보딩 시 닉네임 변경 + 시니어 2명 생성된다")
+    void onboard_success() {
+        // given — 보호자 회원가입
+        final String accessToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "onboard_e2e",
+                            "password": "pass1234!",
+                            "nickname": "임시닉네임"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("accessToken");
+
+        // when — 온보딩
+        RestAssured.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "nickname": "보호자온보딩",
+                            "seniors": [
+                                {
+                                    "nickname": "온보딩할머니",
+                                    "gender": "FEMALE",
+                                    "notificationMode": "BASIC_ALERT"
+                                },
+                                {
+                                    "nickname": "온보딩할아버지",
+                                    "gender": "MALE",
+                                    "notificationMode": "INTENSIVE_CARE"
+                                }
+                            ]
+                        }
+                        """)
+                .when()
+                .post("/api/v1/onboarding")
+                .then()
+                .statusCode(201)
+                .body("caregiverNickname", is("보호자온보딩"))
+                .body("seniors", hasSize(2))
+                .body("seniors[0].nickname", is("온보딩할머니"))
+                .body("seniors[0].seniorId", notNullValue())
+                .body("seniors[0].petId", notNullValue())
+                .body("seniors[1].nickname", is("온보딩할아버지"))
+                .body("seniors[1].seniorId", notNullValue())
+                .body("seniors[1].petId", notNullValue());
+    }
+}

--- a/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
@@ -85,9 +85,9 @@ class OnboardingServiceTest {
 
         // then
         assertThat(response.caregiverNickname()).isEqualTo("보호자닉네임");
-        assertThat(response.seniors()).hasSize(2);
-        assertThat(response.seniors().get(0).nickname()).isEqualTo("할머니");
-        assertThat(response.seniors().get(1).nickname()).isEqualTo("할아버지");
+        assertThat(response.responses()).hasSize(2);
+        assertThat(response.responses().get(0).nickname()).isEqualTo("할머니");
+        assertThat(response.responses().get(1).nickname()).isEqualTo("할아버지");
     }
 
     @Test
@@ -107,8 +107,8 @@ class OnboardingServiceTest {
         assertThatThrownBy(() -> onboardingService.onboard(1L, onboardingRequest))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(exception -> {
-                    final BusinessException be = (BusinessException) exception;
-                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
+                    final BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
                 });
     }
 }

--- a/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
@@ -1,0 +1,114 @@
+package com.ppiyaki.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.pet.Pet;
+import com.ppiyaki.pet.repository.PetRepository;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.Gender;
+import com.ppiyaki.user.NotificationMode;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
+import com.ppiyaki.user.controller.dto.OnboardingRequest;
+import com.ppiyaki.user.controller.dto.OnboardingRequest.SeniorEntry;
+import com.ppiyaki.user.controller.dto.OnboardingResponse;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OnboardingServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CareRelationRepository careRelationRepository;
+
+    @Mock
+    private PetRepository petRepository;
+
+    @InjectMocks
+    private OnboardingService onboardingService;
+
+    @Test
+    @DisplayName("온보딩 시 보호자 닉네임 변경 + 시니어 N명 생성된다")
+    void onboard_success() {
+        // given
+        final User caregiver = mock(User.class);
+        given(caregiver.getRole()).willReturn(UserRole.CAREGIVER);
+        given(caregiver.getNickname()).willReturn("보호자닉네임");
+        given(userRepository.findById(1L)).willReturn(Optional.of(caregiver));
+
+        final User senior1 = mock(User.class);
+        given(senior1.getId()).willReturn(2L);
+        given(senior1.getNickname()).willReturn("할머니");
+
+        final User senior2 = mock(User.class);
+        given(senior2.getId()).willReturn(3L);
+        given(senior2.getNickname()).willReturn("할아버지");
+
+        given(userRepository.save(any(User.class))).willReturn(senior1, senior2);
+
+        final Pet pet1 = mock(Pet.class);
+        given(pet1.getId()).willReturn(1L);
+        final Pet pet2 = mock(Pet.class);
+        given(pet2.getId()).willReturn(2L);
+        given(petRepository.save(any(Pet.class))).willReturn(pet1, pet2);
+
+        given(careRelationRepository.save(any(CareRelation.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        final OnboardingRequest onboardingRequest = new OnboardingRequest(
+                "보호자닉네임",
+                List.of(
+                        new SeniorEntry("할머니", Gender.FEMALE, NotificationMode.BASIC_ALERT),
+                        new SeniorEntry("할아버지", Gender.MALE, NotificationMode.INTENSIVE_CARE)
+                )
+        );
+
+        // when
+        final OnboardingResponse response = onboardingService.onboard(1L, onboardingRequest);
+
+        // then
+        assertThat(response.caregiverNickname()).isEqualTo("보호자닉네임");
+        assertThat(response.seniors()).hasSize(2);
+        assertThat(response.seniors().get(0).nickname()).isEqualTo("할머니");
+        assertThat(response.seniors().get(1).nickname()).isEqualTo("할아버지");
+    }
+
+    @Test
+    @DisplayName("시니어가 온보딩을 시도하면 ROLE_MISMATCH 에러가 발생한다")
+    void onboard_bySenior_throwsRoleMismatch() {
+        // given
+        final User senior = mock(User.class);
+        given(senior.getRole()).willReturn(UserRole.SENIOR);
+        given(userRepository.findById(1L)).willReturn(Optional.of(senior));
+
+        final OnboardingRequest onboardingRequest = new OnboardingRequest(
+                "닉네임",
+                List.of(new SeniorEntry("할머니", Gender.FEMALE, NotificationMode.BASIC_ALERT))
+        );
+
+        // when & then
+        assertThatThrownBy(() -> onboardingService.onboard(1L, onboardingRequest))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    final BusinessException be = (BusinessException) exception;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
+                });
+    }
+}


### PR DESCRIPTION
                                                             
  ## AS-IS                                                                   
  - 보호자 온보딩을 단일 API로 처리할 수 없음                                
  - 시니어 등록 시 알림 모드(돌봄 모드)를 설정할 수 없음                     
                                                                             
  ## TO-BE                                                                 
  - `POST /api/v1/onboarding` 단일 API로 보호자 온보딩 전체 플로우 처리    
    - 보호자 닉네임 변경                                                     
    - 시니어 N명 등록 (이름, 성별, 알림 모드)                                
    - 각 시니어마다 User(SENIOR) + CareRelation + Pet 자동 생성              
  - `NotificationMode` enum 신설 (BASIC_ALERT / INTENSIVE_CARE)              
    - 기본 건강 알림: 복약 확인 알림 + 일간/월간 리포트                      
    - 집중 안심: 복약 완료 즉시 알림 + 30분 지연 경고 + 일간/주간/월간 리포트
    - 이후 알림 설정에서 개별 조정 가능 (알림 기능 구현 시 연동)             
                                                                             
  ## 변경 사항                                                               
  - `NotificationMode` enum 신설                                             
  - `User` — `notificationMode` 필드 추가, `createSenior(nickname, gender,   
  notificationMode)` 오버로드, `updateNickname()` 추가                       
  - `OnboardingService` / `OnboardingController` / DTO 신설                  
  - `schema.sql` — users에 `notification_mode` enum 컬럼 추가                
                                                                             
  ## 테스트                                                                  
  - OnboardingServiceTest 단위 테스트 2개 (성공, 시니어 role 거부)         
  - OnboardingControllerE2ETest E2E 1개 (전체 플로우: 가입 → 온보딩 → 시니어 
  2명 생성)                                                                 
                                                                             
  ## 참고                                                   
  - closes #248                                                              
  - 참고: docs/features/onboarding.md                                        
                                                                             
  ## AI Agent 전용 체크리스트                                                
  - [x] 코드 컨벤션 준수 (final, 어노테이션 순서, 풀네임 변수)             
  - [x] 테스트 작성 (서비스 단위 + E2E)                                    
  - [x] 도메인 문서 갱신 (다음 커밋에서 수행)                                
  - [x] 품질 게이트 통과 (checkstyleMain, spotlessCheck, test)     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 보호자 온보딩: 보호자가 별칭을 설정하고 여러 피보호자를 한 번에 등록할 수 있는 새로운 기능이 추가되었습니다.
  * 알림 설정: 각 피보호자마다 '기본 알림' 또는 '집중 케어' 중 알림 모드를 선택할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->