### PR TITLE
fix(prescription): 처방전 상세 응답 maskedImageUrl full URL — medication_log 패턴

### DIFF
--- a/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionDetailResponse.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionDetailResponse.java
@@ -9,7 +9,7 @@ public record PrescriptionDetailResponse(
         Long id,
         Long ownerId,
         String status,
-        String maskedImageObjectKey,
+        String maskedImageUrl,
         String failureReason,
         List<PrescriptionMedicineCandidateResponse> candidates,
         LocalDateTime createdAt
@@ -17,13 +17,14 @@ public record PrescriptionDetailResponse(
 
     public static PrescriptionDetailResponse from(
             final Prescription prescription,
-            final List<PrescriptionMedicineCandidate> candidates
+            final List<PrescriptionMedicineCandidate> candidates,
+            final String maskedImageUrl
     ) {
         return new PrescriptionDetailResponse(
                 prescription.getId(),
                 prescription.getOwnerId(),
                 prescription.getStatus().name(),
-                prescription.getMaskedImageObjectKey(),
+                maskedImageUrl,
                 prescription.getFailureReason(),
                 candidates.stream()
                         .map(PrescriptionMedicineCandidateResponse::from)

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -8,6 +8,7 @@ import com.ppiyaki.common.ocr.ClovaOcrClient;
 import com.ppiyaki.common.ocr.ClovaOcrClient.OcrResult;
 import com.ppiyaki.common.ocr.ClovaOcrClient.OcrToken;
 import com.ppiyaki.common.storage.NcpStorageProperties;
+import com.ppiyaki.common.storage.PhotoUrlAssembler;
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
@@ -73,6 +74,7 @@ public class PrescriptionService {
     private final ImageOrientationCorrector orientationCorrector;
     private final NcpStorageProperties storageProperties;
     private final S3Client s3Client;
+    private final PhotoUrlAssembler photoUrlAssembler;
 
     public PrescriptionService(
             final PrescriptionRepository prescriptionRepository,
@@ -87,7 +89,8 @@ public class PrescriptionService {
             final PiiMaskingService piiMaskingService,
             final ImageOrientationCorrector orientationCorrector,
             final NcpStorageProperties storageProperties,
-            final S3Client s3Client
+            final S3Client s3Client,
+            final PhotoUrlAssembler photoUrlAssembler
     ) {
         this.prescriptionRepository = prescriptionRepository;
         this.candidateRepository = candidateRepository;
@@ -102,6 +105,7 @@ public class PrescriptionService {
         this.orientationCorrector = orientationCorrector;
         this.storageProperties = storageProperties;
         this.s3Client = s3Client;
+        this.photoUrlAssembler = photoUrlAssembler;
     }
 
     @Transactional
@@ -159,7 +163,8 @@ public class PrescriptionService {
 
             final List<PrescriptionMedicineCandidate> candidates = candidateRepository.findByPrescriptionId(prescription
                     .getId());
-            return PrescriptionDetailResponse.from(prescription, candidates);
+            return PrescriptionDetailResponse.from(prescription, candidates, photoUrlAssembler.toFullUrl(prescription
+                    .getMaskedImageObjectKey()));
 
         } catch (final Exception e) {
             log.error("Prescription processing failed: prescriptionId={}", prescription.getId(), e);
@@ -173,7 +178,8 @@ public class PrescriptionService {
         final Prescription prescription = findPrescription(prescriptionId);
         validateReadAccess(userId, prescription);
         final List<PrescriptionMedicineCandidate> candidates = candidateRepository.findByPrescriptionId(prescriptionId);
-        return PrescriptionDetailResponse.from(prescription, candidates);
+        return PrescriptionDetailResponse.from(prescription, candidates, photoUrlAssembler.toFullUrl(prescription
+                .getMaskedImageObjectKey()));
     }
 
     @Transactional(readOnly = true)
@@ -245,7 +251,8 @@ public class PrescriptionService {
         ));
 
         final List<PrescriptionMedicineCandidate> candidates = candidateRepository.findByPrescriptionId(prescriptionId);
-        return PrescriptionDetailResponse.from(prescription, candidates);
+        return PrescriptionDetailResponse.from(prescription, candidates, photoUrlAssembler.toFullUrl(prescription
+                .getMaskedImageObjectKey()));
     }
 
     @Transactional
@@ -313,7 +320,8 @@ public class PrescriptionService {
         }
 
         prescription.confirm();
-        return PrescriptionDetailResponse.from(prescription, candidates);
+        return PrescriptionDetailResponse.from(prescription, candidates, photoUrlAssembler.toFullUrl(prescription
+                .getMaskedImageObjectKey()));
     }
 
     private boolean isAcceptedOrCorrected(final PrescriptionMedicineCandidate candidate) {

--- a/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
+++ b/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
@@ -73,6 +73,8 @@ class PrescriptionServiceManualAddTest {
     private NcpStorageProperties storageProperties;
     @Mock
     private S3Client s3Client;
+    @Mock
+    private com.ppiyaki.common.storage.PhotoUrlAssembler photoUrlAssembler;
 
     @InjectMocks
     private PrescriptionService prescriptionService;

--- a/src/test/java/com/ppiyaki/prescription/service/PrescriptionServicePermissionTest.java
+++ b/src/test/java/com/ppiyaki/prescription/service/PrescriptionServicePermissionTest.java
@@ -67,6 +67,8 @@ class PrescriptionServicePermissionTest {
     private NcpStorageProperties storageProperties;
     @Mock
     private S3Client s3Client;
+    @Mock
+    private com.ppiyaki.common.storage.PhotoUrlAssembler photoUrlAssembler;
 
     @InjectMocks
     private PrescriptionService prescriptionService;


### PR DESCRIPTION
## AS-IS
\`PrescriptionDetailResponse.maskedImageObjectKey\` — S3 raw object key만 내려주어 프론트가 직접 표시 못 함. medication_log는 \`photoUrl\` full URL을 \`PhotoUrlAssembler.toFullUrl(...)\`로 만들어 응답하는 일관 패턴 있음.

## TO-BE
- 응답 필드명 \`maskedImageObjectKey\` → \`maskedImageUrl\`
- 서비스에서 \`PhotoUrlAssembler.toFullUrl(...)\`로 채움
- medication_log 패턴과 동일

## 영향
- 프론트 응답 필드명 변경 — 사용처 모두 \`maskedImageUrl\`로 갱신 필요
- Notion API 명세 갱신 (응답 필드 변경)

## Test plan
- [x] \`./gradlew checkstyleMain spotlessCheck test\` 통과
- [x] PrescriptionService 단위 테스트 (PhotoUrlAssembler mock 추가)

## 보호 영역 변경 여부
없음.

## AI 보조 작성 여부
- [x] AI 보조

Refs #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)