### PR TITLE
fix(medication): DashboardService에 ConditionalOnProperty 추가 — develop contextLoads 회복

### DIFF
--- a/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
+++ b/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
@@ -3,6 +3,7 @@ package com.ppiyaki.medication.controller;
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
 import com.ppiyaki.medication.service.DashboardService;
 import java.time.LocalDate;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/v1/seniors/{seniorId}/dashboard")
+@ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")
 public class DashboardController {
 
     private final DashboardService dashboardService;

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -35,14 +35,19 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 보호자 대시보드 조회 서비스.
  * spec docs/features/caregiver-dashboard.md.
+ *
+ * <p>{@link com.ppiyaki.common.storage.PhotoUrlAssembler} 의존 — 기존 MedicationLogService 패턴과 동일하게
+ * ncp.storage.bucket-name 설정 시에만 빈 등록 (default 컨텍스트 contextLoads 보호).
  */
 @Service
+@ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")
 public class DashboardService {
 
     private static final Logger log = LoggerFactory.getLogger(DashboardService.class);


### PR DESCRIPTION
## AS-IS
PR #266 머지 후 develop CI fail. 원인:
- PpiyakiBackendApplicationTests > contextLoads() 실패
- 다수 E2E 도미노 fail (chat photo, 404, MedicationSchedule, ChatSession 등)

## 진단
\`DashboardService\`가 \`PhotoUrlAssembler\`에 의존하지만, \`PhotoUrlAssembler\` 자체가 \`@ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")\`이라 default 환경(test contextLoads)에서 빈 미등록. DashboardService 의존성 미충족 → 컨텍스트 시작 실패.

기존 \`MedicationLogService\`도 같은 의존성이지만 \`@ConditionalOnProperty(ncp.storage.bucket-name)\` 보유 → contextLoads 통과.

## TO-BE
\`DashboardService\` + \`DashboardController\` 둘 다에 \`@ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")\` 추가. 기존 패턴과 일관.

## Test plan
- [x] \`./gradlew checkstyleMain spotlessCheck test\` 전체 통과 (29s, 0 fail)
- [ ] CI 재검증

## 보호 영역 변경 여부
없음.

## AI 보조 작성 여부
- [x] AI 보조

Refs #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **설정 (Chores)**
  * 대시보드 기능이 저장소 설정에 따라 조건부로 활성화됩니다. 필수 저장소 설정이 누락된 경우 대시보드 컨트롤러 및 서비스가 비활성화됩니다. 기존 대시보드 기능은 변경되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->