### PR TITLE
feat(medication): 복약 인증 시 dosage 단위 차감 정밀화 — "2정"이면 -2

### DIFF
--- a/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
+++ b/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
@@ -11,6 +11,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +22,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "medication_schedules")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MedicationSchedule extends CreatedTimeEntity {
+
+    private static final Pattern DOSAGE_INT_PATTERN = Pattern.compile("\\d+");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -82,5 +86,24 @@ public class MedicationSchedule extends CreatedTimeEntity {
         if (endDate != null) {
             this.endDate = endDate;
         }
+    }
+
+    /**
+     * dosage 문자열에서 첫 정수를 추출. 예: "1정" → 1, "2정" → 2, "반정"/null → 0.
+     * spec docs/features/caregiver-dashboard.md §8 Q2 default 룰. 잔여분 차감 / 일일 소요량 계산 공용.
+     */
+    public static int parseDosageInt(final String dosage) {
+        if (dosage == null) {
+            return 0;
+        }
+        final Matcher matcher = DOSAGE_INT_PATTERN.matcher(dosage);
+        if (matcher.find()) {
+            try {
+                return Integer.parseInt(matcher.group());
+            } catch (final NumberFormatException e) {
+                return 0;
+            }
+        }
+        return 0;
     }
 }

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -36,8 +36,6 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -58,7 +56,6 @@ public class DashboardService {
     private static final Logger log = LoggerFactory.getLogger(DashboardService.class);
 
     private static final long DELAY_THRESHOLD_MINUTES = 60;
-    private static final Pattern DOSAGE_INT_PATTERN = Pattern.compile("\\d+");
 
     private final UserRepository userRepository;
     private final CareRelationRepository careRelationRepository;
@@ -390,7 +387,7 @@ public class DashboardService {
                     .toList();
             int dailyConsumption = 0;
             for (final MedicationSchedule s : activeSchedules) {
-                dailyConsumption += parseDosageInt(s.getDosage());
+                dailyConsumption += MedicationSchedule.parseDosageInt(s.getDosage());
             }
             if (dailyConsumption == 0) {
                 continue;
@@ -401,21 +398,6 @@ public class DashboardService {
             }
         }
         return minDays;
-    }
-
-    private int parseDosageInt(final String dosage) {
-        if (dosage == null) {
-            return 0;
-        }
-        final Matcher matcher = DOSAGE_INT_PATTERN.matcher(dosage);
-        if (matcher.find()) {
-            try {
-                return Integer.parseInt(matcher.group());
-            } catch (final NumberFormatException e) {
-                return 0;
-            }
-        }
-        return 0;
     }
 
     private void validateAccess(final Long userId, final Long seniorId) {

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -114,8 +114,10 @@ public class MedicationLogService {
         }
 
         // 새로 TAKEN으로 전환되는 케이스에만 잔여분 차감 (멱등성: 이미 TAKEN이던 row 재호출 시 중복 차감 방지).
+        // 차감 단위 = schedule.dosage 정수 파싱. 비정수("반정" 등)면 1 fallback (인증했으니 최소 1정 차감).
         if (request.status() == LogStatus.TAKEN && previousStatus != LogStatus.TAKEN) {
-            medicine.decreaseRemainingAmount();
+            final int dosageCount = MedicationSchedule.parseDosageInt(schedule.getDosage());
+            medicine.decreaseRemainingAmount(dosageCount > 0 ? dosageCount : 1);
         }
 
         // Phase 2: 사진 + status=TAKEN일 때 약 개수 AI 검증 (spec medication-log-phase2 §5-4)

--- a/src/main/java/com/ppiyaki/medicine/Medicine.java
+++ b/src/main/java/com/ppiyaki/medicine/Medicine.java
@@ -86,12 +86,13 @@ public class Medicine extends CreatedTimeEntity {
     }
 
     /**
-     * 복약 인증(TAKEN) 시점에 호출되어 잔여분을 1 차감한다.
-     * remainingAmount가 null이거나 0 이하면 변경 없음 (음수 방지).
+     * 복약 인증(TAKEN) 시점에 호출되어 잔여분을 count만큼 차감한다.
+     * remainingAmount가 null이거나 count <= 0이면 변경 없음. count가 잔여분보다 크면 0으로 clamp(음수 방지).
      */
-    public void decreaseRemainingAmount() {
-        if (remainingAmount != null && remainingAmount > 0) {
-            this.remainingAmount = remainingAmount - 1;
+    public void decreaseRemainingAmount(final int count) {
+        if (remainingAmount == null || count <= 0 || remainingAmount <= 0) {
+            return;
         }
+        this.remainingAmount = Math.max(0, remainingAmount - count);
     }
 }

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -347,6 +347,69 @@ class MedicationLogServiceTest {
     }
 
     @Test
+    @DisplayName("dosage=\"2정\"이면 잔여분 2 차감")
+    void TAKEN_시_dosage_정수_단위로_차감() throws Exception {
+        // given
+        final Medicine medicine = givenScheduleAndMedicineReturning(30, 30, "2정");
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then
+        assertThat(medicine.getRemainingAmount()).isEqualTo(28);
+    }
+
+    @Test
+    @DisplayName("dosage 정수 추출 불가(\"반정\")이면 1 fallback 차감")
+    void TAKEN_시_dosage_비정수면_1_fallback() throws Exception {
+        // given
+        final Medicine medicine = givenScheduleAndMedicineReturning(30, 30, "반정");
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then
+        assertThat(medicine.getRemainingAmount()).isEqualTo(29);
+    }
+
+    @Test
+    @DisplayName("dosage=\"3정\"이고 잔여분이 2면 0으로 clamp (음수 방지)")
+    void TAKEN_시_차감_clamp() throws Exception {
+        // given
+        final Medicine medicine = givenScheduleAndMedicineReturning(30, 2, "3정");
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then
+        assertThat(medicine.getRemainingAmount()).isEqualTo(0);
+    }
+
+    @Test
     @DisplayName("remainingAmount=0이면 차감하지 않아 음수 방지")
     void 잔여분_0이면_차감_안함() throws Exception {
         // given
@@ -368,12 +431,20 @@ class MedicationLogServiceTest {
     }
 
     private Medicine givenScheduleAndMedicineReturning(final int total, final int remaining) throws Exception {
+        return givenScheduleAndMedicineReturning(total, remaining, null);
+    }
+
+    private Medicine givenScheduleAndMedicineReturning(final int total, final int remaining,
+            final String dosage) throws Exception {
         final java.lang.reflect.Constructor<MedicationSchedule> ctor = MedicationSchedule.class
                 .getDeclaredConstructor();
         ctor.setAccessible(true);
         final MedicationSchedule schedule = ctor.newInstance();
         setField(schedule, "id", SCHEDULE_ID);
         setField(schedule, "medicineId", MEDICINE_ID);
+        if (dosage != null) {
+            setField(schedule, "dosage", dosage);
+        }
         when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(schedule));
 
         final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", total, remaining, "ITEM-1", null);


### PR DESCRIPTION
## AS-IS
v0.9.8 PR #260: 복약 인증(TAKEN) 시 \`Medicine.remainingAmount -= 1\` 단순 차감. schedule.dosage가 "2정"이면 실제론 2정 복용했는데 1만 차감 → 잔여분 부정확.

## TO-BE
- \`Medicine.decreaseRemainingAmount(int count)\` 시그니처에 단위 인자 추가
- \`MedicationLogService.upsert\`에서 schedule.dosage 정수 파싱 후 그 값만큼 차감
- 정수 추출 불가("반정", null) → 1 fallback (인증했으니 최소 1정)
- remainingAmount보다 큰 차감은 0으로 clamp (음수 방지)

### 공용 helper 추출
\`MedicationSchedule.parseDosageInt(String)\` static method로 중복 제거. DashboardService의 자체 helper 제거하고 통합.

## Test plan
- [x] dosage="2정" → -2 차감
- [x] dosage="반정" → 1 fallback
- [x] dosage="3정" + remainingAmount=2 → 0 clamp
- [x] 기존 4 케이스(신규 TAKEN, 멱등, MISSED 비차감, 0 차감 안 함) 회귀 통과
- [x] checkstyle/spotless/test 전체 통과

## 보호 영역 변경 여부
없음.

## AI 보조 작성 여부
- [x] AI 보조

Refs #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)