### PR TITLE
refactor(user): notification_settings 테이블 신설 + NotificationMode 이전·리네임

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,3 +71,25 @@ NCP_STORAGE_BUCKET_NAME=ppiyaki-prod
 # 비워두면 약물 검색·DUR 점검 비활성.
 # -----------------------------------------------------------------------------
 MFDS_API_SERVICE_KEY=your-data-go-kr-service-key
+
+# -----------------------------------------------------------------------------
+# FCM (Firebase Cloud Messaging) — 복약 알림 푸시 발송
+# 두 값에 채움. 비워두면 푸시 발송 비활성 (인앱 알림함만 동작).
+# -----------------------------------------------------------------------------
+FCM_PROJECT_ID=your-firebase-project-id
+FCM_CREDENTIALS_JSON_BASE64=your-base64-encoded-service-account-json
+
+# -----------------------------------------------------------------------------
+# CLOVA OCR (NCP) — 처방전 OCR
+# NCP 콘솔 → CLOVA OCR 도메인 생성 후 발급받은 Invoke URL + Secret Key
+# 비워두면 OCR 기능 비활성.
+# -----------------------------------------------------------------------------
+CLOVA_OCR_INVOKE_URL=your-clova-ocr-invoke-url
+CLOVA_OCR_SECRET=your-clova-ocr-secret
+
+# -----------------------------------------------------------------------------
+# OpenAI API — LLM 채팅 / 알약 식별 vision
+# https://platform.openai.com/api-keys 에서 발급
+# 비워두면 LLM 채팅·이미지 분석 기능 비활성.
+# -----------------------------------------------------------------------------
+OPENAI_API_KEY=your-openai-api-key

