### PR TITLE
fix(infra): 운영 timezone Asia/Seoul 통일 — UTC 9h 어긋남 해소

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -61,6 +61,7 @@ jobs:
               --name ppiyaki-server \
               -p 8080:8080 \
               --restart always \
+              -e TZ='Asia/Seoul' \
               -e SPRING_PROFILES_ACTIVE=prod \
               -e DB_URL='${{ secrets.DB_URL }}' \
               -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,8 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:default}
   reactor:
     context-propagation: auto
+  jackson:
+    time-zone: Asia/Seoul
   ai:
     openai:
       api-key: ${OPENAI_API_KEY:sk-placeholder}
@@ -35,6 +37,8 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
+        jdbc:
+          time_zone: Asia/Seoul
 
 jwt:
   secret: ${JWT_SECRET:local-dev-secret-key-must-be-at-least-32-bytes-long}


### PR DESCRIPTION
## AS-IS
프론트에서 알림이 미국 시간으로 보인다는 제보. 진단:

\`\`\`
$ ssh ubuntu@prod 'sudo docker exec ppiyaki-server date'
Fri May  8 12:28:29 PM UTC 2026

$ date  # host
Fri May  8 21:28:29 KST 2026
\`\`\`

prod 컨테이너 TZ 미명시 → UTC로 동작. backend의 \`LocalDateTime.now()\`가 UTC로 생성 → DB는 KST지만 LocalDateTime은 timezone-naive이므로 UTC value 그대로 저장. **알림/log/응답 timestamp가 9h 이른 값**.

prod DB 점검:
- \`prescriptions.created_at\` 최신 \`2026-05-08 10:15:25\` (현 KST 21:39 시점) → 9h 어긋남 확인
- \`medication_logs\` / \`medication_reminders\` row 0 — **지금이 fix 적기**

## TO-BE
1. \`application.yml\`
   - \`spring.jackson.time-zone: Asia/Seoul\` (JSON 직렬화)
   - \`spring.jpa.properties.hibernate.jdbc.time_zone: Asia/Seoul\` (JPA timestamp 변환)
2. \`backend-cd.yml\` docker run에 \`-e TZ='Asia/Seoul'\` 추가 (컨테이너 system clock)

eclipse-temurin:21-jre는 tzdata 기본 포함이라 Dockerfile 변경 불필요.

## 효과
- \`LocalDateTime.now()\` → KST
- @Scheduled cron(이미 zone="Asia/Seoul")과 비즈니스 로직 시각이 일관
- 알림/medication_log/JSON 응답 timestamp 모두 KST

## 마이그레이션
prescriptions row 1건은 검증 dummy라 그냥 두거나 +9h UPDATE. medication_logs/reminders는 NULL이라 영향 없음.

## Test plan
- [x] \`./gradlew checkstyleMain spotlessCheck test\` 통과
- [ ] **머지 후 prod 검증**: 새 medication_log/prescription 생성 시 \`created_at\`이 KST로 저장되는지 확인. \`docker exec ppiyaki-server date\`도 KST 반환 확인.

## 보호 영역 변경
- \`.github/workflows/backend-cd.yml\` (보호)
- \`application.yml\` (보호)
- → \`needs-human-review\` 라벨 부여

## AI 보조 작성 여부
- [x] AI 보조

Refs #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)