### PR TITLE
feat(medication): 보호자 대시보드 monthly endpoint — PR 3

### DIFF
--- a/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
+++ b/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
@@ -1,9 +1,11 @@
 package com.ppiyaki.medication.controller;
 
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
+import com.ppiyaki.medication.controller.dto.dashboard.MonthlyDashboardResponse;
 import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse;
 import com.ppiyaki.medication.service.DashboardService;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -45,5 +47,14 @@ public class DashboardController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate weekStart
     ) {
         return ResponseEntity.ok(dashboardService.getWeekly(userId, seniorId, weekStart));
+    }
+
+    @GetMapping("/monthly")
+    public ResponseEntity<MonthlyDashboardResponse> getMonthly(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long seniorId,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM") final YearMonth yearMonth
+    ) {
+        return ResponseEntity.ok(dashboardService.getMonthly(userId, seniorId, yearMonth));
     }
 }

--- a/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/MonthlyDashboardResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/MonthlyDashboardResponse.java
@@ -1,0 +1,25 @@
+package com.ppiyaki.medication.controller.dto.dashboard;
+
+import com.ppiyaki.medication.DayStatus;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+/**
+ * 월간 대시보드 응답 — 캘린더 색상용.
+ * spec docs/features/caregiver-dashboard.md §5-3.
+ *
+ * <p>일자별 dayStatus만 포함. 슬롯/medicine/photo는 frontend가 일자 클릭 시 daily endpoint로 가져간다.
+ */
+public record MonthlyDashboardResponse(
+        Long seniorId,
+        YearMonth yearMonth,
+        List<DayEntry> days
+) {
+
+    public record DayEntry(
+            LocalDate date,
+            DayStatus dayStatus
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -14,6 +14,7 @@ import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.He
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.MedicineSummary;
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotInfo;
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotMedicine;
+import com.ppiyaki.medication.controller.dto.dashboard.MonthlyDashboardResponse;
 import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse;
 import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse.DayEntry;
 import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse.SlotMarker;
@@ -28,6 +29,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -174,6 +176,45 @@ public class DashboardService {
                 : Math.round(((double) adherenceNumerator / adherenceDenominator) * 10000.0) / 100.0;
 
         return new WeeklyDashboardResponse(seniorId, weekStart, weekEnd, adherenceRate, dayEntries);
+    }
+
+    @Transactional(readOnly = true)
+    public MonthlyDashboardResponse getMonthly(final Long userId, final Long seniorId, final YearMonth yearMonth) {
+        log.info("/dashboard/monthly seniorId={} yearMonth={}", seniorId, yearMonth);
+        validateAccess(userId, seniorId);
+
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        final LocalDate monthStart = yearMonth.atDay(1);
+        final LocalDate monthEnd = yearMonth.atEndOfMonth();
+        final List<MedicationSchedule> schedules = scheduleRepository.findActiveByOwnerAndDateRange(
+                seniorId, monthStart, monthEnd);
+        final List<MedicationLog> logs = logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(
+                seniorId, monthStart, monthEnd);
+
+        final Map<LocalDate, Map<Long, MedicationLog>> logsByDateAndSchedule = new HashMap<>();
+        for (final MedicationLog l : logs) {
+            logsByDateAndSchedule
+                    .computeIfAbsent(l.getTargetDate(), k -> new HashMap<>())
+                    .put(l.getScheduleId(), l);
+        }
+
+        final LocalDate today = LocalDate.now();
+        final List<MonthlyDashboardResponse.DayEntry> dayEntries = new ArrayList<>();
+        for (int day = 1; day <= yearMonth.lengthOfMonth(); day++) {
+            final LocalDate date = yearMonth.atDay(day);
+            final List<SlotMarker> markers = new ArrayList<>();
+            final Map<Long, MedicationLog> logBySchedule = logsByDateAndSchedule.getOrDefault(date, Map.of());
+            for (final MealSlot slot : MealSlot.values()) {
+                final SlotStatus status = deriveSlotStatusForDate(slot, senior, schedules, logBySchedule, date, today);
+                markers.add(new SlotMarker(slot, status));
+            }
+            final DayStatus dayStatus = deriveDayStatusFromMarkers(markers, date, today);
+            dayEntries.add(new MonthlyDashboardResponse.DayEntry(date, dayStatus));
+        }
+
+        return new MonthlyDashboardResponse(seniorId, yearMonth, dayEntries);
     }
 
     private SlotStatus deriveSlotStatusForDate(

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
@@ -1,0 +1,107 @@
+package com.ppiyaki.medication.controller;
+
+import static org.hamcrest.Matchers.is;
+
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.time.YearMonth;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("GET /api/v1/seniors/{seniorId}/dashboard/monthly E2E")
+class DashboardMonthlyE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private static long userSequence = 900000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("시니어 본인 호출 — schedule 없으면 days 모두 PERFECT, 길이는 해당 월 일수")
+    void monthly_seniorSelf_emptySchedules() {
+        final SignupResult senior = signup("월간시니어");
+        final YearMonth ym = YearMonth.of(2026, 1);
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/monthly?yearMonth=" + ym)
+                .then()
+                .statusCode(200)
+                .body("seniorId", is(senior.userId().intValue()))
+                .body("yearMonth", is("2026-01"))
+                .body("days.size()", is(31))
+                .body("days[0].date", is("2026-01-01"))
+                .body("days[0].dayStatus", is("PERFECT"))
+                .body("days[30].date", is("2026-01-31"));
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자 호출 → 403 CARE_RELATION_NOT_FOUND")
+    void monthly_unrelatedUser_returns403() {
+        final SignupResult senior = signup("월간타인시니어");
+        final SignupResult intruder = signup("월간외부인");
+        final YearMonth ym = YearMonth.of(2026, 1);
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + intruder.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/monthly?yearMonth=" + ym)
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "dashmonthly" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -289,6 +289,39 @@ class DashboardServiceTest {
     }
 
     @Test
+    @DisplayName("monthly — schedule 없으면 days 모두 PERFECT (분모 0 케이스)")
+    void monthly_emptySchedules() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        final java.time.YearMonth ym = java.time.YearMonth.of(2026, 1);
+        final var resp = dashboardService.getMonthly(SENIOR_ID, SENIOR_ID, ym);
+
+        org.assertj.core.api.Assertions.assertThat(resp.yearMonth()).isEqualTo(ym);
+        org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(31);
+        org.assertj.core.api.Assertions.assertThat(resp.days())
+                .allMatch(d -> d.dayStatus() == com.ppiyaki.medication.DayStatus.PERFECT);
+    }
+
+    @Test
+    @DisplayName("monthly — 2월(28일)은 days.size=28")
+    void monthly_february28() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        final java.time.YearMonth ym = java.time.YearMonth.of(2025, 2);
+        final var resp = dashboardService.getMonthly(SENIOR_ID, SENIOR_ID, ym);
+
+        org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(28);
+    }
+
+    @Test
     @DisplayName("weekly — 미래 일자(weekStart=today+1)는 FUTURE, adherenceRate=null")
     void weekly_futureWeek() throws Exception {
         givenSeniorAndCaregiver();


### PR DESCRIPTION
## TO-BE
\`GET /api/v1/seniors/{seniorId}/dashboard/monthly?yearMonth=YYYY-MM\`

### 응답
\`\`\`json
{
  "seniorId": 16,
  "yearMonth": "2026-05",
  "days": [
    { "date": "2026-05-01", "dayStatus": "PERFECT" },
    { "date": "2026-05-02", "dayStatus": "DELAYED" },
    { "date": "2026-05-08", "dayStatus": "PENDING" },
    ...
    { "date": "2026-05-31", "dayStatus": "FUTURE" }
  ]
}
\`\`\`

### 핵심
- 캘린더 색상용. dayStatus enum만 (PERFECT/DELAYED/MISSED/PENDING/FUTURE)
- days 길이 = 해당 월 일수 (28~31)
- medicines/photo/슬롯 마커 미포함 — 일자 클릭 시 frontend가 daily endpoint로 가져감
- status 룰은 daily/weekly와 동일

## Test plan
- [x] 단위 테스트 2건 (빈 schedule 31일, 2월 28일)
- [x] E2E 2건 (본인 호출 + 외부인 403)
- [x] checkstyle/spotless/test 전체 통과

## 보호 영역 변경 여부
없음.

## AI 보조 작성 여부
- [x] AI 보조

Refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)