--- a/docs/features/medication-notification.md
+++ b/docs/features/medication-notification.md
@@ -188,9 +188,9 @@ CREATE TABLE notification_settings (
     mode VARCHAR(16) NOT NULL DEFAULT 'STANDARD',  -- 'STANDARD' | 'INTENSIVE' | 'CUSTOM'. 항목 직접 수정 시 자동 'CUSTOM'으로 전환
     dur_warning_enabled BOOLEAN NOT NULL DEFAULT TRUE,
     medication_delay_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-    medication_delay_threshold_minutes INT NOT NULL DEFAULT 30,
+    medication_delay_threshold_minutes INT NOT NULL DEFAULT 60,  -- STANDARD 프리셋 default와 일치
     family_safety_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-    family_safety_threshold_hours INT NOT NULL DEFAULT 24,
+    family_safety_threshold_hours INT NOT NULL DEFAULT 48,        -- STANDARD 프리셋 default와 일치
     medication_complete_enabled BOOLEAN NOT NULL DEFAULT FALSE,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -6,7 +6,7 @@ owner: @qkrehgus02
 scope: user
 related_issues: [248]
 related_prs: []
-last_reviewed: 2026-05-08
+last_reviewed: 2026-05-10
 ---
 
 # 보호자 온보딩 API
@@ -20,20 +20,16 @@ last_reviewed: 2026-05-08
 1. 보호자가 카카오 또는 로컬 로그인으로 회원가입한다.
 2. 온보딩 화면에서 닉네임을 입력한다.
 3. 관리할 시니어의 이름과 성별(남/여/비공개)을 입력한다. 여러 명 추가 가능.
-4. 각 시니어에 대한 돌봄 모드를 선택한다.
-   - 기본 건강 알림: 복약 확인 알림 + 일간/월간 리포트
-   - 집중 안심: 복약 완료 즉시 알림 + 30분 지연 경고 + 일간/주간/월간 리포트
-5. 완료 버튼을 누르면 온보딩이 끝나고 메인 화면으로 이동한다.
+4. 완료 버튼을 누르면 온보딩이 끝나고 메인 화면으로 이동한다. (알림 설정은 default `STANDARD` 프리셋이 자동 적용됨 — 보호자가 추후 알림 설정 페이지에서 시니어별 조정 가능)
 
 ## 3) 요구사항
 ### 기능 요구사항
-- [ ] 보호자 닉네임을 변경할 수 있다
-- [ ] 시니어를 1명 이상 등록할 수 있다 (이름, 성별 필수)
-- [ ] 성별은 MALE / FEMALE / UNKNOWN(비공개) 중 선택
-- [ ] 각 시니어마다 알림 모드(BASIC_ALERT / INTENSIVE_CARE)를 선택할 수 있다
-- [ ] 시니어 등록 시 User(SENIOR) + CareRelation + Pet이 자동 생성된다
-- [ ] 알림 모드는 시니어 엔티티에 저장된다 (이후 알림 설정에서 개별 조정 가능)
-- [ ] 온보딩은 단일 API(`POST /api/v1/onboarding`)로 처리된다
+- [x] 보호자 닉네임을 변경할 수 있다
+- [x] 시니어를 1명 이상 등록할 수 있다 (이름, 성별 필수)
+- [x] 성별은 MALE / FEMALE / UNKNOWN(비공개) 중 선택
+- [x] 시니어 등록 시 User(SENIOR) + CareRelation + Pet이 자동 생성된다
+- [x] 시니어 등록 시 default `STANDARD` 프리셋의 `notification_settings` row가 자동 생성된다 (보호자 ↔ 시니어 1:1 row)
+- [x] 온보딩은 단일 API(`POST /api/v1/onboarding`)로 처리된다
 
 ### 비기능 요구사항
 - 시니어 등록 실패 시 전체 롤백 (트랜잭션 보장)
@@ -41,21 +37,21 @@ last_reviewed: 2026-05-08
 ## 4) 범위 / 비범위 (중요)
 ### 포함
 - `POST /api/v1/onboarding` API
-- `NotificationMode` enum 신설
-- User 엔티티에 `notificationMode` 필드 추가
-- `User.createSenior()` 팩토리에 gender, notificationMode 반영
+- `User.createSenior(nickname, gender)` 팩토리
+- 시니어 생성 시 default `STANDARD` 프리셋 `notification_settings` row 자동 생성
 - 단위 테스트 + E2E 테스트
 
 ### 제외 (Out of Scope)
-- 알림 모드에 따른 실제 알림 발송 로직 (알림 기능 구현 시 연동)
-- 알림 설정 개별 조정 API
+- 알림 모드 직접 입력 (default `STANDARD`로 자동 적용. 보호자가 알림 설정 페이지에서 추후 조정. `docs/features/medication-notification.md` 책임)
+- 알림 모드에 따른 실제 알림 발송 로직 (`docs/features/medication-notification.md` 책임)
+- 알림 설정 개별 조정 API (`docs/features/medication-notification.md` 책임)
 - 온보딩 완료 여부 추적 (isOnboarded 플래그)
 
 ## 5) 설계
 ### 5-1) 도메인 모델
-- `NotificationMode` enum: `BASIC_ALERT` / `INTENSIVE_CARE`
-- `User` 엔티티에 `notificationMode` 필드 추가 (시니어에만 적용)
-- `User.createSenior()` 팩토리에 gender, notificationMode 파라미터 추가
+- `User.createSenior(nickname, gender)` 팩토리
+- `NotificationSettings` 엔티티(`com.ppiyaki.notification`)에 caregiver ↔ senior 1:1 row 자동 생성 (default `STANDARD` 프리셋)
+- ~~`NotificationMode` enum (com.ppiyaki.user)~~, ~~`User.notificationMode` 필드~~ — 2026-05-10 refactor로 제거 (알림 도메인으로 이전, §9 참조)
 
 ### 5-2) API 엔드포인트
 
@@ -72,13 +68,11 @@ last_reviewed: 2026-05-08
   "seniors": [
     {
       "nickname": "할머니",
-      "gender": "FEMALE",
-      "notificationMode": "BASIC_ALERT"
+      "gender": "FEMALE"
     },
     {
       "nickname": "할아버지",
-      "gender": "MALE",
-      "notificationMode": "INTENSIVE_CARE"
+      "gender": "MALE"
     }
   ]
 }
