### PR TITLE
release: v0.9.9

### DIFF
--- a/docs/features/caregiver-dashboard.md
+++ b/docs/features/caregiver-dashboard.md
@@ -1,0 +1,255 @@
+---
+feature: 보호자 대시보드 (일간/주간/월간 복약 현황)
+slug: caregiver-dashboard
+status: draft
+owner: @goohong
+scope: medication
+related_issues: []
+related_prs: []
+last_reviewed: 2026-05-08
+---
+
+# 보호자 대시보드 (일간/주간/월간 복약 현황)
+
+## 1) 개요 (What / Why)
+보호자 앱의 "복약 현황" 화면에서 시니어의 복약 인증 상태를 일/주/월 단위로 볼 수 있게 한다. 보호자가 시니어 상태를 한눈에 파악하고 누락/지연 시 빠르게 인지할 수 있도록 통합 조회 API 3개를 제공한다.
+
+**대상 액터**: 보호자(care_relations 활성), 시니어 본인.
+
+**해결 문제**: 현재는 보호자가 medication-logs / medicines / schedules를 별도로 호출해 합성해야 함. 일자별 상태 색상(초록/노랑/빨강) 같은 비즈니스 룰도 클라이언트에서 계산. → 통합 endpoint로 응답 + status 도출 일관성 확보.
+
+## 2) 사용자 시나리오
+- **일간 진입**: 보호자가 앱 첫 화면에서 오늘 시니어가 아침/점심/저녁 약을 인증했는지, 어떤 약이 어느 슬롯에 처방됐는지 확인. 인증 사진도 본다.
+- **주간 점검**: 일주일 단위로 어떤 날이 빨강(누락)/노랑(지연)/초록(정시)인지 보고, 빨강 일자 클릭 → 일간 화면으로 이동.
+- **월간 트렌드**: 캘린더에서 한 달간 복약 패턴을 색으로 본다. 일자 클릭 → 일간 화면.
+
+## 3) 요구사항
+### 기능 요구사항
+- [ ] `GET /api/v1/seniors/{seniorId}/dashboard/daily?date=YYYY-MM-DD` — 일간 화면용 통합 응답
+  - 헤더 정보(시니어 이름, 보호자 이름, 남은 복약일 수)
+  - 슬롯별(BREAKFAST/LUNCH/DINNER) 인증 상태(`PERFECT`/`DELAYED`/`MISSED`/`PENDING`/`NOT_SCHEDULED`) + 인증 사진 URL + 인증 시각
+  - 슬롯별 복약 대상 약 목록 (medicine + dosage)
+  - 일자별 통합 status enum
+- [ ] `GET /api/v1/seniors/{seniorId}/dashboard/weekly?weekStart=YYYY-MM-DD` — 주간 화면용
+  - 주간 이행률(%) — 정시/지연 인증 슬롯 / 총 슬롯
+  - 일자별(7일) 통합 status enum + 슬롯별 마커
+- [ ] `GET /api/v1/seniors/{seniorId}/dashboard/monthly?yearMonth=YYYY-MM` — 월간 캘린더용
+  - 일자별(해당 월 1일~말일) 통합 status enum
+  - 상세 medicine 정보 미포함 (필요 시 daily 별도 호출)
+- [ ] 권한: 시니어 본인 + 활성 `care_relations` 보호자 (`PrescriptionService.validateAccess` 패턴)
+- [ ] 미존재 시니어는 `USER_NOT_FOUND`, 권한 없으면 `CARE_RELATION_NOT_FOUND`
+
+### 비기능 요구사항
+- **성능**:
+  - daily: schedule + log + medicine 조인. 단일 시니어/단일 일자라 row 수 작음(<100). 쿼리 ≤ 50ms 목표.
+  - weekly: 7일치 → 단일 쿼리 + 메모리 그룹핑.
+  - monthly: 31일치 status만 → 단일 쿼리 + 메모리 그룹핑. medicine 정보 제외로 응답 < 5KB.
+- **신뢰성**: status 룰 동적 계산(log row 미변경)이므로 멱등.
+- **관측성**: dashboard 호출 INFO 로그 1줄(`/dashboard/daily seniorId=… date=…`).
+
+## 4) 범위 / 비범위
+### 포함
+- daily / weekly / monthly 조회 endpoint 3개
+- status enum 동적 계산 룰
+- 일일 소요량 + 남은 복약일 수 계산
+- 권한 검증 재사용
+- 단위 + E2E 테스트
+
+### 제외 (Out of Scope)
+- **MISSED 자동 전환 cron**: log row를 PENDING → MISSED로 batch 전환하는 별도 작업. 본 spec은 dashboard 응답 시 동적 계산만.
+- **푸시 알림 / 보호자 알림**: 빨강 발생 시 알림 발송은 별도 spec.
+- **이행률 통계 추세**: 월간 이행률 그래프 / 추세 분석은 별도.
+- **일간 리포트 PDF / 공유**: 본 spec은 조회 API만.
+- **시니어 다중 보호자 통합 대시보드**: 보호자 1명이 여러 시니어 보는 화면 별도.
+- **schedule 변경 이력**: 과거 schedule이 변경된 경우 과거 일자 status 재계산 룰 — 현재 schedule만으로 계산 (단순화).
+
+## 5) 설계
+### 5-1) 도메인 모델
+재사용:
+- `MedicationLog (status, taken_at, photo_object_key, ...)` — 인증 row
+- `MedicationSchedule (medicine_id, meal_slot, dosage, days_of_week, start_date, end_date)` — 처방 일정
+- `Medicine (name, total_amount, remaining_amount)` — 약
+- `User (breakfast_time, lunch_time, dinner_time, nickname)` — 시니어 mealTimes
+- `CareRelation (senior_id, caregiver_id, deleted_at)` — 보호자 관계
+
+신규 entity 없음.
+
+### 5-2) status 도출 룰
+
+#### 슬롯 단위 status (`SlotStatus`)
+| 값 | 룰 |
+|---|---|
+| `PERFECT` | log.status=TAKEN AND log.taken_at - mealTime ≤ 1시간 |
+| `DELAYED` | log.status=TAKEN AND log.taken_at - mealTime > 1시간 |
+| `MISSED` | log row 없음 또는 log.status=MISSED, **AND** 해당 일자 자정 경과 |
+| `PENDING` | log row 없음 또는 log.status=PENDING/MISSED, **AND** 해당 일자 자정 미경과 (오늘) |
+| `NOT_SCHEDULED` | 해당 슬롯에 schedule 없음 (mealTime null 또는 schedule 미할당) |
+
+비고:
+- `taken_at - mealTime`는 timezone Asia/Seoul (v0.9.7 후) 기준. 음수(정시 전 인증)는 `PERFECT`로 간주.
+- mealTime이 null이면 그 슬롯은 `NOT_SCHEDULED` (status 룰 X). 이 슬롯은 이행률 분모에서 제외.
+
+#### 일자 단위 status (`DayStatus`)
+일자 안의 모든 슬롯을 보고 1개 status로 축약:
+| 값 | 룰 |
+|---|---|
+| `PERFECT` | 모든 schedule된 슬롯이 PERFECT |
+| `DELAYED` | DELAYED 슬롯 1개 이상, MISSED 0 |
+| `MISSED` | MISSED 슬롯 1개 이상 (자정 경과 후만 발생) |
+| `PENDING` | PENDING 슬롯 1개 이상, MISSED 0, DELAYED 0 (오늘 진행 중) |
+| `FUTURE` | date > today |
+
+비고:
+- "오늘"의 status는 frontend isToday 플래그로 추가 강조 (디자인 image2의 25일). backend는 룰 그대로.
+- 시니어 mealTimes가 null이라 모든 슬롯이 `NOT_SCHEDULED`인 일자는 `PERFECT`로 간주(분모 0). 또는 별도 `EMPTY` 추가 — TBD(§8 Q1).
+
+### 5-3) API 엔드포인트
+
+| Method | Path | 설명 | 인증 | Req | Res |
+|---|---|---|---|---|---|
+| GET | `/api/v1/seniors/{seniorId}/dashboard/daily` | 일간 통합 | 본인 또는 활성 보호자 | query: `date` (LocalDate) | `DailyDashboardResponse` |
+| GET | `/api/v1/seniors/{seniorId}/dashboard/weekly` | 주간 통합 | 동일 | query: `weekStart` (LocalDate, 일요일) | `WeeklyDashboardResponse` |
+| GET | `/api/v1/seniors/{seniorId}/dashboard/monthly` | 월간 통합 | 동일 | query: `yearMonth` (YYYY-MM) | `MonthlyDashboardResponse` |
+
+#### DailyDashboardResponse (의사 코드)
+```json
+{
+  "seniorId": 16,
+  "date": "2026-05-08",
+  "dayStatus": "DELAYED",
+  "header": {
+    "seniorName": "김장군",
+    "caregiverName": "김철수",
+    "remainingDays": 3
+  },
+  "slots": [
+    {
+      "slot": "BREAKFAST",
+      "status": "PERFECT",
+      "mealTime": "08:00",
+      "takenAt": "2026-05-08T07:55:00",
+      "photoUrl": "https://kr.object.ncloudstorage.com/.../breakfast.jpg",
+      "medicines": [
+        {"medicineId": 12, "name": "지스로맥스정250mg", "dosage": "1정"},
+        {"medicineId": 13, "name": "엘도신캡슐", "dosage": "1정"}
+      ]
+    },
+    { "slot": "LUNCH", "status": "PERFECT", ... },
+    { "slot": "DINNER", "status": "PENDING", "takenAt": null, "photoUrl": null, "medicines": [...] }
+  ],
+  "medicines": [
+    {"medicineId": 12, "name": "지스로맥스정250mg", "slots": ["BREAKFAST"]},
+    {"medicineId": 14, "name": "코슈정", "slots": ["BREAKFAST", "LUNCH", "DINNER"]}
+  ]
+}
+```
+
+#### WeeklyDashboardResponse
+```json
+{
+  "seniorId": 16,
+  "weekStart": "2026-05-04",
+  "weekEnd": "2026-05-10",
+  "adherenceRate": 75.0,
+  "days": [
+    {
+      "date": "2026-05-04",
+      "dayStatus": "PERFECT",
+      "slots": [
+        {"slot": "BREAKFAST", "status": "PERFECT"},
+        {"slot": "LUNCH", "status": "PERFECT"},
+        {"slot": "DINNER", "status": "PERFECT"}
+      ]
+    },
+    ...
+    { "date": "2026-05-10", "dayStatus": "FUTURE", "slots": [] }
+  ]
+}
+```
+
+#### MonthlyDashboardResponse
+```json
+{
+  "seniorId": 16,
+  "yearMonth": "2026-05",
+  "days": [
+    { "date": "2026-05-01", "dayStatus": "PERFECT" },
+    { "date": "2026-05-02", "dayStatus": "DELAYED" },
+    ...
+    { "date": "2026-05-31", "dayStatus": "FUTURE" }
+  ]
+}
+```
+
+### 5-4) 남은 복약일 수 계산
+`DailyDashboardResponse.header.remainingDays`:
+
+```
+medicineDays(m) = floor(m.remainingAmount / dailyConsumption(m))
+dailyConsumption(m) = sum(parseInt(s.dosage)) for s in active schedules of m
+remainingDays = MIN(medicineDays(m)) for all medicines of senior with dailyConsumption > 0
+```
+
+규칙:
+- `s.dosage`에서 정수 파싱 — `"1정"` → 1, `"2정"` → 2, `"반정"` → 0(소수 미지원, §8 Q2)
+- `dailyConsumption(m) = 0`이면 그 medicine은 분자에서 제외 (남은 일수 무한)
+- 전체 medicines가 dailyConsumption=0이면 `remainingDays=null` (계산 불가)
+- 미래 schedule(start_date > today)은 제외, 종료 schedule(end_date < today) 제외
+
+### 5-5) 데이터 흐름 (daily)
+1. 권한 검증: seniorId가 userId 본인이거나 활성 care_relations
+2. 시니어 + mealTimes 조회 (`User`)
+3. 보호자 닉네임 조회 (요청자)
+4. 해당 일자 active medication_schedules 조회 (start_date ≤ date ≤ end_date)
+5. 해당 일자 medication_logs 조회 (`schedule_id IN (...)`, `target_date = date`)
+6. 약 목록 조회 (`medicineId IN (...)`)
+7. 슬롯별 status 룰 적용 + medicines 슬롯 매핑
+8. 잔여분 기반 remainingDays 계산
+9. DailyDashboardResponse 조립
+
+weekly/monthly는 4~6 단계를 기간으로 확장, status만 도출.
+
+### 5-6) 코드 영향 범위
+| 위치 | 변경 |
+|---|---|
+| `medication/controller/DashboardController.java` | **신규** — 3개 endpoint |
+| `medication/service/DashboardService.java` | **신규** — daily/weekly/monthly 도출 로직 |
+| `medication/controller/dto/DailyDashboardResponse.java` | **신규** |
+| `medication/controller/dto/WeeklyDashboardResponse.java` | **신규** |
+| `medication/controller/dto/MonthlyDashboardResponse.java` | **신규** |
+| `medication/SlotStatus.java` / `DayStatus.java` | **신규 enum** |
+| `medication/repository/MedicationLogRepository.java` | findByScheduleIdsAndTargetDateBetween 추가 |
+| `medication/repository/MedicationScheduleRepository.java` | findActiveByOwnerAndDateRange 추가 |
+| `prescription/service/PrescriptionService.java` | validateAccess 추출(공용 util)? — 옵션 |
+
+## 6) 작업 분할 (예상 PR 리스트)
+- [ ] **PR 1: daily endpoint** — `GET /seniors/{id}/dashboard/daily` + DailyDashboardResponse + slot status 룰. 단위 + E2E 테스트.
+- [ ] **PR 2: weekly endpoint** — `GET /seniors/{id}/dashboard/weekly` + 이행률 + 일자별 slots. 단위 + E2E.
+- [ ] **PR 3: monthly endpoint** — `GET /seniors/{id}/dashboard/monthly` + 캘린더용. 단위 + E2E.
+- (optional) PR 4: 공용 권한 검증 util 추출 (PrescriptionService.validateAccess와 통합).
+
+각 PR scope=`medication`, type=`feat`, ai-generated 라벨. Notion API 명세 동기화 필수.
+
+## 7) 테스트 전략
+- **단위(DashboardService)**: status 룰 분기 — PERFECT/DELAYED/MISSED/PENDING/FUTURE/NOT_SCHEDULED 모든 케이스. mealTime null 처리. dayStatus 축약 룰. remainingDays 계산.
+- **E2E**: RestAssured + 시니어/보호자 토큰 + medication_log seed → 응답 status/slots/medicines 검증. 권한 분기(보호자 외 접근 → 401/403). seniorId 미존재 → USER_NOT_FOUND.
+- 외부 연동 없음 — mock 불필요.
+
+## 8) 오픈 질문
+| # | 질문 | 선택지 | 담당/기한 |
+|---|---|---|---|
+| Q1 | 시니어 mealTimes 미설정 일자(모든 슬롯 NOT_SCHEDULED)의 dayStatus | (a) PERFECT (분모 0이라 완벽 간주) / (b) 별도 `EMPTY` enum 추가 / (c) `NOT_SCHEDULED` 그대로 사용 | @goohong / 구현 시 |
+| Q2 | dosage 파싱 — "반정"(0.5정) / "2정 반"(2.5정) 같은 소수 표기 | (a) 정수만 — 비정수면 0으로 (단순) / (b) BigDecimal로 정밀 / (c) 파싱 실패 시 fallback dailyConsumption=1 | @goohong / 구현 시 |
+| Q3 | weekly의 weekStart 요일 | (a) 일요일 (한국 캘린더 기본) / (b) 월요일 (ISO 8601) — 디자인 image2 "일/월/화/수…" 순이라 (a)로 보임 | 디자인 측 / 구현 시 |
+| Q4 | monthly 응답에 통합 status 외 추가 정보(예: 슬롯별 마커) | (a) 통합 status enum만(권장) / (b) 슬롯별 마커도 — 응답 크기 증가 | @frontend / 구현 시 |
+| Q5 | "지연" 임계값 1시간 — 시니어/보호자별 설정 가능? | (a) 시스템 상수 1h(단순) / (b) 사용자별 설정 — 후속 spec | @goohong / 후순위 |
+
+## 9) 결정 로그
+- 2026-05-08: spec 초안 작성 (status=draft).
+- 2026-05-08: status enum = PERFECT/DELAYED/MISSED/PENDING/FUTURE + 슬롯 단위 NOT_SCHEDULED. 색깔 매핑은 frontend 책임. 사용자 결정.
+- 2026-05-08: DELAYED 임계값 = mealTime 대비 1시간. 사용자 결정.
+- 2026-05-08: MISSED 기준 = 자정까지 미인증. 사용자 결정.
+- 2026-05-08: 오늘 일자 처리 = 기존 룰 그대로(PENDING). "오늘 강조"는 frontend isToday 플래그. 사용자 결정.
+- 2026-05-08: remainingDays = MIN(remainingAmount / dailyConsumption). 잔여분 자동 차감(v0.9.8) + confirm amount 입력(PR #263)에 의존.
+- 2026-05-08: MISSED 자동 전환 cron은 본 spec scope 외 — dashboard 응답 시 동적 계산.
+- 2026-05-08: 통합 endpoint 신규(daily/weekly/monthly) — 기존 logs/medicines/schedules 합성보다 N+1 호출 부담 감소 + status 룰 일관성.

--- a/src/main/java/com/ppiyaki/medication/DayStatus.java
+++ b/src/main/java/com/ppiyaki/medication/DayStatus.java
@@ -1,0 +1,13 @@
+package com.ppiyaki.medication;
+
+/**
+ * 보호자 대시보드 일자 단위 인증 상태.
+ * spec docs/features/caregiver-dashboard.md §5-2.
+ */
+public enum DayStatus {
+    PERFECT,
+    DELAYED,
+    MISSED,
+    PENDING,
+    FUTURE
+}

--- a/src/main/java/com/ppiyaki/medication/SlotStatus.java
+++ b/src/main/java/com/ppiyaki/medication/SlotStatus.java
@@ -1,0 +1,13 @@
+package com.ppiyaki.medication;
+
+/**
+ * 보호자 대시보드 슬롯 단위 인증 상태.
+ * spec docs/features/caregiver-dashboard.md §5-2.
+ */
+public enum SlotStatus {
+    PERFECT,
+    DELAYED,
+    MISSED,
+    PENDING,
+    NOT_SCHEDULED
+}

--- a/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
+++ b/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
@@ -1,0 +1,37 @@
+package com.ppiyaki.medication.controller;
+
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
+import com.ppiyaki.medication.service.DashboardService;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 보호자 대시보드 통합 조회 엔드포인트.
+ * spec docs/features/caregiver-dashboard.md.
+ */
+@RestController
+@RequestMapping("/api/v1/seniors/{seniorId}/dashboard")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    public DashboardController(final DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @GetMapping("/daily")
+    public ResponseEntity<DailyDashboardResponse> getDaily(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long seniorId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate date
+    ) {
+        return ResponseEntity.ok(dashboardService.getDaily(userId, seniorId, date));
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
+++ b/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
@@ -1,9 +1,11 @@
 package com.ppiyaki.medication.controller;
 
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
+import com.ppiyaki.medication.controller.dto.dashboard.MonthlyDashboardResponse;
 import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse;
 import com.ppiyaki.medication.service.DashboardService;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -45,5 +47,14 @@ public class DashboardController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate weekStart
     ) {
         return ResponseEntity.ok(dashboardService.getWeekly(userId, seniorId, weekStart));
+    }
+
+    @GetMapping("/monthly")
+    public ResponseEntity<MonthlyDashboardResponse> getMonthly(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long seniorId,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM") final YearMonth yearMonth
+    ) {
+        return ResponseEntity.ok(dashboardService.getMonthly(userId, seniorId, yearMonth));
     }
 }

--- a/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
+++ b/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.medication.controller;
 
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
+import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse;
 import com.ppiyaki.medication.service.DashboardService;
 import java.time.LocalDate;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,5 +36,14 @@ public class DashboardController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate date
     ) {
         return ResponseEntity.ok(dashboardService.getDaily(userId, seniorId, date));
+    }
+
+    @GetMapping("/weekly")
+    public ResponseEntity<WeeklyDashboardResponse> getWeekly(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long seniorId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate weekStart
+    ) {
+        return ResponseEntity.ok(dashboardService.getWeekly(userId, seniorId, weekStart));
     }
 }

