### PR TITLE
feat(medication): 보호자 대시보드 daily endpoint — PR 1

### DIFF
--- a/src/main/java/com/ppiyaki/medication/DayStatus.java
+++ b/src/main/java/com/ppiyaki/medication/DayStatus.java
@@ -1,0 +1,13 @@
+package com.ppiyaki.medication;
+
+/**
+ * 보호자 대시보드 일자 단위 인증 상태.
+ * spec docs/features/caregiver-dashboard.md §5-2.
+ */
+public enum DayStatus {
+    PERFECT,
+    DELAYED,
+    MISSED,
+    PENDING,
+    FUTURE
+}

--- a/src/main/java/com/ppiyaki/medication/SlotStatus.java
+++ b/src/main/java/com/ppiyaki/medication/SlotStatus.java
@@ -1,0 +1,13 @@
+package com.ppiyaki.medication;
+
+/**
+ * 보호자 대시보드 슬롯 단위 인증 상태.
+ * spec docs/features/caregiver-dashboard.md §5-2.
+ */
+public enum SlotStatus {
+    PERFECT,
+    DELAYED,
+    MISSED,
+    PENDING,
+    NOT_SCHEDULED
+}

--- a/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
+++ b/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
@@ -1,0 +1,37 @@
+package com.ppiyaki.medication.controller;
+
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
+import com.ppiyaki.medication.service.DashboardService;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 보호자 대시보드 통합 조회 엔드포인트.
+ * spec docs/features/caregiver-dashboard.md.
+ */
+@RestController
+@RequestMapping("/api/v1/seniors/{seniorId}/dashboard")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    public DashboardController(final DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @GetMapping("/daily")
+    public ResponseEntity<DailyDashboardResponse> getDaily(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long seniorId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate date
+    ) {
+        return ResponseEntity.ok(dashboardService.getDaily(userId, seniorId, date));
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/DailyDashboardResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/DailyDashboardResponse.java
@@ -1,0 +1,54 @@
+package com.ppiyaki.medication.controller.dto.dashboard;
+
+import com.ppiyaki.medication.DayStatus;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.SlotStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * 일간 대시보드 응답.
+ * spec docs/features/caregiver-dashboard.md §5-3.
+ */
+public record DailyDashboardResponse(
+        Long seniorId,
+        LocalDate date,
+        DayStatus dayStatus,
+        HeaderInfo header,
+        List<SlotInfo> slots,
+        List<MedicineSummary> medicines
+) {
+
+    public record HeaderInfo(
+            String seniorName,
+            String caregiverName,
+            Integer remainingDays
+    ) {
+    }
+
+    public record SlotInfo(
+            MealSlot slot,
+            SlotStatus status,
+            LocalTime mealTime,
+            LocalDateTime takenAt,
+            String photoUrl,
+            List<SlotMedicine> medicines
+    ) {
+    }
+
+    public record SlotMedicine(
+            Long medicineId,
+            String name,
+            String dosage
+    ) {
+    }
+
+    public record MedicineSummary(
+            Long medicineId,
+            String name,
+            List<MealSlot> slots
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/repository/MedicationLogRepository.java
+++ b/src/main/java/com/ppiyaki/medication/repository/MedicationLogRepository.java
@@ -12,4 +12,6 @@ public interface MedicationLogRepository extends JpaRepository<MedicationLog, Lo
 
     List<MedicationLog> findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(
             final Long seniorId, final LocalDate from, final LocalDate to);
+
+    List<MedicationLog> findBySeniorIdAndTargetDate(final Long seniorId, final LocalDate targetDate);
 }

--- a/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
@@ -29,4 +29,18 @@ public interface MedicationScheduleRepository extends JpaRepository<MedicationSc
             @Param("seniorId") final Long seniorId,
             @Param("date") final LocalDate date,
             @Param("mealSlot") final MealSlot mealSlot);
+
+    /**
+     * 같은 시니어의 해당 일자 active schedule 전체 (slot 무관).
+     * spec docs/features/caregiver-dashboard.md §5-5 daily 흐름 4단계.
+     */
+    @Query("""
+            SELECT s FROM MedicationSchedule s
+            WHERE s.medicineId IN (SELECT m.id FROM Medicine m WHERE m.ownerId = :seniorId)
+              AND (s.startDate IS NULL OR s.startDate <= :date)
+              AND (s.endDate IS NULL OR s.endDate >= :date)
+            """)
+    List<MedicationSchedule> findActiveByOwnerAndDate(
+            @Param("seniorId") final Long seniorId,
+            @Param("date") final LocalDate date);
 }

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -1,0 +1,273 @@
+package com.ppiyaki.medication.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.storage.PhotoUrlAssembler;
+import com.ppiyaki.medication.DayStatus;
+import com.ppiyaki.medication.LogStatus;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationLog;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.SlotStatus;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.HeaderInfo;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.MedicineSummary;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotInfo;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotMedicine;
+import com.ppiyaki.medication.repository.MedicationLogRepository;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 보호자 대시보드 조회 서비스.
+ * spec docs/features/caregiver-dashboard.md.
+ */
+@Service
+public class DashboardService {
+
+    private static final Logger log = LoggerFactory.getLogger(DashboardService.class);
+
+    private static final long DELAY_THRESHOLD_MINUTES = 60;
+    private static final Pattern DOSAGE_INT_PATTERN = Pattern.compile("\\d+");
+
+    private final UserRepository userRepository;
+    private final CareRelationRepository careRelationRepository;
+    private final MedicationScheduleRepository scheduleRepository;
+    private final MedicationLogRepository logRepository;
+    private final MedicineRepository medicineRepository;
+    private final PhotoUrlAssembler photoUrlAssembler;
+
+    public DashboardService(
+            final UserRepository userRepository,
+            final CareRelationRepository careRelationRepository,
+            final MedicationScheduleRepository scheduleRepository,
+            final MedicationLogRepository logRepository,
+            final MedicineRepository medicineRepository,
+            final PhotoUrlAssembler photoUrlAssembler
+    ) {
+        this.userRepository = userRepository;
+        this.careRelationRepository = careRelationRepository;
+        this.scheduleRepository = scheduleRepository;
+        this.logRepository = logRepository;
+        this.medicineRepository = medicineRepository;
+        this.photoUrlAssembler = photoUrlAssembler;
+    }
+
+    @Transactional(readOnly = true)
+    public DailyDashboardResponse getDaily(final Long userId, final Long seniorId, final LocalDate date) {
+        log.info("/dashboard/daily seniorId={} date={}", seniorId, date);
+        validateAccess(userId, seniorId);
+
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        final User caregiver = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        final List<MedicationSchedule> schedules = scheduleRepository.findActiveByOwnerAndDate(seniorId, date);
+        final List<MedicationLog> logs = logRepository.findBySeniorIdAndTargetDate(seniorId, date);
+        final List<Medicine> medicines = medicineRepository.findByOwnerId(seniorId);
+
+        final Map<Long, Medicine> medicineById = new HashMap<>();
+        for (final Medicine m : medicines) {
+            medicineById.put(m.getId(), m);
+        }
+
+        final Map<Long, MedicationLog> logByScheduleId = new HashMap<>();
+        for (final MedicationLog l : logs) {
+            logByScheduleId.put(l.getScheduleId(), l);
+        }
+
+        final Map<MealSlot, List<MedicationSchedule>> schedulesBySlot = new HashMap<>();
+        for (final MedicationSchedule s : schedules) {
+            schedulesBySlot.computeIfAbsent(s.getMealSlot(), k -> new ArrayList<>()).add(s);
+        }
+
+        final LocalDate today = LocalDate.now();
+        final List<SlotInfo> slots = new ArrayList<>();
+        for (final MealSlot slot : MealSlot.values()) {
+            slots.add(buildSlotInfo(slot, senior, schedulesBySlot.get(slot), logByScheduleId, medicineById, date,
+                    today));
+        }
+
+        final DayStatus dayStatus = deriveDayStatus(slots, date, today);
+        final List<MedicineSummary> medicineSummaries = buildMedicineSummaries(schedules, medicineById);
+        final Integer remainingDays = computeRemainingDays(medicines, today);
+
+        final HeaderInfo header = new HeaderInfo(senior.getNickname(), caregiver.getNickname(), remainingDays);
+        return new DailyDashboardResponse(seniorId, date, dayStatus, header, slots, medicineSummaries);
+    }
+
+    private SlotInfo buildSlotInfo(
+            final MealSlot slot,
+            final User senior,
+            final List<MedicationSchedule> slotSchedules,
+            final Map<Long, MedicationLog> logByScheduleId,
+            final Map<Long, Medicine> medicineById,
+            final LocalDate date,
+            final LocalDate today
+    ) {
+        final LocalTime mealTime = slot.resolveTime(senior);
+        if (slotSchedules == null || slotSchedules.isEmpty() || mealTime == null) {
+            return new SlotInfo(slot, SlotStatus.NOT_SCHEDULED, mealTime, null, null, List.of());
+        }
+
+        // 슬롯 안의 schedule 중 하나라도 log가 있는지 — 같은 슬롯의 log는 동일 시점에 묶여 처리됨
+        MedicationLog representativeLog = null;
+        for (final MedicationSchedule s : slotSchedules) {
+            final MedicationLog l = logByScheduleId.get(s.getId());
+            if (l != null) {
+                representativeLog = l;
+                break;
+            }
+        }
+
+        final SlotStatus status = deriveSlotStatus(representativeLog, mealTime, date, today);
+        final LocalDateTime takenAt = representativeLog != null ? representativeLog.getTakenAt() : null;
+        final String photoUrl = representativeLog != null
+                ? photoUrlAssembler.toFullUrl(representativeLog.getPhotoObjectKey()) : null;
+
+        final List<SlotMedicine> slotMedicines = new ArrayList<>();
+        for (final MedicationSchedule s : slotSchedules) {
+            final Medicine m = medicineById.get(s.getMedicineId());
+            if (m != null) {
+                slotMedicines.add(new SlotMedicine(m.getId(), m.getName(), s.getDosage()));
+            }
+        }
+        return new SlotInfo(slot, status, mealTime, takenAt, photoUrl, slotMedicines);
+    }
+
+    private SlotStatus deriveSlotStatus(
+            final MedicationLog logRow,
+            final LocalTime mealTime,
+            final LocalDate date,
+            final LocalDate today
+    ) {
+        final boolean pastDate = date.isBefore(today);
+        if (logRow == null || logRow.getStatus() != LogStatus.TAKEN) {
+            return pastDate ? SlotStatus.MISSED : SlotStatus.PENDING;
+        }
+        final LocalDateTime mealDateTime = LocalDateTime.of(date, mealTime);
+        final long minutesLate = Duration.between(mealDateTime, logRow.getTakenAt()).toMinutes();
+        if (minutesLate <= DELAY_THRESHOLD_MINUTES) {
+            return SlotStatus.PERFECT;
+        }
+        return SlotStatus.DELAYED;
+    }
+
+    private DayStatus deriveDayStatus(final List<SlotInfo> slots, final LocalDate date, final LocalDate today) {
+        if (date.isAfter(today)) {
+            return DayStatus.FUTURE;
+        }
+        final EnumSet<SlotStatus> present = EnumSet.noneOf(SlotStatus.class);
+        for (final SlotInfo s : slots) {
+            if (s.status() != SlotStatus.NOT_SCHEDULED) {
+                present.add(s.status());
+            }
+        }
+        if (present.isEmpty()) {
+            return DayStatus.PERFECT;
+        }
+        if (present.contains(SlotStatus.MISSED)) {
+            return DayStatus.MISSED;
+        }
+        if (present.contains(SlotStatus.DELAYED)) {
+            return DayStatus.DELAYED;
+        }
+        if (present.contains(SlotStatus.PENDING)) {
+            return DayStatus.PENDING;
+        }
+        return DayStatus.PERFECT;
+    }
+
+    private List<MedicineSummary> buildMedicineSummaries(
+            final List<MedicationSchedule> schedules,
+            final Map<Long, Medicine> medicineById
+    ) {
+        final Map<Long, EnumSet<MealSlot>> slotsByMedicine = new HashMap<>();
+        for (final MedicationSchedule s : schedules) {
+            slotsByMedicine
+                    .computeIfAbsent(s.getMedicineId(), k -> EnumSet.noneOf(MealSlot.class))
+                    .add(s.getMealSlot());
+        }
+        final List<MedicineSummary> summaries = new ArrayList<>();
+        for (final Map.Entry<Long, EnumSet<MealSlot>> e : slotsByMedicine.entrySet()) {
+            final Medicine m = medicineById.get(e.getKey());
+            if (m == null) {
+                continue;
+            }
+            final List<MealSlot> orderedSlots = new ArrayList<>(e.getValue());
+            orderedSlots.sort(Comparator.comparingInt(Enum::ordinal));
+            summaries.add(new MedicineSummary(m.getId(), m.getName(), orderedSlots));
+        }
+        summaries.sort(Comparator.comparingLong(MedicineSummary::medicineId));
+        return summaries;
+    }
+
+    private Integer computeRemainingDays(final List<Medicine> medicines, final LocalDate today) {
+        Integer minDays = null;
+        for (final Medicine m : medicines) {
+            if (m.getRemainingAmount() == null) {
+                continue;
+            }
+            final List<MedicationSchedule> activeSchedules = scheduleRepository.findByMedicineId(m.getId()).stream()
+                    .filter(s -> (s.getStartDate() == null || !s.getStartDate().isAfter(today))
+                            && (s.getEndDate() == null || !s.getEndDate().isBefore(today)))
+                    .toList();
+            int dailyConsumption = 0;
+            for (final MedicationSchedule s : activeSchedules) {
+                dailyConsumption += parseDosageInt(s.getDosage());
+            }
+            if (dailyConsumption == 0) {
+                continue;
+            }
+            final int days = m.getRemainingAmount() / dailyConsumption;
+            if (minDays == null || days < minDays) {
+                minDays = days;
+            }
+        }
+        return minDays;
+    }
+
+    private int parseDosageInt(final String dosage) {
+        if (dosage == null) {
+            return 0;
+        }
+        final Matcher matcher = DOSAGE_INT_PATTERN.matcher(dosage);
+        if (matcher.find()) {
+            try {
+                return Integer.parseInt(matcher.group());
+            } catch (final NumberFormatException e) {
+                return 0;
+            }
+        }
+        return 0;
+    }
+
+    private void validateAccess(final Long userId, final Long seniorId) {
+        if (userId.equals(seniorId)) {
+            return;
+        }
+        careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(userId, seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardDailyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardDailyE2ETest.java
@@ -1,0 +1,152 @@
+package com.ppiyaki.medication.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("GET /api/v1/seniors/{seniorId}/dashboard/daily E2E")
+class DashboardDailyE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 700000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("시니어 본인 호출 — schedule 없으면 dayStatus=PERFECT, header 채워짐")
+    void daily_seniorSelf_emptySchedules() {
+        final SignupResult senior = signup("일간시니어");
+        setMealTimes(senior.userId(), LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final LocalDate today = LocalDate.now();
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/daily?date=" + today)
+                .then()
+                .statusCode(200)
+                .body("seniorId", is(senior.userId().intValue()))
+                .body("date", is(today.toString()))
+                .body("dayStatus", is("PERFECT"))
+                .body("header.seniorName", is("일간시니어"))
+                .body("header.caregiverName", is("일간시니어"))
+                .body("slots", notNullValue())
+                .body("slots[0].slot", is("BREAKFAST"))
+                .body("slots[0].status", is("NOT_SCHEDULED"))
+                .body("slots[0].mealTime", is("08:00:00"))
+                .body("medicines", notNullValue());
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자 호출 → 403 CARE_RELATION_NOT_FOUND")
+    void daily_unrelatedUser_returns403() {
+        final SignupResult senior = signup("타인접근시니어");
+        final SignupResult intruder = signup("외부인");
+        final LocalDate today = LocalDate.now();
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + intruder.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/daily?date=" + today)
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "dashdaily" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private void setMealTimes(
+            final Long userId,
+            final LocalTime breakfast,
+            final LocalTime lunch,
+            final LocalTime dinner
+    ) {
+        transactionTemplate.executeWithoutResult(status -> {
+            final User user = userRepository.findById(userId).orElseThrow();
+            setHierarchicalField(user, "breakfastTime", breakfast);
+            setHierarchicalField(user, "lunchTime", lunch);
+            setHierarchicalField(user, "dinnerTime", dinner);
+            userRepository.save(user);
+        });
+    }
+
+    private static void setHierarchicalField(final Object target, final String fieldName, final Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Field not found: " + fieldName);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -1,0 +1,302 @@
+package com.ppiyaki.medication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.storage.PhotoUrlAssembler;
+import com.ppiyaki.medication.DayStatus;
+import com.ppiyaki.medication.LogStatus;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationLog;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.SlotStatus;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
+import com.ppiyaki.medication.repository.MedicationLogRepository;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DashboardService.getDaily")
+class DashboardServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private CareRelationRepository careRelationRepository;
+    @Mock
+    private MedicationScheduleRepository scheduleRepository;
+    @Mock
+    private MedicationLogRepository logRepository;
+    @Mock
+    private MedicineRepository medicineRepository;
+    @Mock
+    private PhotoUrlAssembler photoUrlAssembler;
+
+    @InjectMocks
+    private DashboardService dashboardService;
+
+    private static final Long SENIOR_ID = 16L;
+    private static final Long CAREGIVER_ID = 17L;
+    private static final LocalDate TODAY = LocalDate.now();
+    private static final LocalDate YESTERDAY = TODAY.minusDays(1);
+
+    @Test
+    @DisplayName("시니어 본인은 권한 검증 통과")
+    void seniorSelf_passesAccess() throws Exception {
+        givenSeniorAndCaregiver();
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of());
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.seniorId()).isEqualTo(SENIOR_ID);
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.PERFECT);
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자는 CARE_RELATION_NOT_FOUND")
+    void unrelatedUser_throws() {
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(999L, SENIOR_ID))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> dashboardService.getDaily(999L, SENIOR_ID, TODAY))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("오늘 BREAKFAST 정시 인증 → SlotStatus.PERFECT, DayStatus.PERFECT")
+    void today_perfect() throws Exception {
+        givenSeniorAndCaregiver();
+        final LocalTime breakfastTime = LocalTime.of(8, 0);
+        givenSeniorMealTimes(breakfastTime, null, null);
+        final MedicationSchedule schedule = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schedule));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schedule));
+        final MedicationLog logRow = logOf(schedule.getId(),
+                LocalDateTime.of(TODAY, breakfastTime).plusMinutes(10), LogStatus.TAKEN);
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of(logRow));
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "타이레놀", 30)));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.PERFECT);
+        assertThat(resp.slots()).extracting(DailyDashboardResponse.SlotInfo::slot,
+                DailyDashboardResponse.SlotInfo::status)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(MealSlot.BREAKFAST, SlotStatus.PERFECT),
+                        org.assertj.core.groups.Tuple.tuple(MealSlot.LUNCH, SlotStatus.NOT_SCHEDULED),
+                        org.assertj.core.groups.Tuple.tuple(MealSlot.DINNER, SlotStatus.NOT_SCHEDULED));
+    }
+
+    @Test
+    @DisplayName("오늘 BREAKFAST 1시간 초과 지연 인증 → DELAYED")
+    void today_delayed() throws Exception {
+        givenSeniorAndCaregiver();
+        final LocalTime breakfastTime = LocalTime.of(8, 0);
+        givenSeniorMealTimes(breakfastTime, null, null);
+        final MedicationSchedule schedule = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schedule));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schedule));
+        final MedicationLog logRow = logOf(schedule.getId(),
+                LocalDateTime.of(TODAY, breakfastTime).plusMinutes(70), LogStatus.TAKEN);
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of(logRow));
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "타이레놀", 30)));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.DELAYED);
+        assertThat(resp.slots().get(0).status()).isEqualTo(SlotStatus.DELAYED);
+    }
+
+    @Test
+    @DisplayName("오늘 미인증 → PENDING (자정 미경과)")
+    void today_pending() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+        final MedicationSchedule schedule = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schedule));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schedule));
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "타이레놀", 30)));
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.PENDING);
+        assertThat(resp.slots().get(0).status()).isEqualTo(SlotStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("어제 미인증 → MISSED (자정 경과)")
+    void past_missed() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+        final MedicationSchedule schedule = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schedule));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schedule));
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "타이레놀", 30)));
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, YESTERDAY);
+
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.MISSED);
+        assertThat(resp.slots().get(0).status()).isEqualTo(SlotStatus.MISSED);
+    }
+
+    @Test
+    @DisplayName("미래 일자 → DayStatus.FUTURE")
+    void future_date() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of());
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY.plusDays(3));
+
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.FUTURE);
+    }
+
+    @Test
+    @DisplayName("remainingDays = MIN(remainingAmount / dailyConsumption)")
+    void remainingDays_min() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+
+        final MedicationSchedule schA = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");  // medA: 1정/일
+        final MedicationSchedule schB = scheduleOf(2L, 200L, MealSlot.BREAKFAST, "2정");  // medB: 2정/일
+
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schA, schB));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schA));
+        when(scheduleRepository.findByMedicineId(200L)).thenReturn(List.of(schB));
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(
+                medicineOf(100L, "약A", 30),  // 30/1 = 30
+                medicineOf(200L, "약B", 10)   // 10/2 = 5  ← MIN
+        ));
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.header().remainingDays()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("dailyConsumption=0(dosage 비정수)인 medicine은 remainingDays 분모에서 제외")
+    void remainingDays_skipsZeroConsumption() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+
+        final MedicationSchedule sch = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "반정");  // 정수 X → 0
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(sch));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(sch));
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "약A", 10)));
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.header().remainingDays()).isNull();
+    }
+
+    @Test
+    @DisplayName("medicines 슬롯 매핑 — 같은 약이 BREAKFAST+DINNER면 slots=[BREAKFAST,DINNER]")
+    void medicineSummary_aggregatesSlots() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, LocalTime.of(18, 0));
+        final MedicationSchedule schA = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        final MedicationSchedule schB = scheduleOf(2L, 100L, MealSlot.DINNER, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schA, schB));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schA, schB));
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "약A", 30)));
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.medicines()).hasSize(1);
+        assertThat(resp.medicines().get(0).slots()).containsExactly(MealSlot.BREAKFAST, MealSlot.DINNER);
+    }
+
+    private void givenSeniorAndCaregiver() throws Exception {
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(userOf(SENIOR_ID, "김장군")));
+        // userId == seniorId 케이스 외에는 caregiver lookup 호출
+    }
+
+    private void givenSeniorMealTimes(final LocalTime breakfast, final LocalTime lunch,
+            final LocalTime dinner) throws Exception {
+        final User senior = userOf(SENIOR_ID, "김장군");
+        setField(senior, "breakfastTime", breakfast);
+        setField(senior, "lunchTime", lunch);
+        setField(senior, "dinnerTime", dinner);
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(senior));
+    }
+
+    private User userOf(final Long id, final String nickname) throws Exception {
+        final java.lang.reflect.Constructor<User> ctor = User.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final User u = ctor.newInstance();
+        setField(u, "id", id);
+        setField(u, "nickname", nickname);
+        return u;
+    }
+
+    private MedicationSchedule scheduleOf(
+            final Long id, final Long medicineId, final MealSlot slot, final String dosage) throws Exception {
+        final java.lang.reflect.Constructor<MedicationSchedule> ctor = MedicationSchedule.class
+                .getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final MedicationSchedule s = ctor.newInstance();
+        setField(s, "id", id);
+        setField(s, "medicineId", medicineId);
+        setField(s, "mealSlot", slot);
+        setField(s, "dosage", dosage);
+        return s;
+    }
+
+    private MedicationLog logOf(final Long scheduleId, final LocalDateTime takenAt, final LogStatus status) {
+        final MedicationLog l = new MedicationLog(SENIOR_ID, scheduleId, takenAt.toLocalDate(),
+                takenAt, status, null, false, SENIOR_ID);
+        return l;
+    }
+
+    private Medicine medicineOf(final Long id, final String name, final int remaining) throws Exception {
+        final Medicine m = new Medicine(SENIOR_ID, null, name, 30, remaining, null, null);
+        setField(m, "id", id);
+        return m;
+    }
+
+    private static void setField(final Object target, final String fieldName, final Object value) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}