@@ -107,13 +101,14 @@ last_reviewed: 2026-05-08
 1. 보호자 인증 확인 (CAREGIVER role)
 2. 보호자 닉네임 업데이트
 3. 각 시니어에 대해:
-   - User(role=SENIOR, gender, notificationMode) 생성
+   - User(role=SENIOR, gender) 생성
    - CareRelation 생성
    - Pet 생성 + User에 연결
+   - `notification_settings` row 생성 (caregiver_id × senior_id, default `STANDARD` 프리셋)
 4. 전체 결과 응답
 
 ### 5-5) DB 마이그레이션
-- `users` 테이블에 `notification_mode` enum 컬럼 추가 (nullable, 시니어에만 사용)
+- ~~`users.notification_mode` 컬럼~~ — 2026-05-10 DROP (알림 모델이 N:M `notification_settings`로 이전)
 
 ## 6) 작업 분할 (예상 PR 리스트)
 - [ ] PR 1: NotificationMode + 온보딩 API + 테스트
@@ -127,3 +122,4 @@ last_reviewed: 2026-05-08
 
 ## 9) 결정 로그
 - 2026-05-08: 초안 작성. 단일 API, 알림 모드는 프리셋(나중에 개별 조정 가능), 성별 비공개=UNKNOWN.
+- 2026-05-10: **알림 모드 책임 이전** — `docs/features/medication-notification.md` spec(보호자 ↔ 시니어 N:M `notification_settings` 모델 채택)에 따라 onboarding 측에서 알림 모드를 받지 않음. `OnboardingRequest.SeniorEntry.notificationMode` 필드 제거 + `User.notificationMode` 필드 + `users.notification_mode` 컬럼 + `com.ppiyaki.user.NotificationMode` enum 제거 (enum은 `com.ppiyaki.notification`으로 이전 + `STANDARD`/`INTENSIVE`/`CUSTOM`로 리네임). 시니어 생성 시 default `STANDARD` 프리셋의 `notification_settings` row 자동 생성. 호환성 깨짐 — 프론트엔드 cut-over 필요.

--- a/src/main/java/com/ppiyaki/notification/NotificationMode.java
+++ b/src/main/java/com/ppiyaki/notification/NotificationMode.java
@@ -1,0 +1,8 @@
+package com.ppiyaki.notification;
+
+public enum NotificationMode {
+
+    STANDARD,
+    INTENSIVE,
+    CUSTOM
+}