--- a/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
+++ b/src/main/java/com/ppiyaki/medication/controller/DashboardController.java
@@ -3,6 +3,7 @@ package com.ppiyaki.medication.controller;
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
 import com.ppiyaki.medication.service.DashboardService;
 import java.time.LocalDate;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/v1/seniors/{seniorId}/dashboard")
+@ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")
 public class DashboardController {
 
     private final DashboardService dashboardService;

--- a/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/DailyDashboardResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/DailyDashboardResponse.java
@@ -1,0 +1,54 @@
+package com.ppiyaki.medication.controller.dto.dashboard;
+
+import com.ppiyaki.medication.DayStatus;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.SlotStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * 일간 대시보드 응답.
+ * spec docs/features/caregiver-dashboard.md §5-3.
+ */
+public record DailyDashboardResponse(
+        Long seniorId,
+        LocalDate date,
+        DayStatus dayStatus,
+        HeaderInfo header,
+        List<SlotInfo> slots,
+        List<MedicineSummary> medicines
+) {
+
+    public record HeaderInfo(
+            String seniorName,
+            String caregiverName,
+            Integer remainingDays
+    ) {
+    }
+
+    public record SlotInfo(
+            MealSlot slot,
+            SlotStatus status,
+            LocalTime mealTime,
+            LocalDateTime takenAt,
+            String photoUrl,
+            List<SlotMedicine> medicines
+    ) {
+    }
+
+    public record SlotMedicine(
+            Long medicineId,
+            String name,
+            String dosage
+    ) {
+    }
+
+    public record MedicineSummary(
+            Long medicineId,
+            String name,
+            List<MealSlot> slots
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/MonthlyDashboardResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/MonthlyDashboardResponse.java
@@ -1,0 +1,25 @@
+package com.ppiyaki.medication.controller.dto.dashboard;
+
+import com.ppiyaki.medication.DayStatus;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+/**
+ * 월간 대시보드 응답 — 캘린더 색상용.
+ * spec docs/features/caregiver-dashboard.md §5-3.
+ *
+ * <p>일자별 dayStatus만 포함. 슬롯/medicine/photo는 frontend가 일자 클릭 시 daily endpoint로 가져간다.
+ */
+public record MonthlyDashboardResponse(
+        Long seniorId,
+        YearMonth yearMonth,
+        List<DayEntry> days
+) {
+
+    public record DayEntry(
+            LocalDate date,
+            DayStatus dayStatus
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/WeeklyDashboardResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/dashboard/WeeklyDashboardResponse.java
@@ -1,0 +1,33 @@
+package com.ppiyaki.medication.controller.dto.dashboard;
+
+import com.ppiyaki.medication.DayStatus;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.SlotStatus;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 주간 대시보드 응답.
+ * spec docs/features/caregiver-dashboard.md §5-3.
+ */
+public record WeeklyDashboardResponse(
+        Long seniorId,
+        LocalDate weekStart,
+        LocalDate weekEnd,
+        Double adherenceRate,
+        List<DayEntry> days
+) {
+
+    public record DayEntry(
+            LocalDate date,
+            DayStatus dayStatus,
+            List<SlotMarker> slots
+    ) {
+    }
+
+    public record SlotMarker(
+            MealSlot slot,
+            SlotStatus status
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/repository/MedicationLogRepository.java
+++ b/src/main/java/com/ppiyaki/medication/repository/MedicationLogRepository.java
@@ -12,4 +12,6 @@ public interface MedicationLogRepository extends JpaRepository<MedicationLog, Lo
 
     List<MedicationLog> findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(
             final Long seniorId, final LocalDate from, final LocalDate to);
+
+    List<MedicationLog> findBySeniorIdAndTargetDate(final Long seniorId, final LocalDate targetDate);
 }

--- a/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
@@ -43,4 +43,19 @@ public interface MedicationScheduleRepository extends JpaRepository<MedicationSc
     List<MedicationSchedule> findActiveByOwnerAndDate(
             @Param("seniorId") final Long seniorId,
             @Param("date") final LocalDate date);
+
+    /**
+     * 같은 시니어의 [from, to] 기간과 겹치는 active schedule 전체.
+     * spec docs/features/caregiver-dashboard.md §5-5 weekly/monthly 흐름.
+     */
+    @Query("""
+            SELECT s FROM MedicationSchedule s
+            WHERE s.medicineId IN (SELECT m.id FROM Medicine m WHERE m.ownerId = :seniorId)
+              AND (s.startDate IS NULL OR s.startDate <= :to)
+              AND (s.endDate IS NULL OR s.endDate >= :from)
+            """)
+    List<MedicationSchedule> findActiveByOwnerAndDateRange(
+            @Param("seniorId") final Long seniorId,
+            @Param("from") final LocalDate from,
+            @Param("to") final LocalDate to);
 }

--- a/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
+++ b/src/main/java/com/ppiyaki/medication/repository/MedicationScheduleRepository.java
@@ -29,4 +29,18 @@ public interface MedicationScheduleRepository extends JpaRepository<MedicationSc
             @Param("seniorId") final Long seniorId,
             @Param("date") final LocalDate date,
             @Param("mealSlot") final MealSlot mealSlot);
+
+    /**
+     * 같은 시니어의 해당 일자 active schedule 전체 (slot 무관).
+     * spec docs/features/caregiver-dashboard.md §5-5 daily 흐름 4단계.
+     */
+    @Query("""
+            SELECT s FROM MedicationSchedule s
+            WHERE s.medicineId IN (SELECT m.id FROM Medicine m WHERE m.ownerId = :seniorId)
+              AND (s.startDate IS NULL OR s.startDate <= :date)
+              AND (s.endDate IS NULL OR s.endDate >= :date)
+            """)
+    List<MedicationSchedule> findActiveByOwnerAndDate(
+            @Param("seniorId") final Long seniorId,
+            @Param("date") final LocalDate date);
 }

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -35,14 +35,19 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 보호자 대시보드 조회 서비스.
  * spec docs/features/caregiver-dashboard.md.
+ *
+ * <p>{@link com.ppiyaki.common.storage.PhotoUrlAssembler} 의존 — 기존 MedicationLogService 패턴과 동일하게
+ * ncp.storage.bucket-name 설정 시에만 빈 등록 (default 컨텍스트 contextLoads 보호).
  */
 @Service
+@ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")
 public class DashboardService {
 
     private static final Logger log = LoggerFactory.getLogger(DashboardService.class);

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -1,0 +1,273 @@
+package com.ppiyaki.medication.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.storage.PhotoUrlAssembler;
+import com.ppiyaki.medication.DayStatus;
+import com.ppiyaki.medication.LogStatus;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationLog;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.SlotStatus;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.HeaderInfo;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.MedicineSummary;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotInfo;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotMedicine;
+import com.ppiyaki.medication.repository.MedicationLogRepository;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 보호자 대시보드 조회 서비스.
+ * spec docs/features/caregiver-dashboard.md.
+ */
+@Service
+public class DashboardService {
+
+    private static final Logger log = LoggerFactory.getLogger(DashboardService.class);
+
+    private static final long DELAY_THRESHOLD_MINUTES = 60;
+    private static final Pattern DOSAGE_INT_PATTERN = Pattern.compile("\\d+");
+
+    private final UserRepository userRepository;
+    private final CareRelationRepository careRelationRepository;
+    private final MedicationScheduleRepository scheduleRepository;
+    private final MedicationLogRepository logRepository;
+    private final MedicineRepository medicineRepository;
+    private final PhotoUrlAssembler photoUrlAssembler;
+
+    public DashboardService(
+            final UserRepository userRepository,
+            final CareRelationRepository careRelationRepository,
+            final MedicationScheduleRepository scheduleRepository,
+            final MedicationLogRepository logRepository,
+            final MedicineRepository medicineRepository,
+            final PhotoUrlAssembler photoUrlAssembler
+    ) {
+        this.userRepository = userRepository;
+        this.careRelationRepository = careRelationRepository;
+        this.scheduleRepository = scheduleRepository;
+        this.logRepository = logRepository;
+        this.medicineRepository = medicineRepository;
+        this.photoUrlAssembler = photoUrlAssembler;
+    }
+
+    @Transactional(readOnly = true)
+    public DailyDashboardResponse getDaily(final Long userId, final Long seniorId, final LocalDate date) {
+        log.info("/dashboard/daily seniorId={} date={}", seniorId, date);
+        validateAccess(userId, seniorId);
+
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        final User caregiver = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        final List<MedicationSchedule> schedules = scheduleRepository.findActiveByOwnerAndDate(seniorId, date);
+        final List<MedicationLog> logs = logRepository.findBySeniorIdAndTargetDate(seniorId, date);
+        final List<Medicine> medicines = medicineRepository.findByOwnerId(seniorId);
+
+        final Map<Long, Medicine> medicineById = new HashMap<>();
+        for (final Medicine m : medicines) {
+            medicineById.put(m.getId(), m);
+        }
+
+        final Map<Long, MedicationLog> logByScheduleId = new HashMap<>();
+        for (final MedicationLog l : logs) {
+            logByScheduleId.put(l.getScheduleId(), l);
+        }
+
+        final Map<MealSlot, List<MedicationSchedule>> schedulesBySlot = new HashMap<>();
+        for (final MedicationSchedule s : schedules) {
+            schedulesBySlot.computeIfAbsent(s.getMealSlot(), k -> new ArrayList<>()).add(s);
+        }
+
+        final LocalDate today = LocalDate.now();
+        final List<SlotInfo> slots = new ArrayList<>();
+        for (final MealSlot slot : MealSlot.values()) {
+            slots.add(buildSlotInfo(slot, senior, schedulesBySlot.get(slot), logByScheduleId, medicineById, date,
+                    today));
+        }
+
+        final DayStatus dayStatus = deriveDayStatus(slots, date, today);
+        final List<MedicineSummary> medicineSummaries = buildMedicineSummaries(schedules, medicineById);
+        final Integer remainingDays = computeRemainingDays(medicines, today);
+
+        final HeaderInfo header = new HeaderInfo(senior.getNickname(), caregiver.getNickname(), remainingDays);
+        return new DailyDashboardResponse(seniorId, date, dayStatus, header, slots, medicineSummaries);
+    }
+
+    private SlotInfo buildSlotInfo(
+            final MealSlot slot,
+            final User senior,
+            final List<MedicationSchedule> slotSchedules,
+            final Map<Long, MedicationLog> logByScheduleId,
+            final Map<Long, Medicine> medicineById,
+            final LocalDate date,
+            final LocalDate today
+    ) {
+        final LocalTime mealTime = slot.resolveTime(senior);
+        if (slotSchedules == null || slotSchedules.isEmpty() || mealTime == null) {
+            return new SlotInfo(slot, SlotStatus.NOT_SCHEDULED, mealTime, null, null, List.of());
+        }
+
+        // 슬롯 안의 schedule 중 하나라도 log가 있는지 — 같은 슬롯의 log는 동일 시점에 묶여 처리됨
+        MedicationLog representativeLog = null;
+        for (final MedicationSchedule s : slotSchedules) {
+            final MedicationLog l = logByScheduleId.get(s.getId());
+            if (l != null) {
+                representativeLog = l;
+                break;
+            }
+        }
+
+        final SlotStatus status = deriveSlotStatus(representativeLog, mealTime, date, today);
+        final LocalDateTime takenAt = representativeLog != null ? representativeLog.getTakenAt() : null;
+        final String photoUrl = representativeLog != null
+                ? photoUrlAssembler.toFullUrl(representativeLog.getPhotoObjectKey()) : null;
+
+        final List<SlotMedicine> slotMedicines = new ArrayList<>();
+        for (final MedicationSchedule s : slotSchedules) {
+            final Medicine m = medicineById.get(s.getMedicineId());
+            if (m != null) {
+                slotMedicines.add(new SlotMedicine(m.getId(), m.getName(), s.getDosage()));
+            }
+        }
+        return new SlotInfo(slot, status, mealTime, takenAt, photoUrl, slotMedicines);
+    }
+
+    private SlotStatus deriveSlotStatus(
+            final MedicationLog logRow,
+            final LocalTime mealTime,
+            final LocalDate date,
+            final LocalDate today
+    ) {
+        final boolean pastDate = date.isBefore(today);
+        if (logRow == null || logRow.getStatus() != LogStatus.TAKEN) {
+            return pastDate ? SlotStatus.MISSED : SlotStatus.PENDING;
+        }
+        final LocalDateTime mealDateTime = LocalDateTime.of(date, mealTime);
+        final long minutesLate = Duration.between(mealDateTime, logRow.getTakenAt()).toMinutes();
+        if (minutesLate <= DELAY_THRESHOLD_MINUTES) {
+            return SlotStatus.PERFECT;
+        }
+        return SlotStatus.DELAYED;
+    }
+
+    private DayStatus deriveDayStatus(final List<SlotInfo> slots, final LocalDate date, final LocalDate today) {
+        if (date.isAfter(today)) {
+            return DayStatus.FUTURE;
+        }
+        final EnumSet<SlotStatus> present = EnumSet.noneOf(SlotStatus.class);
+        for (final SlotInfo s : slots) {
+            if (s.status() != SlotStatus.NOT_SCHEDULED) {
+                present.add(s.status());
+            }
+        }
+        if (present.isEmpty()) {
+            return DayStatus.PERFECT;
+        }
+        if (present.contains(SlotStatus.MISSED)) {
+            return DayStatus.MISSED;
+        }
+        if (present.contains(SlotStatus.DELAYED)) {
+            return DayStatus.DELAYED;
+        }
+        if (present.contains(SlotStatus.PENDING)) {
+            return DayStatus.PENDING;
+        }
+        return DayStatus.PERFECT;
+    }
+
+    private List<MedicineSummary> buildMedicineSummaries(
+            final List<MedicationSchedule> schedules,
+            final Map<Long, Medicine> medicineById
+    ) {
+        final Map<Long, EnumSet<MealSlot>> slotsByMedicine = new HashMap<>();
+        for (final MedicationSchedule s : schedules) {
+            slotsByMedicine
+                    .computeIfAbsent(s.getMedicineId(), k -> EnumSet.noneOf(MealSlot.class))
+                    .add(s.getMealSlot());
+        }
+        final List<MedicineSummary> summaries = new ArrayList<>();
+        for (final Map.Entry<Long, EnumSet<MealSlot>> e : slotsByMedicine.entrySet()) {
+            final Medicine m = medicineById.get(e.getKey());
+            if (m == null) {
+                continue;
+            }
+            final List<MealSlot> orderedSlots = new ArrayList<>(e.getValue());
+            orderedSlots.sort(Comparator.comparingInt(Enum::ordinal));
+            summaries.add(new MedicineSummary(m.getId(), m.getName(), orderedSlots));
+        }
+        summaries.sort(Comparator.comparingLong(MedicineSummary::medicineId));
+        return summaries;
+    }
+
+    private Integer computeRemainingDays(final List<Medicine> medicines, final LocalDate today) {
+        Integer minDays = null;
+        for (final Medicine m : medicines) {
+            if (m.getRemainingAmount() == null) {
+                continue;
+            }
+            final List<MedicationSchedule> activeSchedules = scheduleRepository.findByMedicineId(m.getId()).stream()
+                    .filter(s -> (s.getStartDate() == null || !s.getStartDate().isAfter(today))
+                            && (s.getEndDate() == null || !s.getEndDate().isBefore(today)))
+                    .toList();
+            int dailyConsumption = 0;
+            for (final MedicationSchedule s : activeSchedules) {
+                dailyConsumption += parseDosageInt(s.getDosage());
+            }
+            if (dailyConsumption == 0) {
+                continue;
+            }
+            final int days = m.getRemainingAmount() / dailyConsumption;
+            if (minDays == null || days < minDays) {
+                minDays = days;
+            }
+        }
+        return minDays;
+    }
+
+    private int parseDosageInt(final String dosage) {
+        if (dosage == null) {
+            return 0;
+        }
+        final Matcher matcher = DOSAGE_INT_PATTERN.matcher(dosage);
+        if (matcher.find()) {
+            try {
+                return Integer.parseInt(matcher.group());
+            } catch (final NumberFormatException e) {
+                return 0;
+            }
+        }
+        return 0;
+    }
+
+    private void validateAccess(final Long userId, final Long seniorId) {
+        if (userId.equals(seniorId)) {
+            return;
+        }
+        careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(userId, seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -14,6 +14,9 @@ import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.He
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.MedicineSummary;
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotInfo;
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotMedicine;
+import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse;
+import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse.DayEntry;
+import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse.SlotMarker;
 import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
@@ -120,6 +123,112 @@ public class DashboardService {
 
         final HeaderInfo header = new HeaderInfo(senior.getNickname(), caregiver.getNickname(), remainingDays);
         return new DailyDashboardResponse(seniorId, date, dayStatus, header, slots, medicineSummaries);
+    }
+
+    @Transactional(readOnly = true)
+    public WeeklyDashboardResponse getWeekly(final Long userId, final Long seniorId, final LocalDate weekStart) {
+        log.info("/dashboard/weekly seniorId={} weekStart={}", seniorId, weekStart);
+        validateAccess(userId, seniorId);
+
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        final LocalDate weekEnd = weekStart.plusDays(6);
+        final List<MedicationSchedule> schedules = scheduleRepository.findActiveByOwnerAndDateRange(
+                seniorId, weekStart, weekEnd);
+        final List<MedicationLog> logs = logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(
+                seniorId, weekStart, weekEnd);
+
+        final Map<LocalDate, Map<Long, MedicationLog>> logsByDateAndSchedule = new HashMap<>();
+        for (final MedicationLog l : logs) {
+            logsByDateAndSchedule
+                    .computeIfAbsent(l.getTargetDate(), k -> new HashMap<>())
+                    .put(l.getScheduleId(), l);
+        }
+
+        final LocalDate today = LocalDate.now();
+        final List<DayEntry> dayEntries = new ArrayList<>();
+        int adherenceNumerator = 0;
+        int adherenceDenominator = 0;
+        for (int i = 0; i < 7; i++) {
+            final LocalDate date = weekStart.plusDays(i);
+            final List<SlotMarker> slotMarkers = new ArrayList<>();
+            final Map<Long, MedicationLog> logBySchedule = logsByDateAndSchedule.getOrDefault(date, Map.of());
+            for (final MealSlot slot : MealSlot.values()) {
+                final SlotStatus status = deriveSlotStatusForDate(slot, senior, schedules, logBySchedule, date, today);
+                slotMarkers.add(new SlotMarker(slot, status));
+                if (date.isAfter(today) || status == SlotStatus.NOT_SCHEDULED) {
+                    continue;
+                }
+                adherenceDenominator++;
+                if (status == SlotStatus.PERFECT || status == SlotStatus.DELAYED) {
+                    adherenceNumerator++;
+                }
+            }
+            final DayStatus dayStatus = deriveDayStatusFromMarkers(slotMarkers, date, today);
+            dayEntries.add(new DayEntry(date, dayStatus, slotMarkers));
+        }
+
+        final Double adherenceRate = adherenceDenominator == 0
+                ? null
+                : Math.round(((double) adherenceNumerator / adherenceDenominator) * 10000.0) / 100.0;
+
+        return new WeeklyDashboardResponse(seniorId, weekStart, weekEnd, adherenceRate, dayEntries);
+    }
+
+    private SlotStatus deriveSlotStatusForDate(
+            final MealSlot slot,
+            final User senior,
+            final List<MedicationSchedule> allSchedules,
+            final Map<Long, MedicationLog> logBySchedule,
+            final LocalDate date,
+            final LocalDate today
+    ) {
+        final LocalTime mealTime = slot.resolveTime(senior);
+        final List<MedicationSchedule> slotSchedules = allSchedules.stream()
+                .filter(s -> s.getMealSlot() == slot)
+                .filter(s -> (s.getStartDate() == null || !s.getStartDate().isAfter(date))
+                        && (s.getEndDate() == null || !s.getEndDate().isBefore(date)))
+                .toList();
+        if (slotSchedules.isEmpty() || mealTime == null) {
+            return SlotStatus.NOT_SCHEDULED;
+        }
+        MedicationLog representativeLog = null;
+        for (final MedicationSchedule s : slotSchedules) {
+            final MedicationLog l = logBySchedule.get(s.getId());
+            if (l != null) {
+                representativeLog = l;
+                break;
+            }
+        }
+        return deriveSlotStatus(representativeLog, mealTime, date, today);
+    }
+
+    private DayStatus deriveDayStatusFromMarkers(
+            final List<SlotMarker> markers, final LocalDate date, final LocalDate today
+    ) {
+        if (date.isAfter(today)) {
+            return DayStatus.FUTURE;
+        }
+        final EnumSet<SlotStatus> present = EnumSet.noneOf(SlotStatus.class);
+        for (final SlotMarker m : markers) {
+            if (m.status() != SlotStatus.NOT_SCHEDULED) {
+                present.add(m.status());
+            }
+        }
+        if (present.isEmpty()) {
+            return DayStatus.PERFECT;
+        }
+        if (present.contains(SlotStatus.MISSED)) {
+            return DayStatus.MISSED;
+        }
+        if (present.contains(SlotStatus.DELAYED)) {
+            return DayStatus.DELAYED;
+        }
+        if (present.contains(SlotStatus.PENDING)) {
+            return DayStatus.PENDING;
+        }
+        return DayStatus.PERFECT;
     }
 
     private SlotInfo buildSlotInfo(

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -14,6 +14,7 @@ import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.He
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.MedicineSummary;
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotInfo;
 import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse.SlotMedicine;
+import com.ppiyaki.medication.controller.dto.dashboard.MonthlyDashboardResponse;
 import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse;
 import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse.DayEntry;
 import com.ppiyaki.medication.controller.dto.dashboard.WeeklyDashboardResponse.SlotMarker;
@@ -28,6 +29,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -174,6 +176,45 @@ public class DashboardService {
                 : Math.round(((double) adherenceNumerator / adherenceDenominator) * 10000.0) / 100.0;
 
         return new WeeklyDashboardResponse(seniorId, weekStart, weekEnd, adherenceRate, dayEntries);
+    }
+
+    @Transactional(readOnly = true)
+    public MonthlyDashboardResponse getMonthly(final Long userId, final Long seniorId, final YearMonth yearMonth) {
+        log.info("/dashboard/monthly seniorId={} yearMonth={}", seniorId, yearMonth);
+        validateAccess(userId, seniorId);
+
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        final LocalDate monthStart = yearMonth.atDay(1);
+        final LocalDate monthEnd = yearMonth.atEndOfMonth();
+        final List<MedicationSchedule> schedules = scheduleRepository.findActiveByOwnerAndDateRange(
+                seniorId, monthStart, monthEnd);
+        final List<MedicationLog> logs = logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(
+                seniorId, monthStart, monthEnd);
+
+        final Map<LocalDate, Map<Long, MedicationLog>> logsByDateAndSchedule = new HashMap<>();
+        for (final MedicationLog l : logs) {
+            logsByDateAndSchedule
+                    .computeIfAbsent(l.getTargetDate(), k -> new HashMap<>())
+                    .put(l.getScheduleId(), l);
+        }
+
+        final LocalDate today = LocalDate.now();
+        final List<MonthlyDashboardResponse.DayEntry> dayEntries = new ArrayList<>();
+        for (int day = 1; day <= yearMonth.lengthOfMonth(); day++) {
+            final LocalDate date = yearMonth.atDay(day);
+            final List<SlotMarker> markers = new ArrayList<>();
+            final Map<Long, MedicationLog> logBySchedule = logsByDateAndSchedule.getOrDefault(date, Map.of());
+            for (final MealSlot slot : MealSlot.values()) {
+                final SlotStatus status = deriveSlotStatusForDate(slot, senior, schedules, logBySchedule, date, today);
+                markers.add(new SlotMarker(slot, status));
+            }
+            final DayStatus dayStatus = deriveDayStatusFromMarkers(markers, date, today);
+            dayEntries.add(new MonthlyDashboardResponse.DayEntry(date, dayStatus));
+        }
+
+        return new MonthlyDashboardResponse(seniorId, yearMonth, dayEntries);
     }
 
     private SlotStatus deriveSlotStatusForDate(

--- a/src/main/java/com/ppiyaki/prescription/controller/PrescriptionController.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/PrescriptionController.java
@@ -2,6 +2,7 @@ package com.ppiyaki.prescription.controller;
 
 import com.ppiyaki.prescription.PrescriptionStatus;
 import com.ppiyaki.prescription.controller.dto.CandidateDecisionRequest;
+import com.ppiyaki.prescription.controller.dto.PrescriptionConfirmRequest;
 import com.ppiyaki.prescription.controller.dto.PrescriptionCreateRequest;
 import com.ppiyaki.prescription.controller.dto.PrescriptionDetailResponse;
 import com.ppiyaki.prescription.controller.dto.PrescriptionListResponse;
@@ -82,9 +83,10 @@ public class PrescriptionController {
     @PostMapping("/{prescriptionId}/confirm")
     public ResponseEntity<PrescriptionDetailResponse> confirm(
             @AuthenticationPrincipal final Long userId,
-            @PathVariable final Long prescriptionId
+            @PathVariable final Long prescriptionId,
+            @Valid @RequestBody(required = false) final PrescriptionConfirmRequest request
     ) {
-        return ResponseEntity.ok(prescriptionService.confirm(userId, prescriptionId));
+        return ResponseEntity.ok(prescriptionService.confirm(userId, prescriptionId, request));
     }
 
     @PostMapping("/{prescriptionId}/reject")

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionConfirmRequest.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionConfirmRequest.java
@@ -1,0 +1,25 @@
+package com.ppiyaki.prescription.controller.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+/**
+ * 처방전 확정(confirm) 요청 body.
+ * spec docs/features/caregiver-dashboard.md (의존: 잔여분 의미화).
+ *
+ * <p>보호자가 confirm 시점에 약별 총량/잔여분을 함께 입력.
+ * 입력 없는 candidate는 0/0 fallback (backward compat).
+ */
+public record PrescriptionConfirmRequest(
+        @Valid List<MedicineAmountInput> medicineAmounts
+) {
+
+    public record MedicineAmountInput(
+            @NotNull Long candidateId,
+            @NotNull @Min(0) Integer totalAmount,
+            @NotNull @Min(0) Integer remainingAmount
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -24,6 +24,8 @@ import com.ppiyaki.prescription.Prescription;
 import com.ppiyaki.prescription.PrescriptionMedicineCandidate;
 import com.ppiyaki.prescription.PrescriptionStatus;
 import com.ppiyaki.prescription.controller.dto.CandidateDecisionRequest;
+import com.ppiyaki.prescription.controller.dto.PrescriptionConfirmRequest;
+import com.ppiyaki.prescription.controller.dto.PrescriptionConfirmRequest.MedicineAmountInput;
 import com.ppiyaki.prescription.controller.dto.PrescriptionDetailResponse;
 import com.ppiyaki.prescription.controller.dto.PrescriptionListResponse;
 import com.ppiyaki.prescription.controller.dto.PrescriptionMedicineAddRequest;
@@ -256,7 +258,11 @@ public class PrescriptionService {
     }
 
     @Transactional
-    public PrescriptionDetailResponse confirm(final Long userId, final Long prescriptionId) {
+    public PrescriptionDetailResponse confirm(
+            final Long userId,
+            final Long prescriptionId,
+            final PrescriptionConfirmRequest request
+    ) {
         final Prescription prescription = findPrescription(prescriptionId);
         validateMutationAccess(userId, prescription);
 
@@ -268,6 +274,12 @@ public class PrescriptionService {
             throw new BusinessException(ErrorCode.INVALID_INPUT,
                     "All candidates must be decided before confirming.");
         }
+
+        final java.util.Map<Long, MedicineAmountInput> amountByCandidate = (request == null
+                || request.medicineAmounts() == null)
+                        ? java.util.Collections.emptyMap()
+                        : request.medicineAmounts().stream()
+                                .collect(java.util.stream.Collectors.toMap(MedicineAmountInput::candidateId, m -> m));
 
         // 시니어 mealTimes 사전 검증: 슬롯 자동 생성 대상 candidate가 있는데
         // 해당 슬롯의 mealTime이 null이면 트랜잭션 변경 시작 전에 거절 (spec §3, USER_002).
@@ -301,9 +313,12 @@ public class PrescriptionService {
                     ? candidate.getMatchedItemName()
                     : candidate.getExtractedName();
 
+            final MedicineAmountInput amount = amountByCandidate.get(candidate.getId());
+            final int totalAmount = amount != null ? amount.totalAmount() : 0;
+            final int remainingAmount = amount != null ? amount.remainingAmount() : 0;
             final Medicine medicine = new Medicine(
                     prescription.getOwnerId(), prescription.getId(),
-                    name, 0, 0, itemSeq, null);
+                    name, totalAmount, remainingAmount, itemSeq, null);
             medicineRepository.save(medicine);
             candidate.linkMedicine(medicine.getId());
 

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardDailyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardDailyE2ETest.java
@@ -1,0 +1,152 @@
+package com.ppiyaki.medication.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("GET /api/v1/seniors/{seniorId}/dashboard/daily E2E")
+class DashboardDailyE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 700000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("시니어 본인 호출 — schedule 없으면 dayStatus=PERFECT, header 채워짐")
+    void daily_seniorSelf_emptySchedules() {
+        final SignupResult senior = signup("일간시니어");
+        setMealTimes(senior.userId(), LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final LocalDate today = LocalDate.now();
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/daily?date=" + today)
+                .then()
+                .statusCode(200)
+                .body("seniorId", is(senior.userId().intValue()))
+                .body("date", is(today.toString()))
+                .body("dayStatus", is("PERFECT"))
+                .body("header.seniorName", is("일간시니어"))
+                .body("header.caregiverName", is("일간시니어"))
+                .body("slots", notNullValue())
+                .body("slots[0].slot", is("BREAKFAST"))
+                .body("slots[0].status", is("NOT_SCHEDULED"))
+                .body("slots[0].mealTime", is("08:00:00"))
+                .body("medicines", notNullValue());
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자 호출 → 403 CARE_RELATION_NOT_FOUND")
+    void daily_unrelatedUser_returns403() {
+        final SignupResult senior = signup("타인접근시니어");
+        final SignupResult intruder = signup("외부인");
+        final LocalDate today = LocalDate.now();
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + intruder.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/daily?date=" + today)
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "dashdaily" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private void setMealTimes(
+            final Long userId,
+            final LocalTime breakfast,
+            final LocalTime lunch,
+            final LocalTime dinner
+    ) {
+        transactionTemplate.executeWithoutResult(status -> {
+            final User user = userRepository.findById(userId).orElseThrow();
+            setHierarchicalField(user, "breakfastTime", breakfast);
+            setHierarchicalField(user, "lunchTime", lunch);
+            setHierarchicalField(user, "dinnerTime", dinner);
+            userRepository.save(user);
+        });
+    }
+
+    private static void setHierarchicalField(final Object target, final String fieldName, final Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Field not found: " + fieldName);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
@@ -1,0 +1,107 @@
+package com.ppiyaki.medication.controller;
+
+import static org.hamcrest.Matchers.is;
+
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.time.YearMonth;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("GET /api/v1/seniors/{seniorId}/dashboard/monthly E2E")
+class DashboardMonthlyE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private static long userSequence = 900000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("시니어 본인 호출 — schedule 없으면 days 모두 PERFECT, 길이는 해당 월 일수")
+    void monthly_seniorSelf_emptySchedules() {
+        final SignupResult senior = signup("월간시니어");
+        final YearMonth ym = YearMonth.of(2026, 1);
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/monthly?yearMonth=" + ym)
+                .then()
+                .statusCode(200)
+                .body("seniorId", is(senior.userId().intValue()))
+                .body("yearMonth", is("2026-01"))
+                .body("days.size()", is(31))
+                .body("days[0].date", is("2026-01-01"))
+                .body("days[0].dayStatus", is("PERFECT"))
+                .body("days[30].date", is("2026-01-31"));
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자 호출 → 403 CARE_RELATION_NOT_FOUND")
+    void monthly_unrelatedUser_returns403() {
+        final SignupResult senior = signup("월간타인시니어");
+        final SignupResult intruder = signup("월간외부인");
+        final YearMonth ym = YearMonth.of(2026, 1);
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + intruder.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/monthly?yearMonth=" + ym)
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "dashmonthly" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
@@ -1,0 +1,151 @@
+package com.ppiyaki.medication.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "clova.ocr.secret=test-secret",
+        "clova.ocr.invoke-url=https://test.example.com/clova-ocr",
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "mfds.api.service-key=test-service-key",
+        "mfds.api.base-url=test.example.com/mfds",
+        "mfds.api.connect-timeout=2000",
+        "mfds.api.read-timeout=5000",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("GET /api/v1/seniors/{seniorId}/dashboard/weekly E2E")
+class DashboardWeeklyE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 800000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("시니어 본인 호출 — schedule 없으면 days[7] 모두 PERFECT, adherenceRate=null")
+    void weekly_seniorSelf_emptySchedules() {
+        final SignupResult senior = signup("주간시니어");
+        setMealTimes(senior.userId(), LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        final LocalDate weekStart = LocalDate.now().minusDays(7);
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/weekly?weekStart=" + weekStart)
+                .then()
+                .statusCode(200)
+                .body("seniorId", is(senior.userId().intValue()))
+                .body("weekStart", is(weekStart.toString()))
+                .body("weekEnd", is(weekStart.plusDays(6).toString()))
+                .body("adherenceRate", is(nullValue()))
+                .body("days.size()", is(7))
+                .body("days[0].dayStatus", is("PERFECT"))
+                .body("days[0].slots", notNullValue())
+                .body("days[0].slots[0].status", is("NOT_SCHEDULED"));
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자 호출 → 403 CARE_RELATION_NOT_FOUND")
+    void weekly_unrelatedUser_returns403() {
+        final SignupResult senior = signup("주간타인시니어");
+        final SignupResult intruder = signup("주간외부인");
+        final LocalDate weekStart = LocalDate.now().minusDays(7);
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + intruder.accessToken())
+                .when()
+                .get("/api/v1/seniors/" + senior.userId() + "/dashboard/weekly?weekStart=" + weekStart)
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    private SignupResult signup(final String nickname) {
+        final String loginId = "dashweekly" + userSequence++;
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, nickname))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+        return new SignupResult(userId, accessToken);
+    }
+
+    private void setMealTimes(
+            final Long userId,
+            final LocalTime breakfast,
+            final LocalTime lunch,
+            final LocalTime dinner
+    ) {
+        transactionTemplate.executeWithoutResult(status -> {
+            final User user = userRepository.findById(userId).orElseThrow();
+            setHierarchicalField(user, "breakfastTime", breakfast);
+            setHierarchicalField(user, "lunchTime", lunch);
+            setHierarchicalField(user, "dinnerTime", dinner);
+            userRepository.save(user);
+        });
+    }
+
+    private static void setHierarchicalField(final Object target, final String fieldName, final Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Field not found: " + fieldName);
+    }
+
+    private record SignupResult(Long userId, String accessToken) {
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -237,6 +237,80 @@ class DashboardServiceTest {
         assertThat(resp.medicines().get(0).slots()).containsExactly(MealSlot.BREAKFAST, MealSlot.DINNER);
     }
 
+    @Test
+    @DisplayName("weekly — 모든 일자 schedule 없음 → adherenceRate=null, days[7] 모두 PERFECT/NOT_SCHEDULED")
+    void weekly_emptySchedules() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        final LocalDate weekStart = TODAY.minusDays(7);
+        final var resp = dashboardService.getWeekly(SENIOR_ID, SENIOR_ID, weekStart);
+
+        org.assertj.core.api.Assertions.assertThat(resp.weekStart()).isEqualTo(weekStart);
+        org.assertj.core.api.Assertions.assertThat(resp.weekEnd()).isEqualTo(weekStart.plusDays(6));
+        org.assertj.core.api.Assertions.assertThat(resp.adherenceRate()).isNull();
+        org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(7);
+        org.assertj.core.api.Assertions.assertThat(resp.days()).allMatch(d -> d.dayStatus()
+                == com.ppiyaki.medication.DayStatus.PERFECT
+                && d.slots().stream().allMatch(s -> s.status() == SlotStatus.NOT_SCHEDULED));
+    }
+
+    @Test
+    @DisplayName("weekly — 과거 6일 모두 PERFECT 인증, 오늘은 PENDING → adherenceRate=100")
+    void weekly_pastPerfect_todayPending() throws Exception {
+        givenSeniorAndCaregiver();
+        final LocalTime breakfastTime = LocalTime.of(8, 0);
+        givenSeniorMealTimes(breakfastTime, null, null);
+
+        final LocalDate weekStart = TODAY.minusDays(6);
+        final MedicationSchedule schedule = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of(schedule));
+
+        final List<MedicationLog> pastLogs = new java.util.ArrayList<>();
+        for (int i = 0; i < 6; i++) {
+            final LocalDate date = weekStart.plusDays(i);
+            pastLogs.add(logOnDate(schedule.getId(), date, breakfastTime, 10));
+        }
+        // 오늘은 미인증
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(pastLogs);
+
+        final var resp = dashboardService.getWeekly(SENIOR_ID, SENIOR_ID, weekStart);
+
+        // 분모: 7일 모두 schedule된 BREAKFAST = 7. 분자: 과거 6 PERFECT = 6 (오늘 PENDING은 분자 제외).
+        org.assertj.core.api.Assertions.assertThat(resp.adherenceRate())
+                .isEqualTo(Math.round(6.0 / 7 * 10000) / 100.0);
+        org.assertj.core.api.Assertions.assertThat(resp.days().get(6).dayStatus())
+                .isEqualTo(com.ppiyaki.medication.DayStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("weekly — 미래 일자(weekStart=today+1)는 FUTURE, adherenceRate=null")
+    void weekly_futureWeek() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        final LocalDate weekStart = TODAY.plusDays(1);
+        final var resp = dashboardService.getWeekly(SENIOR_ID, SENIOR_ID, weekStart);
+
+        org.assertj.core.api.Assertions.assertThat(resp.adherenceRate()).isNull();
+        org.assertj.core.api.Assertions.assertThat(resp.days()).allMatch(d -> d.dayStatus()
+                == com.ppiyaki.medication.DayStatus.FUTURE);
+    }
+
+    private MedicationLog logOnDate(final Long scheduleId, final LocalDate date,
+            final LocalTime mealTime, final int minutesAfter) {
+        return new MedicationLog(SENIOR_ID, scheduleId, date,
+                LocalDateTime.of(date, mealTime).plusMinutes(minutesAfter), LogStatus.TAKEN, null, false, SENIOR_ID);
+    }
+
     private void givenSeniorAndCaregiver() throws Exception {
         when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(userOf(SENIOR_ID, "김장군")));
         // userId == seniorId 케이스 외에는 caregiver lookup 호출

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -289,6 +289,39 @@ class DashboardServiceTest {
     }
 
     @Test
+    @DisplayName("monthly — schedule 없으면 days 모두 PERFECT (분모 0 케이스)")
+    void monthly_emptySchedules() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        final java.time.YearMonth ym = java.time.YearMonth.of(2026, 1);
+        final var resp = dashboardService.getMonthly(SENIOR_ID, SENIOR_ID, ym);
+
+        org.assertj.core.api.Assertions.assertThat(resp.yearMonth()).isEqualTo(ym);
+        org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(31);
+        org.assertj.core.api.Assertions.assertThat(resp.days())
+                .allMatch(d -> d.dayStatus() == com.ppiyaki.medication.DayStatus.PERFECT);
+    }
+
+    @Test
+    @DisplayName("monthly — 2월(28일)은 days.size=28")
+    void monthly_february28() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        final java.time.YearMonth ym = java.time.YearMonth.of(2025, 2);
+        final var resp = dashboardService.getMonthly(SENIOR_ID, SENIOR_ID, ym);
+
+        org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(28);
+    }
+
+    @Test
     @DisplayName("weekly — 미래 일자(weekStart=today+1)는 FUTURE, adherenceRate=null")
     void weekly_futureWeek() throws Exception {
         givenSeniorAndCaregiver();

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -1,0 +1,302 @@
+package com.ppiyaki.medication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.storage.PhotoUrlAssembler;
+import com.ppiyaki.medication.DayStatus;
+import com.ppiyaki.medication.LogStatus;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationLog;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.SlotStatus;
+import com.ppiyaki.medication.controller.dto.dashboard.DailyDashboardResponse;
+import com.ppiyaki.medication.repository.MedicationLogRepository;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DashboardService.getDaily")
+class DashboardServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private CareRelationRepository careRelationRepository;
+    @Mock
+    private MedicationScheduleRepository scheduleRepository;
+    @Mock
+    private MedicationLogRepository logRepository;
+    @Mock
+    private MedicineRepository medicineRepository;
+    @Mock
+    private PhotoUrlAssembler photoUrlAssembler;
+
+    @InjectMocks
+    private DashboardService dashboardService;
+
+    private static final Long SENIOR_ID = 16L;
+    private static final Long CAREGIVER_ID = 17L;
+    private static final LocalDate TODAY = LocalDate.now();
+    private static final LocalDate YESTERDAY = TODAY.minusDays(1);
+
+    @Test
+    @DisplayName("시니어 본인은 권한 검증 통과")
+    void seniorSelf_passesAccess() throws Exception {
+        givenSeniorAndCaregiver();
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of());
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.seniorId()).isEqualTo(SENIOR_ID);
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.PERFECT);
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자는 CARE_RELATION_NOT_FOUND")
+    void unrelatedUser_throws() {
+        when(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(999L, SENIOR_ID))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> dashboardService.getDaily(999L, SENIOR_ID, TODAY))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("오늘 BREAKFAST 정시 인증 → SlotStatus.PERFECT, DayStatus.PERFECT")
+    void today_perfect() throws Exception {
+        givenSeniorAndCaregiver();
+        final LocalTime breakfastTime = LocalTime.of(8, 0);
+        givenSeniorMealTimes(breakfastTime, null, null);
+        final MedicationSchedule schedule = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schedule));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schedule));
+        final MedicationLog logRow = logOf(schedule.getId(),
+                LocalDateTime.of(TODAY, breakfastTime).plusMinutes(10), LogStatus.TAKEN);
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of(logRow));
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "타이레놀", 30)));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.PERFECT);
+        assertThat(resp.slots()).extracting(DailyDashboardResponse.SlotInfo::slot,
+                DailyDashboardResponse.SlotInfo::status)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(MealSlot.BREAKFAST, SlotStatus.PERFECT),
+                        org.assertj.core.groups.Tuple.tuple(MealSlot.LUNCH, SlotStatus.NOT_SCHEDULED),
+                        org.assertj.core.groups.Tuple.tuple(MealSlot.DINNER, SlotStatus.NOT_SCHEDULED));
+    }
+
+    @Test
+    @DisplayName("오늘 BREAKFAST 1시간 초과 지연 인증 → DELAYED")
+    void today_delayed() throws Exception {
+        givenSeniorAndCaregiver();
+        final LocalTime breakfastTime = LocalTime.of(8, 0);
+        givenSeniorMealTimes(breakfastTime, null, null);
+        final MedicationSchedule schedule = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schedule));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schedule));
+        final MedicationLog logRow = logOf(schedule.getId(),
+                LocalDateTime.of(TODAY, breakfastTime).plusMinutes(70), LogStatus.TAKEN);
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of(logRow));
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "타이레놀", 30)));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.DELAYED);
+        assertThat(resp.slots().get(0).status()).isEqualTo(SlotStatus.DELAYED);
+    }
+
+    @Test
+    @DisplayName("오늘 미인증 → PENDING (자정 미경과)")
+    void today_pending() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+        final MedicationSchedule schedule = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schedule));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schedule));
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "타이레놀", 30)));
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.PENDING);
+        assertThat(resp.slots().get(0).status()).isEqualTo(SlotStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("어제 미인증 → MISSED (자정 경과)")
+    void past_missed() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+        final MedicationSchedule schedule = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schedule));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schedule));
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "타이레놀", 30)));
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, YESTERDAY);
+
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.MISSED);
+        assertThat(resp.slots().get(0).status()).isEqualTo(SlotStatus.MISSED);
+    }
+
+    @Test
+    @DisplayName("미래 일자 → DayStatus.FUTURE")
+    void future_date() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of());
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY.plusDays(3));
+
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.FUTURE);
+    }
+
+    @Test
+    @DisplayName("remainingDays = MIN(remainingAmount / dailyConsumption)")
+    void remainingDays_min() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+
+        final MedicationSchedule schA = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");  // medA: 1정/일
+        final MedicationSchedule schB = scheduleOf(2L, 200L, MealSlot.BREAKFAST, "2정");  // medB: 2정/일
+
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schA, schB));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schA));
+        when(scheduleRepository.findByMedicineId(200L)).thenReturn(List.of(schB));
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(
+                medicineOf(100L, "약A", 30),  // 30/1 = 30
+                medicineOf(200L, "약B", 10)   // 10/2 = 5  ← MIN
+        ));
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.header().remainingDays()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("dailyConsumption=0(dosage 비정수)인 medicine은 remainingDays 분모에서 제외")
+    void remainingDays_skipsZeroConsumption() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, null);
+
+        final MedicationSchedule sch = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "반정");  // 정수 X → 0
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(sch));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(sch));
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "약A", 10)));
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.header().remainingDays()).isNull();
+    }
+
+    @Test
+    @DisplayName("medicines 슬롯 매핑 — 같은 약이 BREAKFAST+DINNER면 slots=[BREAKFAST,DINNER]")
+    void medicineSummary_aggregatesSlots() throws Exception {
+        givenSeniorAndCaregiver();
+        givenSeniorMealTimes(LocalTime.of(8, 0), null, LocalTime.of(18, 0));
+        final MedicationSchedule schA = scheduleOf(1L, 100L, MealSlot.BREAKFAST, "1정");
+        final MedicationSchedule schB = scheduleOf(2L, 100L, MealSlot.DINNER, "1정");
+        when(scheduleRepository.findActiveByOwnerAndDate(eq(SENIOR_ID), any())).thenReturn(List.of(schA, schB));
+        when(scheduleRepository.findByMedicineId(100L)).thenReturn(List.of(schA, schB));
+        when(logRepository.findBySeniorIdAndTargetDate(eq(SENIOR_ID), any())).thenReturn(List.of());
+        when(medicineRepository.findByOwnerId(SENIOR_ID)).thenReturn(List.of(medicineOf(100L, "약A", 30)));
+
+        final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
+
+        assertThat(resp.medicines()).hasSize(1);
+        assertThat(resp.medicines().get(0).slots()).containsExactly(MealSlot.BREAKFAST, MealSlot.DINNER);
+    }
+
+    private void givenSeniorAndCaregiver() throws Exception {
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(userOf(SENIOR_ID, "김장군")));
+        // userId == seniorId 케이스 외에는 caregiver lookup 호출
+    }
+
+    private void givenSeniorMealTimes(final LocalTime breakfast, final LocalTime lunch,
+            final LocalTime dinner) throws Exception {
+        final User senior = userOf(SENIOR_ID, "김장군");
+        setField(senior, "breakfastTime", breakfast);
+        setField(senior, "lunchTime", lunch);
+        setField(senior, "dinnerTime", dinner);
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(senior));
+    }
+
+    private User userOf(final Long id, final String nickname) throws Exception {
+        final java.lang.reflect.Constructor<User> ctor = User.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final User u = ctor.newInstance();
+        setField(u, "id", id);
+        setField(u, "nickname", nickname);
+        return u;
+    }
+
+    private MedicationSchedule scheduleOf(
+            final Long id, final Long medicineId, final MealSlot slot, final String dosage) throws Exception {
+        final java.lang.reflect.Constructor<MedicationSchedule> ctor = MedicationSchedule.class
+                .getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final MedicationSchedule s = ctor.newInstance();
+        setField(s, "id", id);
+        setField(s, "medicineId", medicineId);
+        setField(s, "mealSlot", slot);
+        setField(s, "dosage", dosage);
+        return s;
+    }
+
+    private MedicationLog logOf(final Long scheduleId, final LocalDateTime takenAt, final LogStatus status) {
+        final MedicationLog l = new MedicationLog(SENIOR_ID, scheduleId, takenAt.toLocalDate(),
+                takenAt, status, null, false, SENIOR_ID);
+        return l;
+    }
+
+    private Medicine medicineOf(final Long id, final String name, final int remaining) throws Exception {
+        final Medicine m = new Medicine(SENIOR_ID, null, name, 30, remaining, null, null);
+        setField(m, "id", id);
+        return m;
+    }
+
+    private static void setField(final Object target, final String fieldName, final Object value) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
@@ -91,6 +91,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()
@@ -127,6 +129,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()
@@ -154,6 +158,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()
@@ -179,6 +185,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()
@@ -205,6 +213,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when — 1차 confirm
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()
@@ -217,6 +227,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         // when — 2차 confirm (이미 CONFIRMED라 동일 호출)
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
+                .contentType(ContentType.JSON)
+                .body("{}")
                 .when()
                 .post("/api/v1/prescriptions/" + prescriptionId + "/confirm")
                 .then()


