### PR TITLE
feat(prescription): confirm body에 medicine amount 입력 — 잔여분 갭 해소

### DIFF
--- a/src/main/java/com/ppiyaki/prescription/controller/PrescriptionController.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/PrescriptionController.java
@@ -2,6 +2,7 @@ package com.ppiyaki.prescription.controller;
 
 import com.ppiyaki.prescription.PrescriptionStatus;
 import com.ppiyaki.prescription.controller.dto.CandidateDecisionRequest;
+import com.ppiyaki.prescription.controller.dto.PrescriptionConfirmRequest;
 import com.ppiyaki.prescription.controller.dto.PrescriptionCreateRequest;
 import com.ppiyaki.prescription.controller.dto.PrescriptionDetailResponse;
 import com.ppiyaki.prescription.controller.dto.PrescriptionListResponse;
@@ -82,9 +83,10 @@ public class PrescriptionController {
     @PostMapping("/{prescriptionId}/confirm")
     public ResponseEntity<PrescriptionDetailResponse> confirm(
             @AuthenticationPrincipal final Long userId,
-            @PathVariable final Long prescriptionId
+            @PathVariable final Long prescriptionId,
+            @Valid @RequestBody(required = false) final PrescriptionConfirmRequest request
     ) {
-        return ResponseEntity.ok(prescriptionService.confirm(userId, prescriptionId));
+        return ResponseEntity.ok(prescriptionService.confirm(userId, prescriptionId, request));
     }
 
     @PostMapping("/{prescriptionId}/reject")

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionConfirmRequest.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionConfirmRequest.java
@@ -1,0 +1,25 @@
+package com.ppiyaki.prescription.controller.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+/**
+ * 처방전 확정(confirm) 요청 body.
+ * spec docs/features/caregiver-dashboard.md (의존: 잔여분 의미화).
+ *
+ * <p>보호자가 confirm 시점에 약별 총량/잔여분을 함께 입력.
+ * 입력 없는 candidate는 0/0 fallback (backward compat).
+ */
+public record PrescriptionConfirmRequest(
+        @Valid List<MedicineAmountInput> medicineAmounts
+) {
+
+    public record MedicineAmountInput(
+            @NotNull Long candidateId,
+            @NotNull @Min(0) Integer totalAmount,
+            @NotNull @Min(0) Integer remainingAmount
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -24,6 +24,8 @@ import com.ppiyaki.prescription.Prescription;
 import com.ppiyaki.prescription.PrescriptionMedicineCandidate;
 import com.ppiyaki.prescription.PrescriptionStatus;
 import com.ppiyaki.prescription.controller.dto.CandidateDecisionRequest;
+import com.ppiyaki.prescription.controller.dto.PrescriptionConfirmRequest;
+import com.ppiyaki.prescription.controller.dto.PrescriptionConfirmRequest.MedicineAmountInput;
 import com.ppiyaki.prescription.controller.dto.PrescriptionDetailResponse;
 import com.ppiyaki.prescription.controller.dto.PrescriptionListResponse;
 import com.ppiyaki.prescription.controller.dto.PrescriptionMedicineAddRequest;
@@ -256,7 +258,11 @@ public class PrescriptionService {
     }
 
     @Transactional
-    public PrescriptionDetailResponse confirm(final Long userId, final Long prescriptionId) {
+    public PrescriptionDetailResponse confirm(
+            final Long userId,
+            final Long prescriptionId,
+            final PrescriptionConfirmRequest request
+    ) {
         final Prescription prescription = findPrescription(prescriptionId);
         validateMutationAccess(userId, prescription);
 
@@ -268,6 +274,12 @@ public class PrescriptionService {
             throw new BusinessException(ErrorCode.INVALID_INPUT,
                     "All candidates must be decided before confirming.");
         }
+
+        final java.util.Map<Long, MedicineAmountInput> amountByCandidate = (request == null
+                || request.medicineAmounts() == null)
+                        ? java.util.Collections.emptyMap()
+                        : request.medicineAmounts().stream()
+                                .collect(java.util.stream.Collectors.toMap(MedicineAmountInput::candidateId, m -> m));
 
         // 시니어 mealTimes 사전 검증: 슬롯 자동 생성 대상 candidate가 있는데
         // 해당 슬롯의 mealTime이 null이면 트랜잭션 변경 시작 전에 거절 (spec §3, USER_002).
@@ -301,9 +313,12 @@ public class PrescriptionService {
                     ? candidate.getMatchedItemName()
                     : candidate.getExtractedName();
 
+            final MedicineAmountInput amount = amountByCandidate.get(candidate.getId());
+            final int totalAmount = amount != null ? amount.totalAmount() : 0;
+            final int remainingAmount = amount != null ? amount.remainingAmount() : 0;
             final Medicine medicine = new Medicine(
                     prescription.getOwnerId(), prescription.getId(),
-                    name, 0, 0, itemSeq, null);
+                    name, totalAmount, remainingAmount, itemSeq, null);
             medicineRepository.save(medicine);
             candidate.linkMedicine(medicine.getId());
 

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
@@ -91,6 +91,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()
@@ -127,6 +129,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()
@@ -154,6 +158,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()
@@ -179,6 +185,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()
@@ -205,6 +213,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when — 1차 confirm
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()
@@ -217,6 +227,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when — 2차 confirm (이미 CONFIRMED라 동일 호출)
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()


### PR DESCRIPTION
## AS-IS
\`POST /api/v1/prescriptions/{id}/confirm\`이 \`Medicine\`을 \`totalAmount=0, remainingAmount=0\`으로 생성. 보호자가 별도 \`PATCH /medicines/{id}\`로 채워야 의미.

이로 인해:
- v0.9.8 자동 차감(PR #260)이 기능적으로 의미 없음 (0에서 차감 안 됨)
- 보호자 대시보드의 "남은 복약일 수" 계산 불가

## TO-BE
프론트 협의 완료 — confirm UI에 처방전 사진 + 약별 잔여분 입력 필드 추가.

backend:
- \`PrescriptionConfirmRequest\` DTO 신설
  \`\`\`json
  {
    "medicineAmounts": [
      { "candidateId": 26, "totalAmount": 30, "remainingAmount": 30 }
    ]
  }
  \`\`\`
- \`POST /confirm\` body로 받음 (\`@RequestBody(required = false)\`)
- \`PrescriptionService.confirm\`에서 candidateId → amount Map. ACCEPTED/MANUALLY_CORRECTED candidate는 해당 amount로 Medicine 생성 (입력 없으면 0 fallback — backward compat).

## 검증
- \`@Min(0)\` — 음수 금지
- \`@NotNull\` — candidateId / totalAmount / remainingAmount 필수

## Test plan
- [x] 기존 confirm E2E 5건 — 빈 body \`{}\` + Content-Type 명시로 갱신
- [x] \`./gradlew checkstyleMain spotlessCheck test\` 전체 통과

## 영향
- 프론트 confirm 호출 body 변경 (협의 완료)
- Notion API 명세 갱신 (POST /confirm Request Body)

## 보호 영역 변경 여부
없음.

## AI 보조 작성 여부
- [x] AI 보조

Refs #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)