### PR TITLE
feat(medication): 알림함 영속화 기반 + 조회/읽음 처리 API

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -67,6 +67,13 @@
 | `CARE_003` | 403 | Only caregivers can specify seniorId | 시니어는 seniorId 지정 불가 |
 | `CARE_004` | 403 | Senior cannot mutate prescription before caregiver review window | MANAGED 모드 0~72h 사이 시니어 본인이 처방전 변경 시도. 보호자 검토 대기 중. 72h 경과 시 fallback 통과 |
 
+### Notification
+
+| 코드 | HTTP | 메시지 | 설명 |
+|---|---|---|---|
+| `NOTIFICATION_001` | 404 | Notification not found | 알림 row 없음 |
+| `NOTIFICATION_002` | 403 | Cannot access another user's notification | 본인 알림 아님 |
+
 ## 프론트엔드 처리 가이드
 
 ```javascript

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -55,7 +55,11 @@ public enum ErrorCode {
     CHAT_PHOTO_FILE_EMPTY(HttpStatus.BAD_REQUEST, "CHAT_005", "Photo file is empty"),
     CHAT_PHOTO_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "CHAT_006",
             "Photo file type not supported (jpeg/png/webp only)"),
-    CHAT_PHOTO_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "CHAT_007", "Photo file exceeds 10MB limit");
+    CHAT_PHOTO_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "CHAT_007", "Photo file exceeds 10MB limit"),
+
+    // Notification
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_001", "Notification not found"),
+    NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_002", "Cannot access another user's notification");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ppiyaki/notification/Notification.java
+++ b/src/main/java/com/ppiyaki/notification/Notification.java
@@ -1,0 +1,98 @@
+package com.ppiyaki.notification;
+
+import com.ppiyaki.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "notifications", indexes = @Index(name = "idx_notifications_user_created", columnList = "user_id, created_at"), uniqueConstraints = @UniqueConstraint(
+                name = "uk_notifications_dedup", columnNames = {"user_id", "category", "senior_id", "target_date",
+                        "meal_slot", "schedule_id"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "senior_id")
+    private Long seniorId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 32)
+    private NotificationCategory category;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "body", nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    @Column(name = "payload", columnDefinition = "JSON")
+    private String payload;
+
+    @Column(name = "target_date")
+    private LocalDate targetDate;
+
+    @Column(name = "meal_slot", length = 16)
+    private String mealSlot;
+
+    @Column(name = "schedule_id")
+    private Long scheduleId;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    Notification(
+            final Long userId,
+            final Long seniorId,
+            final NotificationCategory category,
+            final String title,
+            final String body,
+            final String payload,
+            final LocalDate targetDate,
+            final String mealSlot,
+            final Long scheduleId
+    ) {
+        this.userId = Objects.requireNonNull(userId, "userId must not be null");
+        this.category = Objects.requireNonNull(category, "category must not be null");
+        this.title = Objects.requireNonNull(title, "title must not be null");
+        this.body = Objects.requireNonNull(body, "body must not be null");
+        this.seniorId = seniorId;
+        this.payload = payload;
+        this.targetDate = targetDate;
+        this.mealSlot = mealSlot;
+        this.scheduleId = scheduleId;
+    }
+
+    public boolean isRead() {
+        return this.readAt != null;
+    }
+
+    public void markAsRead(final LocalDateTime readAt) {
+        if (this.readAt == null) {
+            this.readAt = Objects.requireNonNull(readAt, "readAt must not be null");
+        }
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/NotificationCategory.java
+++ b/src/main/java/com/ppiyaki/notification/NotificationCategory.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.notification;
+
+public enum NotificationCategory {
+
+    MEDICATION_REMINDER,
+    MEDICATION_DELAY,
+    DUR_WARNING,
+    FAMILY_SAFETY,
+    MEDICATION_COMPLETE
+}

--- a/src/main/java/com/ppiyaki/notification/controller/NotificationController.java
+++ b/src/main/java/com/ppiyaki/notification/controller/NotificationController.java
@@ -1,0 +1,50 @@
+package com.ppiyaki.notification.controller;
+
+import com.ppiyaki.notification.NotificationCategory;
+import com.ppiyaki.notification.controller.dto.NotificationListResponse;
+import com.ppiyaki.notification.service.NotificationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    public NotificationController(final NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @GetMapping
+    public ResponseEntity<NotificationListResponse> list(
+            @AuthenticationPrincipal final Long userId,
+            @RequestParam(required = false) final NotificationCategory category,
+            @RequestParam(required = false) final Long cursor,
+            @RequestParam(required = false) final Integer size
+    ) {
+        return ResponseEntity.ok(notificationService.listForUser(userId, category, cursor, size));
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<Void> markAsRead(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long notificationId
+    ) {
+        notificationService.markAsRead(userId, notificationId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/read-all")
+    public ResponseEntity<Void> markAllAsRead(@AuthenticationPrincipal final Long userId) {
+        notificationService.markAllAsRead(userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
@@ -1,0 +1,32 @@
+package com.ppiyaki.notification.controller.dto;
+
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.NotificationCategory;
+import java.time.LocalDateTime;
+
+public record NotificationItemResponse(
+        Long id,
+        NotificationCategory category,
+        Long seniorId,
+        String title,
+        String body,
+        String payload,
+        boolean isRead,
+        LocalDateTime readAt,
+        LocalDateTime createdAt
+) {
+
+    public static NotificationItemResponse from(final Notification notification) {
+        return new NotificationItemResponse(
+                notification.getId(),
+                notification.getCategory(),
+                notification.getSeniorId(),
+                notification.getTitle(),
+                notification.getBody(),
+                notification.getPayload(),
+                notification.isRead(),
+                notification.getReadAt(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/controller/dto/NotificationListResponse.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/NotificationListResponse.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.notification.controller.dto;
+
+import java.util.List;
+
+public record NotificationListResponse(
+        List<NotificationItemResponse> responses,
+        Long nextCursor,
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
@@ -1,0 +1,36 @@
+package com.ppiyaki.notification.repository;
+
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.NotificationCategory;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("""
+            SELECT n FROM Notification n
+            WHERE n.userId = :userId
+              AND (:category IS NULL OR n.category = :category)
+              AND (:cursor IS NULL OR n.id < :cursor)
+            ORDER BY n.id DESC
+            """)
+    List<Notification> findPageByUserId(
+            @Param("userId") final Long userId,
+            @Param("category") final NotificationCategory category,
+            @Param("cursor") final Long cursor,
+            final Pageable pageable
+    );
+
+    @Modifying
+    @Query("""
+            UPDATE Notification n
+            SET n.readAt = :readAt
+            WHERE n.userId = :userId AND n.readAt IS NULL
+            """)
+    int markAllAsRead(@Param("userId") final Long userId, @Param("readAt") final LocalDateTime readAt);
+}

--- a/src/main/java/com/ppiyaki/notification/service/NotificationService.java
+++ b/src/main/java/com/ppiyaki/notification/service/NotificationService.java
@@ -1,0 +1,71 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.NotificationCategory;
+import com.ppiyaki.notification.controller.dto.NotificationItemResponse;
+import com.ppiyaki.notification.controller.dto.NotificationListResponse;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class NotificationService {
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int MAX_PAGE_SIZE = 50;
+
+    private final NotificationRepository notificationRepository;
+
+    public NotificationService(final NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public NotificationListResponse listForUser(
+            final Long userId,
+            final NotificationCategory category,
+            final Long cursor,
+            final Integer size
+    ) {
+        final int pageSize = resolvePageSize(size);
+        final List<Notification> page = notificationRepository.findPageByUserId(
+                userId, category, cursor, PageRequest.of(0, pageSize + 1));
+
+        final boolean hasNext = page.size() > pageSize;
+        final List<Notification> items = hasNext ? page.subList(0, pageSize) : page;
+        final Long nextCursor = hasNext ? items.get(items.size() - 1).getId() : null;
+
+        final List<NotificationItemResponse> responses = items.stream()
+                .map(NotificationItemResponse::from)
+                .toList();
+
+        return new NotificationListResponse(responses, nextCursor, hasNext);
+    }
+
+    @Transactional
+    public void markAsRead(final Long userId, final Long notificationId) {
+        final Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+        if (!notification.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.NOTIFICATION_FORBIDDEN);
+        }
+        notification.markAsRead(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void markAllAsRead(final Long userId) {
+        notificationRepository.markAllAsRead(userId, LocalDateTime.now());
+    }
+
+    private int resolvePageSize(final Integer size) {
+        if (size == null || size <= 0) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return Math.min(size, MAX_PAGE_SIZE);
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -129,6 +129,28 @@
     alter table notification_settings
        add constraint uk_caregiver_senior unique (caregiver_id, senior_id);
 
+    create table notifications (
+        target_date date,
+        created_at datetime(6),
+        id bigint not null auto_increment,
+        read_at datetime(6),
+        schedule_id bigint,
+        senior_id bigint,
+        updated_at datetime(6),
+        user_id bigint not null,
+        meal_slot varchar(16),
+        category varchar(32) not null,
+        title varchar(255) not null,
+        body TEXT not null,
+        payload JSON,
+        primary key (id)
+    ) engine=InnoDB;
+
+    create index idx_notifications_user_created on notifications (user_id, created_at);
+
+    alter table notifications
+       add constraint uk_notifications_dedup unique (user_id, category, senior_id, target_date, meal_slot, schedule_id);
+
     create table oauth_identities (
         created_at datetime(6),
         id bigint not null auto_increment,

--- a/src/test/java/com/ppiyaki/notification/controller/NotificationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/NotificationControllerE2ETest.java
@@ -1,0 +1,126 @@
+package com.ppiyaki.notification.controller;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class NotificationControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        jdbcTemplate.update("DELETE FROM notifications WHERE user_id IN "
+                + "(SELECT id FROM users WHERE login_id IN ('noti_owner', 'noti_other'))");
+        jdbcTemplate.update("DELETE FROM refresh_tokens WHERE user_id IN "
+                + "(SELECT id FROM users WHERE login_id IN ('noti_owner', 'noti_other'))");
+        jdbcTemplate.update("DELETE FROM users WHERE login_id IN ('noti_owner', 'noti_other')");
+    }
+
+    @Test
+    @DisplayName("본인 알림함 조회 + 단건 읽음 + 모두 읽음 + 타인 알림 접근 시 403")
+    void notification_flow() {
+        // given — 두 사용자 회원가입
+        final String ownerToken = signupAndGetToken("noti_owner");
+        final String otherToken = signupAndGetToken("noti_other");
+        final Long ownerId = jdbcTemplate.queryForObject(
+                "SELECT id FROM users WHERE login_id = 'noti_owner'", Long.class);
+        final Long otherId = jdbcTemplate.queryForObject(
+                "SELECT id FROM users WHERE login_id = 'noti_other'", Long.class);
+
+        // owner 알림 2건 + other 알림 1건 INSERT
+        jdbcTemplate.update("INSERT INTO notifications "
+                + "(user_id, category, title, body, created_at) "
+                + "VALUES (?, 'MEDICATION_REMINDER', '아침 약 복용', '아침 약 드세요', NOW(6))", ownerId);
+        jdbcTemplate.update("INSERT INTO notifications "
+                + "(user_id, category, title, body, created_at) "
+                + "VALUES (?, 'MEDICATION_REMINDER', '저녁 약 복용', '저녁 약 드세요', NOW(6))", ownerId);
+        jdbcTemplate.update("INSERT INTO notifications "
+                + "(user_id, category, title, body, created_at) "
+                + "VALUES (?, 'MEDICATION_REMINDER', 'other notification', 'other body', NOW(6))", otherId);
+
+        final Long ownerNotificationId = jdbcTemplate.queryForObject(
+                "SELECT id FROM notifications WHERE user_id = ? ORDER BY id ASC LIMIT 1",
+                Long.class, ownerId);
+        final Long otherNotificationId = jdbcTemplate.queryForObject(
+                "SELECT id FROM notifications WHERE user_id = ?", Long.class, otherId);
+
+        // when & then — owner가 자기 알림 2건만 조회
+        RestAssured.given()
+                .header("Authorization", "Bearer " + ownerToken)
+                .when()
+                .get("/api/v1/notifications")
+                .then()
+                .statusCode(200)
+                .body("responses.size()", greaterThanOrEqualTo(2))
+                .body("hasNext", is(false));
+
+        // 단건 읽음
+        RestAssured.given()
+                .header("Authorization", "Bearer " + ownerToken)
+                .when()
+                .patch("/api/v1/notifications/" + ownerNotificationId + "/read")
+                .then()
+                .statusCode(204);
+
+        final Integer readCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE id = ? AND read_at IS NOT NULL",
+                Integer.class, ownerNotificationId);
+        assert readCount != null && readCount == 1;
+
+        // 모두 읽음
+        RestAssured.given()
+                .header("Authorization", "Bearer " + ownerToken)
+                .when()
+                .post("/api/v1/notifications/read-all")
+                .then()
+                .statusCode(204);
+
+        final Integer ownerUnread = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notifications WHERE user_id = ? AND read_at IS NULL",
+                Integer.class, ownerId);
+        assert ownerUnread != null && ownerUnread == 0;
+
+        // 타인 알림 PATCH 시 403 NOTIFICATION_FORBIDDEN
+        RestAssured.given()
+                .header("Authorization", "Bearer " + ownerToken)
+                .when()
+                .patch("/api/v1/notifications/" + otherNotificationId + "/read")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("NOTIFICATION_002"));
+    }
+
+    private String signupAndGetToken(final String loginId) {
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "pass1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, loginId))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("accessToken");
+    }
+}

--- a/src/test/java/com/ppiyaki/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/NotificationServiceTest.java
@@ -1,0 +1,125 @@
+package com.ppiyaki.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.controller.dto.NotificationListResponse;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("repo가 pageSize+1개 반환하면 hasNext=true + nextCursor는 마지막 표시 row id")
+    void listForUser_hasNext() {
+        // given — pageSize=2, repo returns 3
+        final Notification first = mock(Notification.class);
+        final Notification second = mock(Notification.class);
+        given(second.getId()).willReturn(100L);
+        final Notification third = mock(Notification.class);
+        given(notificationRepository.findPageByUserId(any(), any(), any(), any(Pageable.class)))
+                .willReturn(List.of(first, second, third));
+
+        // when
+        final NotificationListResponse response = notificationService.listForUser(7L, null, null, 2);
+
+        // then
+        assertThat(response.responses()).hasSize(2);
+        assertThat(response.hasNext()).isTrue();
+        assertThat(response.nextCursor()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("repo가 pageSize 이하 반환하면 hasNext=false + nextCursor=null")
+    void listForUser_lastPage() {
+        // given
+        final Notification only = mock(Notification.class);
+        given(notificationRepository.findPageByUserId(any(), any(), any(), any(Pageable.class)))
+                .willReturn(List.of(only));
+
+        // when
+        final NotificationListResponse response = notificationService.listForUser(7L, null, null, 20);
+
+        // then
+        assertThat(response.responses()).hasSize(1);
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("본인 알림 markAsRead 시 entity.markAsRead 호출")
+    void markAsRead_owner_success() {
+        // given
+        final Notification notification = mock(Notification.class);
+        given(notification.getUserId()).willReturn(7L);
+        given(notificationRepository.findById(1L)).willReturn(Optional.of(notification));
+
+        // when
+        notificationService.markAsRead(7L, 1L);
+
+        // then
+        verify(notification).markAsRead(any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("타인 알림 markAsRead 시 NOTIFICATION_FORBIDDEN")
+    void markAsRead_nonOwner_throwsForbidden() {
+        // given — notification.userId=7, requester=99
+        final Notification notification = mock(Notification.class);
+        given(notification.getUserId()).willReturn(7L);
+        given(notificationRepository.findById(1L)).willReturn(Optional.of(notification));
+
+        // when & then
+        assertThatThrownBy(() -> notificationService.markAsRead(99L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> assertThat(((BusinessException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.NOTIFICATION_FORBIDDEN));
+    }
+
+    @Test
+    @DisplayName("미존재 알림 markAsRead 시 NOTIFICATION_NOT_FOUND")
+    void markAsRead_notFound() {
+        // given
+        given(notificationRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> notificationService.markAsRead(7L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> assertThat(((BusinessException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.NOTIFICATION_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("markAllAsRead는 repository.markAllAsRead 호출")
+    void markAllAsRead_callsRepository() {
+        // when
+        notificationService.markAllAsRead(7L);
+
+        // then
+        verify(notificationRepository).markAllAsRead(anyLong(), any(LocalDateTime.class));
+    }
+}


### PR DESCRIPTION
## AS-IS
- 알림함(인앱 알림 리스트) 자체가 미구현. `notifications` 테이블 없음, 알림 row를 영속화할 곳 없음.
- 백엔드는 알림 발송 조회/읽음 처리 API 미제공.

## TO-BE
복약 알림 Feature Spec(`docs/features/medication-notification.md`) §6 PR 3 작업.

알림함 영속화 기반 구축. **발송 트리거는 후속 PR(5~10)** 에서 본 PR의 영속화 + 조회 API 위에 구현.

### 신규 도메인
- `com.ppiyaki.notification.Notification` 엔티티
- `com.ppiyaki.notification.NotificationCategory` enum (5종)
- `com.ppiyaki.notification.repository.NotificationRepository` (cursor 페이징 + markAllAsRead bulk update)
- `com.ppiyaki.notification.service.NotificationService`
- `com.ppiyaki.notification.controller.NotificationController` + DTO

### 신규 API
| Method | Path | 설명 | 인증 |
|---|---|---|---|
| GET | `/api/v1/notifications` | 본인 알림 리스트 (cursor 페이징 + category 필터) | 필수 |
| PATCH | `/api/v1/notifications/{id}/read` | 단건 읽음 | 필수 (본인) |
| POST | `/api/v1/notifications/read-all` | 모두 읽음 | 필수 |

### 신규 에러 코드
- `NOTIFICATION_001` (404): Notification not found
- `NOTIFICATION_002` (403): Cannot access another user's notification

## DB 마이그레이션 (보호 영역)
```sql
CREATE TABLE notifications (
    id BIGINT PRIMARY KEY AUTO_INCREMENT,
    user_id BIGINT NOT NULL,
    senior_id BIGINT,
    category VARCHAR(32) NOT NULL,
    title VARCHAR(255) NOT NULL,
    body TEXT NOT NULL,
    payload JSON,
    target_date DATE,
    meal_slot VARCHAR(16),
    schedule_id BIGINT,
    read_at DATETIME(6),
    created_at DATETIME(6),
    updated_at DATETIME(6),
    UNIQUE KEY uk_notifications_dedup (user_id, category, senior_id, target_date, meal_slot, schedule_id)
) ENGINE=InnoDB;
CREATE INDEX idx_notifications_user_created ON notifications (user_id, created_at);
```

→ release 시점에 prod에 적용. local은 ddl-auto: update로 자동.

## 테스트
- 단위 (NotificationServiceTest, 6 케이스): cursor 페이징 hasNext, markAsRead 본인/타인/미존재, markAllAsRead repository 호출
- E2E (NotificationControllerE2ETest): 조회 + 단건 읽음 + 모두 읽음 + 타인 알림 PATCH 403 멀티 시나리오 1건

## 비범위
- FCM 푸시 발송 — PR 4
- 알림 발송 트리거 (시니어 복약시간/보호자 미복약/DUR/가족안전망/복약완료) — PR 5~10
- 보호자 알림 설정 조회/갱신 API — PR 5
- payload 필드 활용 (scheduleId/prescriptionId 등 메타) — 발송 PR에서

## AI 체크리스트
- [x] 도메인 모델 영향 — `Notification` 엔티티 신설. **`docs/ai-harness/06-domain-model.md` 갱신 follow-up 필요**
- [x] DB 마이그레이션 — schema.sql 갱신, 보호 영역
- [x] 에러 코드 — `NOTIFICATION_001/002` 추가, `docs/error-codes.md` 갱신
- [x] 인덱스 — `idx_notifications_user_created`, `uk_notifications_dedup`
- [ ] **Notion API 명세 3건 등록 — PR 머지 후 follow-up**
- [x] 단위 + E2E 테스트
- [x] 보호자/시니어 권한 검증 (본인 row만 조회/읽음)

## 참고
- spec: `docs/features/medication-notification.md`
- PR #283 (refactor + notification_settings 신설) 위에서 작업

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)