### PR DESCRIPTION
## v0.9.9

### feat
- **#271 (medication)** — 보호자 대시보드 **monthly** endpoint. \`GET /seniors/{id}/dashboard/monthly?yearMonth=YYYY-MM\` — 월 1일~말일 일자별 dayStatus만 반환 (캘린더 색상용).
- **#269 (medication)** — 보호자 대시보드 **weekly** endpoint. \`GET /seniors/{id}/dashboard/weekly?weekStart=...\` — 주간 이행률 + 일자별 dayStatus + 슬롯 마커.
- **#266 (medication)** — 보호자 대시보드 **daily** endpoint. \`GET /seniors/{id}/dashboard/daily?date=...\` — 헤더(남은 복약일 수) + 슬롯별 인증 사진 + 약 목록.
- **#263 (prescription)** — 처방전 confirm body에 medicine amount 입력. \`PrescriptionConfirmRequest\` DTO 신설. 이전엔 Medicine.totalAmount/remainingAmount=0이라 v0.9.8 자동 차감이 무력화됐는데, 본 변경으로 잔여분이 의미를 가짐.

### fix
- **#267 (medication)** — \`DashboardService\`에 \`ncp.storage.bucket-name\` ConditionalOnProperty 추가. PR #266 머지 후 contextLoads 도미노 fail 회복(hotfix).

### docs
- **#264 (medication)** — 보호자 대시보드 Feature Spec(\`docs/features/caregiver-dashboard.md\`). status enum / DELAYED 1h+ / MISSED 자정 미인증 / API 3개 / 작업 분할 / 오픈 질문 5개.

### Notion API 명세 신규/갱신
- POST \`/api/v1/prescriptions/{id}/confirm\` — Request Body 신규 추가 (#263)
- GET \`/api/v1/seniors/{id}/dashboard/daily\` — 신규 등록 (#266)
- GET \`/api/v1/seniors/{id}/dashboard/weekly\` — 신규 등록 (#269)
- GET \`/api/v1/seniors/{id}/dashboard/monthly\` — 신규 등록 (#271)

## Prod 검증 포인트 (머지 후)
- [ ] 처방전 confirm 호출 시 amount 입력 반영 → Medicine.remainingAmount > 0
- [ ] \`/dashboard/daily\` 시니어 본인 200 + header.remainingDays 계산
- [ ] \`/dashboard/weekly\` adherenceRate 계산
- [ ] \`/dashboard/monthly\` 캘린더 31일치 dayStatus
- [ ] 외부인 접근 시 403 CARE_001

🤖 Generated with [Claude Code](https://claude.com/claude-code)