### PR DESCRIPTION
## TO-BE
spec \`docs/features/caregiver-dashboard.md\` 합의 완료(#264). PR 1 = daily endpoint.

\`GET /api/v1/seniors/{seniorId}/dashboard/daily?date=YYYY-MM-DD\`

### 응답
\`\`\`json
{
  "seniorId": 16,
  "date": "2026-05-08",
  "dayStatus": "DELAYED",
  "header": { "seniorName": "...", "caregiverName": "...", "remainingDays": 5 },
  "slots": [
    { "slot": "BREAKFAST", "status": "PERFECT", "mealTime": "08:00:00",
      "takenAt": "...", "photoUrl": "...", "medicines": [...] },
    { "slot": "LUNCH", ... },
    { "slot": "DINNER", ... }
  ],
  "medicines": [
    { "medicineId": 12, "name": "타이레놀", "slots": ["BREAKFAST", "DINNER"] }
  ]
}
\`\`\`

### status 룰
- \`SlotStatus\`: PERFECT / DELAYED / MISSED / PENDING / NOT_SCHEDULED
- \`DayStatus\`: PERFECT / DELAYED / MISSED / PENDING / FUTURE
- DELAYED 임계: mealTime 대비 60분 초과
- MISSED: 자정 경과 후 미인증 / PENDING: 오늘 진행 중 미인증
- 색깔 매핑은 frontend ("오늘 강조"는 isToday)

### remainingDays
\`MIN(medicine.remainingAmount / dailyConsumption)\` — dosage 정수 파싱 (\`"1정"\` → 1, \`"반정"\` → 0). dailyConsumption=0인 medicine은 분모 제외. 모든 medicine이 0이면 null.

### 권한
시니어 본인 + 활성 \`care_relations\` 보호자. 외부인은 403 CARE_001.

### 오픈 질문 default 적용
- Q1: mealTimes 미설정 → PERFECT (분모 0)
- Q2: dosage 정수만, 비정수 → 0
- Q5: 1시간 시스템 상수

## Test plan
- [x] 단위 테스트 9건 (DashboardServiceTest) — 권한, 시니어 본인, PERFECT/DELAYED/PENDING/MISSED/FUTURE, remainingDays MIN, 0 분모 제외, medicine slot 매핑
- [x] E2E 2건 (DashboardDailyE2ETest) — 본인 호출 + 외부인 403
- [x] checkstyle/spotless 통과
- [ ] 머지 후 prod 검증 + Notion API 명세 신규 등록

## 보호 영역 변경 여부
없음.

## AI 보조 작성 여부
- [x] AI 보조

Refs #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)