### PR TITLE
feat(medication): 보호자 대시보드 weekly endpoint — PR 2

### DIFF
--- a/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
+++ b/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.medication.controller;
 
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
+import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse;
 import com.ppiyaki.medication.service.DashboardService;
 import java.time.LocalDate;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,5 +36,14 @@ public class DashboardController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate date
     ) {
         return ResponseEntity.ok(dashboardService.getDaily(userId, seniorId, date));
+    }
+
+    @GetMapping("/weekly")
+    public ResponseEntity<WeeklyDashboardResponse> getWeekly(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long seniorId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate weekStart
+    ) {
+        return ResponseEntity.ok(dashboardService.getWeekly(userId, seniorId, weekStart));
     }
 }

--- a/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/WeeklyDashboardResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/WeeklyDashboardResponse.java
@@ -1,0 +1,33 @@
+package com.ppiyaki.medication.controller.dto.dashboard;
+
+import com.ppiyaki.medication.DayStatus;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.SlotStatus;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 주간 대시보드 응답.
+ * spec docs/features/caregiver-dashboard.md §5-3.
+ */
+public record WeeklyDashboardResponse(
+        Long seniorId,
+        LocalDate weekStart,
+        LocalDate weekEnd,
+        Double adherenceRate,
+        List<DayEntry> days
+) {
+
+    public record DayEntry(
+            LocalDate date,
+            DayStatus dayStatus,
+            List<SlotMarker> slots
+    ) {
+    }
+
+    public record SlotMarker(
+            MealSlot slot,
+            SlotStatus status
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
@@ -43,4 +43,19 @@ public interface MedicationScheduleRepository extends JpaRepository<MedicationSc
     List<MedicationSchedule> findActiveByOwnerAndDate(
             @Param("seniorId") final Long seniorId,
             @Param("date") final LocalDate date);
+
+    /**
+     * 같은 시니어의 [from, to] 기간과 겹치는 active schedule 전체.
+     * spec docs/features/caregiver-dashboard.md §5-5 weekly/monthly 흐름.
+     */
+    @Query("""
+            SELECT s FROM MedicationSchedule s
+            WHERE s.medicineId IN (SELECT m.id FROM Medicine m WHERE m.ownerId = :seniorId)
+              AND (s.startDate IS NULL OR s.startDate <= :to)
+              AND (s.endDate IS NULL OR s.endDate >= :from)
+            """)
+    List<MedicationSchedule> findActiveByOwnerAndDateRange(
+            @Param("seniorId") final Long seniorId,
+            @Param("from") final LocalDate from,
+            @Param("to") final LocalDate to);
 }

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -14,6 +14,9 @@ import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.He
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.MedicineSummary;
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotInfo;
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotMedicine;
+import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse;
+import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse.DayEntry;
+import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse.SlotMarker;
 import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
@@ -120,6 +123,112 @@ public class DashboardService {
 
         final HeaderInfo header = new HeaderInfo(senior.getNickname(), caregiver.getNickname(), remainingDays);
         return new DailyDashboardResponse(seniorId, date, dayStatus, header, slots, medicineSummaries);
+    }
+
+    @Transactional(readOnly = true)
+    public WeeklyDashboardResponse getWeekly(final Long userId, final Long seniorId, final LocalDate weekStart) {
+        log.info("/dashboard/weekly seniorId={} weekStart={}", seniorId, weekStart);
+        validateAccess(userId, seniorId);
+
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        final LocalDate weekEnd = weekStart.plusDays(6);
+        final List<MedicationSchedule> schedules = scheduleRepository.findActiveByOwnerAndDateRange(
+                seniorId, weekStart, weekEnd);
+        final List<MedicationLog> logs = logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(
+                seniorId, weekStart, weekEnd);
+
+        final Map<LocalDate, Map<Long, MedicationLog>> logsByDateAndSchedule = new HashMap<>();
+        for (final MedicationLog l : logs) {
+            logsByDateAndSchedule
+                    .computeIfAbsent(l.getTargetDate(), k -> new HashMap<>())
+                    .put(l.getScheduleId(), l);
+        }
+
+        final LocalDate today = LocalDate.now();
+        final List<DayEntry> dayEntries = new ArrayList<>();
+        int adherenceNumerator = 0;
+        int adherenceDenominator = 0;
+        for (int i = 0; i < 7; i++) {
+            final LocalDate date = weekStart.plusDays(i);
+            final List<SlotMarker> slotMarkers = new ArrayList<>();
+            final Map<Long, MedicationLog> logBySchedule = logsByDateAndSchedule.getOrDefault(date, Map.of());
+            for (final MealSlot slot : MealSlot.values()) {
+                final SlotStatus status = deriveSlotStatusForDate(slot, senior, schedules, logBySchedule, date, today);
+                slotMarkers.add(new SlotMarker(slot, status));
+                if (date.isAfter(today) || status == SlotStatus.NOT_SCHEDULED) {
+                    continue;
+                }
+                adherenceDenominator++;
+                if (status == SlotStatus.PERFECT || status == SlotStatus.DELAYED) {
+                    adherenceNumerator++;
+                }
+            }
+            final DayStatus dayStatus = deriveDayStatusFromMarkers(slotMarkers, date, today);
+            dayEntries.add(new DayEntry(date, dayStatus, slotMarkers));
+        }
+
+        final Double adherenceRate = adherenceDenominator == 0
+                ? null
+                : Math.round(((double) adherenceNumerator / adherenceDenominator) * 10000.0) / 100.0;
+
+        return new WeeklyDashboardResponse(seniorId, weekStart, weekEnd, adherenceRate, dayEntries);
+    }
+
+    private SlotStatus deriveSlotStatusForDate(
+            final MealSlot slot,
+            final User senior,
+            final List<MedicationSchedule> allSchedules,
+            final Map<Long, MedicationLog> logBySchedule,
+            final LocalDate date,
+            final LocalDate today
+    ) {
+        final LocalTime mealTime = slot.resolveTime(senior);
+        final List<MedicationSchedule> slotSchedules = allSchedules.stream()
+                .filter(s -> s.getMealSlot() == slot)
+                .filter(s -> (s.getStartDate() == null || !s.getStartDate().isAfter(date))
+                        && (s.getEndDate() == null || !s.getEndDate().isBefore(date)))
+                .toList();
+        if (slotSchedules.isEmpty() || mealTime == null) {
+            return SlotStatus.NOT_SCHEDULED;
+        }
+        MedicationLog representativeLog = null;
+        for (final MedicationSchedule s : slotSchedules) {
+            final MedicationLog l = logBySchedule.get(s.getId());
+            if (l != null) {
+                representativeLog = l;
+                break;
+            }
+        }
+        return deriveSlotStatus(representativeLog, mealTime, date, today);
+    }
+
+    private DayStatus deriveDayStatusFromMarkers(
+            final List<SlotMarker> markers, final LocalDate date, final LocalDate today
+    ) {
+        if (date.isAfter(today)) {
+            return DayStatus.FUTURE;
+        }
+        final EnumSet<SlotStatus> present = EnumSet.noneOf(SlotStatus.class);
+        for (final SlotMarker m : markers) {
+            if (m.status() != SlotStatus.NOT_SCHEDULED) {
+                present.add(m.status());
+            }
+        }
+        if (present.isEmpty()) {
+            return DayStatus.PERFECT;
+        }
+        if (present.contains(SlotStatus.MISSED)) {
+            return DayStatus.MISSED;
+        }
+        if (present.contains(SlotStatus.DELAYED)) {
+            return DayStatus.DELAYED;
+        }
+        if (present.contains(SlotStatus.PENDING)) {
+            return DayStatus.PENDING;
+        }
+        return DayStatus.PERFECT;
     }
 
     private SlotInfo buildSlotInfo(

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
@@ -1,0 +1,151 @@
+package com.ppiyaki.medication.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("GET /api/v1/seniors/{seniorId}/dashboard/weekly E2E")
+class DashboardWeeklyE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 800000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("시니어 본인 호출 — schedule 없으면 days[7] 모두 PERFECT, adherenceRate=null")
+    void weekly_seniorSelf_emptySchedules() {
+        final SignupResult senior = signup("주간시니어");
+        setMealTimes(senior.userId(), LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final LocalDate weekStart = LocalDate.now().minusDays(7);
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/weekly?weekStart=" + weekStart)
+                .then()
+                .statusCode(200)
+                .body("seniorId", is(senior.userId().intValue()))
+                .body("weekStart", is(weekStart.toString()))
+                .body("weekEnd", is(weekStart.plusDays(6).toString()))
+                .body("adherenceRate", is(nullValue()))
+                .body("days.size()", is(7))
+                .body("days[0].dayStatus", is("PERFECT"))
+                .body("days[0].slots", notNullValue())
+                .body("days[0].slots[0].status", is("NOT_SCHEDULED"));
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자 호출 → 403 CARE_RELATION_NOT_FOUND")
+    void weekly_unrelatedUser_returns403() {
+        final SignupResult senior = signup("주간타인시니어");
+        final SignupResult intruder = signup("주간외부인");
+        final LocalDate weekStart = LocalDate.now().minusDays(7);
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + intruder.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/weekly?weekStart=" + weekStart)
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "dashweekly" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private void setMealTimes(
+            final Long userId,
+            final LocalTime breakfast,
+            final LocalTime lunch,
+            final LocalTime dinner
+    ) {
+        transactionTemplate.executeWithoutResult(status -> {
+            final User user = userRepository.findById(userId).orElseThrow();
+            setHierarchicalField(user, "breakfastTime", breakfast);
+            setHierarchicalField(user, "lunchTime", lunch);
+            setHierarchicalField(user, "dinnerTime", dinner);
+            userRepository.save(user);
+        });
+    }
+
+    private static void setHierarchicalField(final Object target, final String fieldName, final Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Field not found: " + fieldName);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -237,6 +237,80 @@ class DashboardServiceTest {
         assertThat(resp.medicines().get(0).slots()).containsExactly(MealSlot.BREAKFAST, MealSlot.DINNER);
     }
 
+    @Test
+    @DisplayName("weekly — 모든 일자 schedule 없음 → adherenceRate=null, days[7] 모두 PERFECT/NOT_SCHEDULED")
+    void weekly_emptySchedules() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        final LocalDate weekStart = TODAY.minusDays(7);
+        final var resp = dashboardService.getWeekly(SENIOR_ID, SENIOR_ID, weekStart);
+
+        org.assertj.core.api.Assertions.assertThat(resp.weekStart()).isEqualTo(weekStart);
+        org.assertj.core.api.Assertions.assertThat(resp.weekEnd()).isEqualTo(weekStart.plusDays(6));
+        org.assertj.core.api.Assertions.assertThat(resp.adherenceRate()).isNull();
+        org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(7);
+        org.assertj.core.api.Assertions.assertThat(resp.days()).allMatch(d -> d.dayStatus()
+                == com.ppiyaki.medication.DayStatus.PERFECT
+                && d.slots().stream().allMatch(s -> s.status() == SlotStatus.NOT_SCHEDULED));
+    }
+
+    @Test
+    @DisplayName("weekly — 과거 6일 모두 PERFECT 인증, 오늘은 PENDING → adherenceRate=100")
+    void weekly_pastPerfect_todayPending() throws Exception {
+        givenSeniorAndCaregiver();
+        final LocalTime breakfastTime = LocalTime.of(8, 0);
+        givenSeniorMealTimes(breakfastTime, null, null);
+
+        final LocalDate weekStart = TODAY.minusDays(6);
+        final MedicationSchedule schedule = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of(schedule));
+
+        final List<MedicationLog> pastLogs = new java.util.ArrayList<>();
+        for (int i = 0; i < 6; i++) {
+            final LocalDate date = weekStart.plusDays(i);
+            pastLogs.add(logOnDate(schedule.getId(), date, breakfastTime, 10));
+        }
+        // 오늘은 미인증
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(pastLogs);
+
+        final var resp = dashboardService.getWeekly(SENIOR_ID, SENIOR_ID, weekStart);
+
+        // 분모: 7일 모두 schedule된 BREAKFAST = 7. 분자: 과거 6 PERFECT = 6 (오늘 PENDING은 분자 제외).
+        org.assertj.core.api.Assertions.assertThat(resp.adherenceRate())
+                .isEqualTo(Math.round(6.0 / 7 * 10000) / 100.0);
+        org.assertj.core.api.Assertions.assertThat(resp.days().get(6).dayStatus())
+                .isEqualTo(com.ppiyaki.medication.DayStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("weekly — 미래 일자(weekStart=today+1)는 FUTURE, adherenceRate=null")
+    void weekly_futureWeek() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        final LocalDate weekStart = TODAY.plusDays(1);
+        final var resp = dashboardService.getWeekly(SENIOR_ID, SENIOR_ID, weekStart);
+
+        org.assertj.core.api.Assertions.assertThat(resp.adherenceRate()).isNull();
+        org.assertj.core.api.Assertions.assertThat(resp.days()).allMatch(d -> d.dayStatus()
+                == com.ppiyaki.medication.DayStatus.FUTURE);
+    }
+
+    private MedicationLog logOnDate(final Long scheduleId, final LocalDate date,
+            final LocalTime mealTime, final int minutesAfter) {
+        return new MedicationLog(SENIOR_ID, scheduleId, date,
+                LocalDateTime.of(date, mealTime).plusMinutes(minutesAfter), LogStatus.TAKEN, null, false, SENIOR_ID);
+    }
+
     private void givenSeniorAndCaregiver() throws Exception {
         when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(userOf(SENIOR_ID, "김장군")));
         // userId == seniorId 케이스 외에는 caregiver lookup 호출


### PR DESCRIPTION
## TO-BE
\`GET /api/v1/seniors/{seniorId}/dashboard/weekly?weekStart=YYYY-MM-DD\`

### 응답
\`\`\`json
{
  "seniorId": 16,
  "weekStart": "2026-05-04",
  "weekEnd": "2026-05-10",
  "adherenceRate": 75.0,
  "days": [
    {
      "date": "2026-05-04",
      "dayStatus": "PERFECT",
      "slots": [
        {"slot": "BREAKFAST", "status": "PERFECT"},
        {"slot": "LUNCH", "status": "PERFECT"},
        {"slot": "DINNER", "status": "PERFECT"}
      ]
    },
    ...
    {"date": "2026-05-10", "dayStatus": "FUTURE", "slots": [...]}
  ]
}
\`\`\`

### 핵심 룰
- adherenceRate(%) = (PERFECT + DELAYED) / (PERFECT + DELAYED + MISSED + PENDING). NOT_SCHEDULED + FUTURE 일자 슬롯 제외. 분모 0 → null.
- days[7]에 medicines/photo 미포함 — frontend가 일자 클릭 시 daily 호출

### 영향
- 신규 endpoint
- WeeklyDashboardResponse DTO
- DashboardService.getWeekly + helper 메서드 추출
- MedicationScheduleRepository.findActiveByOwnerAndDateRange (기간 활성 schedule)
- DashboardController weekly endpoint

## Test plan
- [x] 단위 테스트 3건 (모든 일자 빈 schedule, 과거 6일 PERFECT + 오늘 PENDING, 미래 주)
- [x] E2E 2건 (본인 호출 + 외부인 403)
- [x] checkstyle/spotless/test 전체 통과
- [ ] CI 재검증 + 머지 후 Notion 등록

## 보호 영역 변경 여부
없음.

## AI 보조 작성 여부
- [x] AI 보조

Refs #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)