### PR TITLE
release: v0.9.8

### DIFF
--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -91,13 +91,16 @@ public class MedicationLogService {
 
         final LocalDateTime takenAt = request.takenAt() != null ? request.takenAt() : LocalDateTime.now();
 
+        final Optional<MedicationLog> existing = medicationLogRepository
+                .findByScheduleIdAndTargetDate(request.scheduleId(), request.targetDate());
+        final LogStatus previousStatus = existing.map(MedicationLog::getStatus).orElse(null);
+
         final MedicationLog log;
         try {
-            log = medicationLogRepository
-                    .findByScheduleIdAndTargetDate(request.scheduleId(), request.targetDate())
-                    .map(existing -> {
-                        existing.updateRecord(takenAt, request.status(), request.photoObjectKey(), isProxy, userId);
-                        return existing;
+            log = existing
+                    .map(found -> {
+                        found.updateRecord(takenAt, request.status(), request.photoObjectKey(), isProxy, userId);
+                        return found;
                     })
                     .orElseGet(() -> medicationLogRepository.saveAndFlush(new MedicationLog(
                             seniorId, request.scheduleId(), request.targetDate(),
@@ -108,6 +111,11 @@ public class MedicationLogService {
             // 클라이언트가 재시도하면 다음 트랜잭션에서 정상 update 경로로 진입한다 (spec §5-2 멱등 보장).
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
                     "Concurrent upsert conflict on (scheduleId, targetDate); please retry");
+        }
+
+        // 새로 TAKEN으로 전환되는 케이스에만 잔여분 차감 (멱등성: 이미 TAKEN이던 row 재호출 시 중복 차감 방지).
+        if (request.status() == LogStatus.TAKEN && previousStatus != LogStatus.TAKEN) {
+            medicine.decreaseRemainingAmount();
         }
 
         // Phase 2: 사진 + status=TAKEN일 때 약 개수 AI 검증 (spec medication-log-phase2 §5-4)

--- a/src/main/java/com/ppiyaki/medicine/Medicine.java
+++ b/src/main/java/com/ppiyaki/medicine/Medicine.java
@@ -84,4 +84,14 @@ public class Medicine extends CreatedTimeEntity {
             this.durWarningText = durWarningText;
         }
     }
+
+    /**
+     * 복약 인증(TAKEN) 시점에 호출되어 잔여분을 1 차감한다.
+     * remainingAmount가 null이거나 0 이하면 변경 없음 (음수 방지).
+     */
+    public void decreaseRemainingAmount() {
+        if (remainingAmount != null && remainingAmount > 0) {
+            this.remainingAmount = remainingAmount - 1;
+        }
+    }
 }

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionDetailResponse.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionDetailResponse.java
@@ -9,7 +9,7 @@ public record PrescriptionDetailResponse(
         Long id,
         Long ownerId,
         String status,
-        String maskedImageObjectKey,
+        String maskedImageUrl,
         String failureReason,
         List<PrescriptionMedicineCandidateResponse> candidates,
         LocalDateTime createdAt
@@ -17,13 +17,14 @@ public record PrescriptionDetailResponse(
 
     public static PrescriptionDetailResponse from(
             final Prescription prescription,
-            final List<PrescriptionMedicineCandidate> candidates
+            final List<PrescriptionMedicineCandidate> candidates,
+            final String maskedImageUrl
     ) {
         return new PrescriptionDetailResponse(
                 prescription.getId(),
                 prescription.getOwnerId(),
                 prescription.getStatus().name(),
-                prescription.getMaskedImageObjectKey(),
+                maskedImageUrl,
                 prescription.getFailureReason(),
                 candidates.stream()
                         .map(PrescriptionMedicineCandidateResponse::from)

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -8,6 +8,7 @@ import com.ppiyaki.common.ocr.ClovaOcrClient;
 import com.ppiyaki.common.ocr.ClovaOcrClient.OcrResult;
 import com.ppiyaki.common.ocr.ClovaOcrClient.OcrToken;
 import com.ppiyaki.common.storage.NcpStorageProperties;
+import com.ppiyaki.common.storage.PhotoUrlAssembler;
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
@@ -73,6 +74,7 @@ public class PrescriptionService {
     private final ImageOrientationCorrector orientationCorrector;
     private final NcpStorageProperties storageProperties;
     private final S3Client s3Client;
+    private final PhotoUrlAssembler photoUrlAssembler;
 
     public PrescriptionService(
             final PrescriptionRepository prescriptionRepository,
@@ -87,7 +89,8 @@ public class PrescriptionService {
             final PiiMaskingService piiMaskingService,
             final ImageOrientationCorrector orientationCorrector,
             final NcpStorageProperties storageProperties,
-            final S3Client s3Client
+            final S3Client s3Client,
+            final PhotoUrlAssembler photoUrlAssembler
     ) {
         this.prescriptionRepository = prescriptionRepository;
         this.candidateRepository = candidateRepository;
@@ -102,6 +105,7 @@ public class PrescriptionService {
         this.orientationCorrector = orientationCorrector;
         this.storageProperties = storageProperties;
         this.s3Client = s3Client;
+        this.photoUrlAssembler = photoUrlAssembler;
     }
 
     @Transactional
@@ -159,7 +163,8 @@ public class PrescriptionService {
 
             final List<PrescriptionMedicineCandidate> candidates = candidateRepository.findByPrescriptionId(prescription
                     .getId());
-            return PrescriptionDetailResponse.from(prescription, candidates);
+            return PrescriptionDetailResponse.from(prescription, candidates, photoUrlAssembler.toFullUrl(prescription
+                    .getMaskedImageObjectKey()));
 
         } catch (final Exception e) {
             log.error("Prescription processing failed: prescriptionId={}", prescription.getId(), e);
@@ -173,7 +178,8 @@ public class PrescriptionService {
         final Prescription prescription = findPrescription(prescriptionId);
         validateReadAccess(userId, prescription);
         final List<PrescriptionMedicineCandidate> candidates = candidateRepository.findByPrescriptionId(prescriptionId);
-        return PrescriptionDetailResponse.from(prescription, candidates);
+        return PrescriptionDetailResponse.from(prescription, candidates, photoUrlAssembler.toFullUrl(prescription
+                .getMaskedImageObjectKey()));
     }
 
     @Transactional(readOnly = true)
@@ -245,7 +251,8 @@ public class PrescriptionService {
         ));
 
         final List<PrescriptionMedicineCandidate> candidates = candidateRepository.findByPrescriptionId(prescriptionId);
-        return PrescriptionDetailResponse.from(prescription, candidates);
+        return PrescriptionDetailResponse.from(prescription, candidates, photoUrlAssembler.toFullUrl(prescription
+                .getMaskedImageObjectKey()));
     }
 
     @Transactional
@@ -313,7 +320,8 @@ public class PrescriptionService {
         }
 
         prescription.confirm();
-        return PrescriptionDetailResponse.from(prescription, candidates);
+        return PrescriptionDetailResponse.from(prescription, candidates, photoUrlAssembler.toFullUrl(prescription
+                .getMaskedImageObjectKey()));
     }
 
     private boolean isAcceptedOrCorrected(final PrescriptionMedicineCandidate candidate) {

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -282,6 +282,106 @@ class MedicationLogServiceTest {
         assertThat(resp.responses()).isEmpty();
     }
 
+    @Test
+    @DisplayName("신규 TAKEN 업서트 시 Medicine.remainingAmount 1 차감")
+    void 신규_TAKEN_시_잔여분_차감() throws Exception {
+        // given
+        final Medicine medicine = givenScheduleAndMedicineReturning(30, 30);
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then
+        assertThat(medicine.getRemainingAmount()).isEqualTo(29);
+    }
+
+    @Test
+    @DisplayName("이미 TAKEN인 row 재호출 시 잔여분 중복 차감 없음 — 멱등")
+    void 이미_TAKEN인_경우_차감_없음() throws Exception {
+        // given
+        final Medicine medicine = givenScheduleAndMedicineReturning(30, 25);
+        final MedicationLog existing = new MedicationLog(
+                SENIOR_ID, SCHEDULE_ID, TARGET_DATE, LocalDateTime.of(2026, 4, 18, 8, 0),
+                LogStatus.TAKEN, null, false, SENIOR_ID);
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.of(existing));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then — 이미 TAKEN이었으니 변경 없음
+        assertThat(medicine.getRemainingAmount()).isEqualTo(25);
+    }
+
+    @Test
+    @DisplayName("MISSED 등 TAKEN 외 상태는 잔여분 차감 안 함")
+    void TAKEN_아닌_상태는_차감_안함() throws Exception {
+        // given
+        final Medicine medicine = givenScheduleAndMedicineReturning(30, 30);
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.MISSED, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then
+        assertThat(medicine.getRemainingAmount()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("remainingAmount=0이면 차감하지 않아 음수 방지")
+    void 잔여분_0이면_차감_안함() throws Exception {
+        // given
+        final Medicine medicine = givenScheduleAndMedicineReturning(30, 0);
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then
+        assertThat(medicine.getRemainingAmount()).isEqualTo(0);
+    }
+
+    private Medicine givenScheduleAndMedicineReturning(final int total, final int remaining) throws Exception {
+        final java.lang.reflect.Constructor<MedicationSchedule> ctor = MedicationSchedule.class
+                .getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final MedicationSchedule schedule = ctor.newInstance();
+        setField(schedule, "id", SCHEDULE_ID);
+        setField(schedule, "medicineId", MEDICINE_ID);
+        when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(schedule));
+
+        final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", total, remaining, "ITEM-1", null);
+        setField(medicine, "id", MEDICINE_ID);
+        when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(medicine));
+        return medicine;
+    }
+
     private void givenScheduleAndMedicine() throws Exception {
         final java.lang.reflect.Constructor<MedicationSchedule> ctor = MedicationSchedule.class
                 .getDeclaredConstructor();

--- a/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
+++ b/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
@@ -73,6 +73,8 @@ class PrescriptionServiceManualAddTest {
     private NcpStorageProperties storageProperties;
     @Mock
     private S3Client s3Client;
+    @Mock
+    private com.ppiyaki.common.storage.PhotoUrlAssembler photoUrlAssembler;
 
     @InjectMocks
     private PrescriptionService prescriptionService;

--- a/src/test/java/com/ppiyaki/prescription/service/PrescriptionServicePermissionTest.java
+++ b/src/test/java/com/ppiyaki/prescription/service/PrescriptionServicePermissionTest.java
@@ -67,6 +67,8 @@ class PrescriptionServicePermissionTest {
     private NcpStorageProperties storageProperties;
     @Mock
     private S3Client s3Client;
+    @Mock
+    private com.ppiyaki.common.storage.PhotoUrlAssembler photoUrlAssembler;
 
     @InjectMocks
     private PrescriptionService prescriptionService;


### PR DESCRIPTION
## v0.9.8

### feat
- **#260 (medication)** — 복약 인증(TAKEN) 시 \`Medicine.remainingAmount\` 자동 1 차감. 멱등(이미 TAKEN인 row 재호출 시 차감 X) + 음수 방지(remainingAmount=0이면 그대로). 이전엔 클라이언트가 별도 PATCH /medicines/{id}로 깎아야 했음.

### fix
- **#258 (prescription)** — 처방전 상세 응답 \`maskedImageObjectKey\` → \`maskedImageUrl\` (medication_log 패턴). \`PhotoUrlAssembler.toFullUrl(...)\`로 NCP S3 endpoint+bucket 조립한 full URL 노출. 프론트가 endpoint 하드코딩 없이 바로 표시 가능. **breaking**: 응답 필드명 변경.

### docs
- Notion API 명세 DB 갱신: POST /prescriptions, POST /prescriptions/{id}/medicines 페이지의 Response Body 예시에 \`maskedImageUrl\` 반영.

## Prod 검증 포인트 (머지 후)
- [ ] 처방전 상세 응답의 \`maskedImageUrl\`이 full URL 형태로 내려오는지 확인
- [ ] 복약 인증(PUT medication-logs status=TAKEN) 시 Medicine.remainingAmount가 1 차감되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 약물 복용 로그 중복 등록 시 약품 잔량이 중복 감소되는 문제를 해결했습니다.

* **새로운 기능**
  * 처방전 세부 정보에 마스킹된 이미지 URL과 오류 사유 정보가 추가되었습니다.
  * 약품 잔량 자동 차감 기능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->