### PR TITLE
fix(chat): 알약 식별 도구 INFO 로그 인자를 새 시그니처에 맞게 수정 — develop hotfix

### DIFF
--- a/src/main/java/com/ppiyaki/common/mcp/PillIdentificationMcpTools.java
+++ b/src/main/java/com/ppiyaki/common/mcp/PillIdentificationMcpTools.java
@@ -53,8 +53,8 @@ public class PillIdentificationMcpTools {
             @ToolParam(description = "Back imprint. null if not visible.") final String printBack,
             @ToolParam(description = "Primary color (예: '하양', '노랑', '빨강', '파랑', '초록', '주황', '분홍', '자주', '갈색', '검정'). null if uncertain.") final String colorClass1
     ) {
-        log.info("identifyPillByAppearance called: printFront={} printBack={} drugShape={} colorClass1={} lineFront={}",
-                printFront, printBack, drugShape, colorClass1, lineFront);
+        log.info("identifyPillByAppearance called: printFront={} printBack={} colorClass1={}",
+                printFront, printBack, colorClass1);
         final Page<PillIdentification> page = repository.findAll(
                 PillIdentificationSpecifications.byAppearance(printFront, printBack, colorClass1),
                 PageRequest.of(0, LIMIT)


### PR DESCRIPTION
## AS-IS — develop 컴파일 에러
PR #247(INFO 로그 추가)과 PR #252(drugShape/lineFront 시그니처 제거)를 순차 squash merge한 결과, GitHub 자동 3-way merge가 시그니처는 새 버전(파라미터 3개) + log.info 인자는 옛 버전(\`drugShape\`/\`lineFront\` 참조)으로 합쳐져 develop이 컴파일 안 되는 상태.

\`\`\`
PillIdentificationMcpTools.java:57: error: cannot find symbol
        log.info(..., printFront, printBack, drugShape, colorClass1, lineFront);
                                             ^
  symbol:   variable drugShape
\`\`\`

## TO-BE
\`log.info\` 인자에서 drugShape/lineFront 제거. 메시지도 새 시그니처에 맞게 축소.

## 학습
서로 다른 PR이 같은 메서드의 별개 부분을 변경할 때 GitHub mergeability check는 줄 단위 conflict만 봐서 의미적 conflict를 놓칠 수 있음. 향후 동일 파일 변경 PR이 동시에 떠 있으면 한쪽 머지 후 나머지 PR을 rebase해서 컴파일 검증을 거쳐야 안전.

## Test plan
- [x] \`./gradlew checkstyleMain spotlessCheck test\` 통과
- [ ] develop 머지 후 CI 재확인

## 보호 영역 변경 여부
없음.

## AI 보조 작성 여부
- [x] AI 보조

Refs #251 #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)