--- a/src/main/java/com/ppiyaki/notification/NotificationSettings.java
+++ b/src/main/java/com/ppiyaki/notification/NotificationSettings.java
@@ -1,0 +1,129 @@
+package com.ppiyaki.notification;
+
+import com.ppiyaki.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "notification_settings", uniqueConstraints = @UniqueConstraint(
+                name = "uk_caregiver_senior", columnNames = {"caregiver_id", "senior_id"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationSettings extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "caregiver_id", nullable = false)
+    private Long caregiverId;
+
+    @Column(name = "senior_id", nullable = false)
+    private Long seniorId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mode", nullable = false, length = 16)
+    private NotificationMode mode;
+
+    @Column(name = "dur_warning_enabled", nullable = false)
+    private boolean durWarningEnabled;
+
+    @Column(name = "medication_delay_enabled", nullable = false)
+    private boolean medicationDelayEnabled;
+
+    @Column(name = "medication_delay_threshold_minutes", nullable = false)
+    private int medicationDelayThresholdMinutes;
+
+    @Column(name = "family_safety_enabled", nullable = false)
+    private boolean familySafetyEnabled;
+
+    @Column(name = "family_safety_threshold_hours", nullable = false)
+    private int familySafetyThresholdHours;
+
+    @Column(name = "medication_complete_enabled", nullable = false)
+    private boolean medicationCompleteEnabled;
+
+    NotificationSettings(
+            final Long caregiverId,
+            final Long seniorId,
+            final NotificationMode mode,
+            final boolean durWarningEnabled,
+            final boolean medicationDelayEnabled,
+            final int medicationDelayThresholdMinutes,
+            final boolean familySafetyEnabled,
+            final int familySafetyThresholdHours,
+            final boolean medicationCompleteEnabled
+    ) {
+        this.caregiverId = Objects.requireNonNull(caregiverId, "caregiverId must not be null");
+        this.seniorId = Objects.requireNonNull(seniorId, "seniorId must not be null");
+        this.mode = Objects.requireNonNull(mode, "mode must not be null");
+        this.durWarningEnabled = durWarningEnabled;
+        this.medicationDelayEnabled = medicationDelayEnabled;
+        this.medicationDelayThresholdMinutes = medicationDelayThresholdMinutes;
+        this.familySafetyEnabled = familySafetyEnabled;
+        this.familySafetyThresholdHours = familySafetyThresholdHours;
+        this.medicationCompleteEnabled = medicationCompleteEnabled;
+    }
+
+    public static NotificationSettings createWithStandardPreset(final Long caregiverId, final Long seniorId) {
+        return new NotificationSettings(
+                caregiverId,
+                seniorId,
+                NotificationMode.STANDARD,
+                true,
+                true,
+                60,
+                true,
+                48,
+                false
+        );
+    }
+
+    public static NotificationSettings createWithIntensivePreset(final Long caregiverId, final Long seniorId) {
+        return new NotificationSettings(
+                caregiverId,
+                seniorId,
+                NotificationMode.INTENSIVE,
+                true,
+                true,
+                30,
+                true,
+                12,
+                true
+        );
+    }
+
+    public void applyStandardPreset() {
+        this.mode = NotificationMode.STANDARD;
+        this.durWarningEnabled = true;
+        this.medicationDelayEnabled = true;
+        this.medicationDelayThresholdMinutes = 60;
+        this.familySafetyEnabled = true;
+        this.familySafetyThresholdHours = 48;
+        this.medicationCompleteEnabled = false;
+    }
+
+    public void applyIntensivePreset() {
+        this.mode = NotificationMode.INTENSIVE;
+        this.durWarningEnabled = true;
+        this.medicationDelayEnabled = true;
+        this.medicationDelayThresholdMinutes = 30;
+        this.familySafetyEnabled = true;
+        this.familySafetyThresholdHours = 12;
+        this.medicationCompleteEnabled = true;
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/repository/NotificationSettingsRepository.java
+++ b/src/main/java/com/ppiyaki/notification/repository/NotificationSettingsRepository.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.notification.repository;
+
+import com.ppiyaki.notification.NotificationSettings;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationSettingsRepository extends JpaRepository<NotificationSettings, Long> {
+
+    Optional<NotificationSettings> findByCaregiverIdAndSeniorId(final Long caregiverId, final Long seniorId);
+}

--- a/src/main/java/com/ppiyaki/user/NotificationMode.java
+++ b/src/main/java/com/ppiyaki/user/NotificationMode.java
@@ -1,6 +1,0 @@
-package com.ppiyaki.user;
-
-public enum NotificationMode {
-    BASIC_ALERT,
-    INTENSIVE_CARE
-}

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -57,10 +57,6 @@ public class User extends BaseTimeEntity {
     @Column(name = "care_mode", nullable = false)
     private CareMode careMode;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "notification_mode")
-    private NotificationMode notificationMode;
-
     @Column(name = "breakfast_time")
     private LocalTime breakfastTime;
 
@@ -96,18 +92,11 @@ public class User extends BaseTimeEntity {
                 nickname, null, dob, null);
     }
 
-    public static User createSenior(
-            final String nickname,
-            final Gender gender,
-            final NotificationMode notificationMode
-    ) {
+    public static User createSenior(final String nickname, final Gender gender) {
         Objects.requireNonNull(nickname, "nickname must not be null");
         Objects.requireNonNull(gender, "gender must not be null");
-        Objects.requireNonNull(notificationMode, "notificationMode must not be null");
-        final User user = new User(null, null, UserRole.SENIOR, AuthProvider.INVITE_ONLY,
+        return new User(null, null, UserRole.SENIOR, AuthProvider.INVITE_ONLY,
                 nickname, gender, null, null);
-        user.notificationMode = notificationMode;
-        return user;
     }
 
     public void updateNickname(final String nickname) {

--- a/src/main/java/com/ppiyaki/user/controller/dto/OnboardingRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/OnboardingRequest.java
@@ -1,7 +1,6 @@
 package com.ppiyaki.user.controller.dto;
 
 import com.ppiyaki.user.Gender;
-import com.ppiyaki.user.NotificationMode;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -15,8 +14,7 @@ public record OnboardingRequest(
 
     public record SeniorEntry(
             @NotBlank String nickname,
-            @NotNull Gender gender,
-            @NotNull NotificationMode notificationMode
+            @NotNull Gender gender
     ) {
     }
 }

--- a/src/main/java/com/ppiyaki/user/service/OnboardingService.java
+++ b/src/main/java/com/ppiyaki/user/service/OnboardingService.java
@@ -2,6 +2,8 @@ package com.ppiyaki.user.service;
 
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.notification.NotificationSettings;
+import com.ppiyaki.notification.repository.NotificationSettingsRepository;
 import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.CareRelation;
@@ -23,15 +25,18 @@ public class OnboardingService {
     private final UserRepository userRepository;
     private final CareRelationRepository careRelationRepository;
     private final PetRepository petRepository;
+    private final NotificationSettingsRepository notificationSettingsRepository;
 
     public OnboardingService(
             final UserRepository userRepository,
             final CareRelationRepository careRelationRepository,
-            final PetRepository petRepository
+            final PetRepository petRepository,
+            final NotificationSettingsRepository notificationSettingsRepository
     ) {
         this.userRepository = userRepository;
         this.careRelationRepository = careRelationRepository;
         this.petRepository = petRepository;
+        this.notificationSettingsRepository = notificationSettingsRepository;
     }
 
     @Transactional
@@ -49,12 +54,15 @@ public class OnboardingService {
 
         for (final OnboardingRequest.SeniorEntry seniorEntry : onboardingRequest.seniors()) {
             final User senior = userRepository.save(
-                    User.createSenior(seniorEntry.nickname(), seniorEntry.gender(), seniorEntry.notificationMode()));
+                    User.createSenior(seniorEntry.nickname(), seniorEntry.gender()));
 
             final Pet pet = petRepository.save(Pet.create());
             senior.assignPet(pet.getId());
 
             careRelationRepository.save(CareRelation.createLinked(senior.getId(), caregiverId));
+
+            notificationSettingsRepository.save(
+                    NotificationSettings.createWithStandardPreset(caregiverId, senior.getId()));
 
             seniorResults.add(new SeniorResult(senior.getId(), senior.getNickname(), pet.getId()));
         }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -110,6 +110,25 @@
         primary key (id)
     ) engine=InnoDB;
 
+    create table notification_settings (
+        dur_warning_enabled bit not null,
+        family_safety_enabled bit not null,
+        family_safety_threshold_hours integer not null,
+        medication_complete_enabled bit not null,
+        medication_delay_enabled bit not null,
+        medication_delay_threshold_minutes integer not null,
+        caregiver_id bigint not null,
+        created_at datetime(6),
+        id bigint not null auto_increment,
+        senior_id bigint not null,
+        updated_at datetime(6),
+        mode enum ('CUSTOM','INTENSIVE','STANDARD') not null,
+        primary key (id)
+    ) engine=InnoDB;
+
+    alter table notification_settings
+       add constraint uk_caregiver_senior unique (caregiver_id, senior_id);
+
     create table oauth_identities (
         created_at datetime(6),
         id bigint not null auto_increment,
@@ -200,7 +219,6 @@
         auth_provider enum ('INVITE_ONLY','KAKAO','LOCAL') not null,
         care_mode enum ('AUTONOMOUS','MANAGED') not null,
         gender enum ('FEMALE','MALE','OTHER','UNKNOWN'),
-        notification_mode enum ('BASIC_ALERT','INTENSIVE_CARE'),
         role enum ('CAREGIVER','SENIOR'),
         primary key (id)
     ) engine=InnoDB;

--- a/src/test/java/com/ppiyaki/user/controller/OnboardingControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/OnboardingControllerE2ETest.java
@@ -26,6 +26,8 @@ class OnboardingControllerE2ETest {
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+        jdbcTemplate.update("DELETE FROM notification_settings WHERE caregiver_id IN "
+                + "(SELECT id FROM users WHERE login_id = 'onboard_e2e')");
         jdbcTemplate.update("DELETE FROM care_relations WHERE caregiver_id IN "
                 + "(SELECT id FROM users WHERE login_id = 'onboard_e2e')");
         jdbcTemplate.update("DELETE FROM pets WHERE id IN "
@@ -66,13 +68,11 @@ class OnboardingControllerE2ETest {
                             "seniors": [
                                 {
                                     "nickname": "온보딩할머니",
-                                    "gender": "FEMALE",
-                                    "notificationMode": "BASIC_ALERT"
+                                    "gender": "FEMALE"
                                 },
                                 {
                                     "nickname": "온보딩할아버지",
-                                    "gender": "MALE",
-                                    "notificationMode": "INTENSIVE_CARE"
+                                    "gender": "MALE"
                                 }
                             ]
                         }

--- a/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
@@ -5,14 +5,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.notification.NotificationSettings;
+import com.ppiyaki.notification.repository.NotificationSettingsRepository;
 import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.Gender;
-import com.ppiyaki.user.NotificationMode;
 import com.ppiyaki.user.User;
 import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.OnboardingRequest;
@@ -40,6 +43,9 @@ class OnboardingServiceTest {
 
     @Mock
     private PetRepository petRepository;
+
+    @Mock
+    private NotificationSettingsRepository notificationSettingsRepository;
 
     @InjectMocks
     private OnboardingService onboardingService;
@@ -75,8 +81,8 @@ class OnboardingServiceTest {
         final OnboardingRequest onboardingRequest = new OnboardingRequest(
                 "보호자닉네임",
                 List.of(
-                        new SeniorEntry("할머니", Gender.FEMALE, NotificationMode.BASIC_ALERT),
-                        new SeniorEntry("할아버지", Gender.MALE, NotificationMode.INTENSIVE_CARE)
+                        new SeniorEntry("할머니", Gender.FEMALE),
+                        new SeniorEntry("할아버지", Gender.MALE)
                 )
         );
 
@@ -88,6 +94,7 @@ class OnboardingServiceTest {
         assertThat(response.responses()).hasSize(2);
         assertThat(response.responses().get(0).nickname()).isEqualTo("할머니");
         assertThat(response.responses().get(1).nickname()).isEqualTo("할아버지");
+        verify(notificationSettingsRepository, times(2)).save(any(NotificationSettings.class));
     }
 
     @Test
@@ -100,7 +107,7 @@ class OnboardingServiceTest {
 
         final OnboardingRequest onboardingRequest = new OnboardingRequest(
                 "닉네임",
-                List.of(new SeniorEntry("할머니", Gender.FEMALE, NotificationMode.BASIC_ALERT))
+                List.of(new SeniorEntry("할머니", Gender.FEMALE))
         );
 
         // when & then


### PR DESCRIPTION
## AS-IS
- `users.notification_mode` 컬럼 (시니어 row 단일 enum) — 다중 보호자 시나리오 대응 불가, Figma 보호자 알림 설정의 항목별 toggle/임계 시간 드롭다운 표현 불가
- `OnboardingRequest.SeniorEntry.notificationMode` 필드로 온보딩 시 모드 직접 입력
- `com.ppiyaki.user.NotificationMode` enum (`BASIC_ALERT`, `INTENSIVE_CARE`)

## TO-BE
- `notification_settings` 테이블 (caregiver_id × senior_id, mode + 5종 toggle/임계 컬럼)
- `OnboardingRequest`에서 `notificationMode` 필드 제거 → 시니어 생성 시 default `STANDARD` 프리셋 settings row 자동 생성
- `com.ppiyaki.notification.NotificationMode` enum (`STANDARD`, `INTENSIVE`, `CUSTOM`) — `CARE` 단어 충돌 회피
- `NotificationSettings` 엔티티 + `NotificationSettingsRepository` (STANDARD/INTENSIVE 프리셋 팩토리 + 모드 적용 메서드)

## ⚠️ 호환성 깨짐
- `POST /api/v1/onboarding` 요청 스키마 변경 — 각 senior obj에서 `notificationMode` 필드 제거
- **프론트엔드 cut-over 필요**

## DB 마이그레이션 (보호 영역)
```sql
ALTER TABLE users DROP COLUMN notification_mode;

CREATE TABLE notification_settings (
    id BIGINT PRIMARY KEY AUTO_INCREMENT,
    caregiver_id BIGINT NOT NULL,
    senior_id BIGINT NOT NULL,
    mode ENUM('STANDARD','INTENSIVE','CUSTOM') NOT NULL,
    dur_warning_enabled BIT NOT NULL,
    medication_delay_enabled BIT NOT NULL,
    medication_delay_threshold_minutes INT NOT NULL,
    family_safety_enabled BIT NOT NULL,
    family_safety_threshold_hours INT NOT NULL,
    medication_complete_enabled BIT NOT NULL,
    created_at DATETIME(6),
    updated_at DATETIME(6),
    UNIQUE KEY uk_caregiver_senior (caregiver_id, senior_id)
) ENGINE=InnoDB;
```
프로파일별 적용:
- local (ddl-auto: update): 자동 적용
- prod (ddl-auto: validate): **운영자가 직접 ALTER + CREATE 적용 후 배포**

## 부속 변경
- `docs/features/onboarding.md` 갱신 — 알림 모드 책임을 `medication-notification.md`로 이전 명시 (out-of-scope, §9 결정 로그)
- `docs/features/medication-notification.md` §5-5 SQL DEFAULT 60/48 (STANDARD 프리셋 일치)
- `.env.example` FCM + CLOVA OCR + OpenAI 누락 키 동기화

## 테스트
- `OnboardingServiceTest`: NotificationSettingsRepository mock 추가, settings save 호출 검증
- `OnboardingControllerE2ETest`: Request body에서 notificationMode 제거, 정리 SQL에 notification_settings DELETE 추가
- 모든 기존 테스트 통과 확인 (`./gradlew test`)

## AI 체크리스트
- [x] 도메인 모델 영향 명시 — `NotificationSettings` 신규, `User.notificationMode` 제거. **`docs/ai-harness/06-domain-model.md` 갱신 필요** (다음 PR 또는 follow-up)
- [x] DB 마이그레이션 명시 — schema.sql 갱신, 보호 영역
- [ ] Notion API 명세 갱신 — `POST /api/v1/onboarding` request body 변경 (notificationMode 필드 제거). **PR 머지 후 갱신 필요**
- [x] 에러 코드 — 새 코드 추가 없음 (기존 `CARE_RELATION_ROLE_MISMATCH` 재활용)
- [x] 인덱스 — `uk_caregiver_senior` UNIQUE constraint
- [x] 테스트 — 단위 + E2E 갱신
- [x] spec 갱신 — `onboarding.md` (out-of-scope), `medication-notification.md` (SQL default)

## 참고
- Feature spec: `docs/features/medication-notification.md` (PR #281 머지)
- 모델 결정: spec §9 결정 로그 (2026-05-10 — 옵션 B)
- 영향 받는 spec: `docs/features/onboarding.md` (이 PR에서 갱신), `docs/features/caregiver-dashboard.md` (PR 7에서 §8 Q5 해소 예정)

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)