### PR TITLE
feat(medication): device token API + FCM PushSender 어댑터

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -80,6 +80,8 @@ jobs:
               -e OPENAI_API_KEY='${{ secrets.OPENAI_API_KEY }}' \
               -e OPENAI_TEXT_MODEL='gpt-5.4-nano' \
               -e OPENAI_VISION_MODEL='gpt-5.4-mini' \
+              -e FCM_PROJECT_ID='${{ secrets.FCM_PROJECT_ID }}' \
+              -e FCM_CREDENTIALS_JSON_BASE64='${{ secrets.FCM_CREDENTIALS_JSON_BASE64 }}' \
               ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
             
             echo "Cleaning up old images..."

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation platform('org.springframework.ai:spring-ai-bom:1.1.4')
     implementation 'org.springframework.ai:spring-ai-starter-model-openai'
     implementation 'com.drewnoakes:metadata-extractor:2.19.0'
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -73,6 +73,8 @@
 |---|---|---|---|
 | `NOTIFICATION_001` | 404 | Notification not found | 알림 row 없음 |
 | `NOTIFICATION_002` | 403 | Cannot access another user's notification | 본인 알림 아님 |
+| `NOTIFICATION_003` | 404 | Device token not found | 디바이스 토큰 row 없음 |
+| `NOTIFICATION_004` | 403 | Cannot access another user's device token | 본인 디바이스 토큰 아님 |
 
 ## 프론트엔드 처리 가이드
 

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -59,7 +59,9 @@ public enum ErrorCode {
 
     // Notification
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_001", "Notification not found"),
-    NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_002", "Cannot access another user's notification");
+    NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_002", "Cannot access another user's notification"),
+    DEVICE_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_003", "Device token not found"),
+    DEVICE_TOKEN_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_004", "Cannot access another user's device token");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ppiyaki/notification/DevicePlatform.java
+++ b/src/main/java/com/ppiyaki/notification/DevicePlatform.java
@@ -1,6 +1,7 @@
-package com.ppiyaki.medication;
+package com.ppiyaki.notification;
 
 public enum DevicePlatform {
+
     IOS,
     ANDROID,
     WEB

--- a/src/main/java/com/ppiyaki/notification/DeviceToken.java
+++ b/src/main/java/com/ppiyaki/notification/DeviceToken.java
@@ -1,4 +1,4 @@
-package com.ppiyaki.medication;
+package com.ppiyaki.notification;
 
 import com.ppiyaki.common.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,16 +41,29 @@ public class DeviceToken extends BaseTimeEntity {
     @Column(name = "last_seen_at")
     private LocalDateTime lastSeenAt;
 
-    public DeviceToken(
+    DeviceToken(
             final Long userId,
             final String token,
             final DevicePlatform platform,
-            final Boolean isActive,
-            final LocalDateTime lastSeenAt) {
-        this.userId = userId;
-        this.token = token;
-        this.platform = platform;
-        this.isActive = isActive;
+            final LocalDateTime lastSeenAt
+    ) {
+        this.userId = Objects.requireNonNull(userId, "userId must not be null");
+        this.token = Objects.requireNonNull(token, "token must not be null");
+        this.platform = Objects.requireNonNull(platform, "platform must not be null");
+        this.isActive = true;
         this.lastSeenAt = lastSeenAt;
+    }
+
+    public static DeviceToken register(final Long userId, final String token, final DevicePlatform platform) {
+        return new DeviceToken(userId, token, platform, LocalDateTime.now());
+    }
+
+    public void reactivate(final LocalDateTime lastSeenAt) {
+        this.isActive = true;
+        this.lastSeenAt = Objects.requireNonNull(lastSeenAt, "lastSeenAt must not be null");
+    }
+
+    public void deactivate() {
+        this.isActive = false;
     }
 }

--- a/src/main/java/com/ppiyaki/notification/controller/DeviceTokenController.java
+++ b/src/main/java/com/ppiyaki/notification/controller/DeviceTokenController.java
@@ -1,0 +1,44 @@
+package com.ppiyaki.notification.controller;
+
+import com.ppiyaki.notification.controller.dto.DeviceTokenRegisterRequest;
+import com.ppiyaki.notification.controller.dto.DeviceTokenResponse;
+import com.ppiyaki.notification.service.DeviceTokenService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users/me/devices")
+public class DeviceTokenController {
+
+    private final DeviceTokenService deviceTokenService;
+
+    public DeviceTokenController(final DeviceTokenService deviceTokenService) {
+        this.deviceTokenService = deviceTokenService;
+    }
+
+    @PostMapping
+    public ResponseEntity<DeviceTokenResponse> register(
+            @AuthenticationPrincipal final Long userId,
+            @Valid @RequestBody final DeviceTokenRegisterRequest request
+    ) {
+        final DeviceTokenResponse response = deviceTokenService.register(userId, request.token(), request.platform());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @DeleteMapping("/{tokenId}")
+    public ResponseEntity<Void> deactivate(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long tokenId
+    ) {
+        deviceTokenService.deactivate(userId, tokenId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/controller/dto/DeviceTokenRegisterRequest.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/DeviceTokenRegisterRequest.java
@@ -1,0 +1,11 @@
+package com.ppiyaki.notification.controller.dto;
+
+import com.ppiyaki.notification.DevicePlatform;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record DeviceTokenRegisterRequest(
+        @NotBlank String token,
+        @NotNull DevicePlatform platform
+) {
+}

--- a/src/main/java/com/ppiyaki/notification/controller/dto/DeviceTokenResponse.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/DeviceTokenResponse.java
@@ -1,0 +1,19 @@
+package com.ppiyaki.notification.controller.dto;
+
+import com.ppiyaki.notification.DevicePlatform;
+import com.ppiyaki.notification.DeviceToken;
+
+public record DeviceTokenResponse(
+        Long tokenId,
+        DevicePlatform platform,
+        boolean isActive
+) {
+
+    public static DeviceTokenResponse from(final DeviceToken deviceToken) {
+        return new DeviceTokenResponse(
+                deviceToken.getId(),
+                deviceToken.getPlatform(),
+                deviceToken.getIsActive()
+        );
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/push/FcmProperties.java
+++ b/src/main/java/com/ppiyaki/notification/push/FcmProperties.java
@@ -1,0 +1,15 @@
+package com.ppiyaki.notification.push;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "fcm")
+public record FcmProperties(
+        String projectId,
+        String credentialsJsonBase64
+) {
+
+    public boolean isEnabled() {
+        return projectId != null && !projectId.isBlank()
+                && credentialsJsonBase64 != null && !credentialsJsonBase64.isBlank();
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/push/FcmPushSender.java
+++ b/src/main/java/com/ppiyaki/notification/push/FcmPushSender.java
@@ -1,0 +1,46 @@
+package com.ppiyaki.notification.push;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FcmPushSender implements PushSender {
+
+    private static final Logger log = LoggerFactory.getLogger(FcmPushSender.class);
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    public FcmPushSender(final FirebaseMessaging firebaseMessaging) {
+        this.firebaseMessaging = firebaseMessaging;
+    }
+
+    @Override
+    public PushSendResult send(final String deviceToken, final PushPayload payload) {
+        final Message.Builder builder = Message.builder()
+                .setToken(deviceToken)
+                .setNotification(Notification.builder()
+                        .setTitle(payload.title())
+                        .setBody(payload.body())
+                        .build());
+        if (payload.data() != null) {
+            payload.data().forEach(builder::putData);
+        }
+        try {
+            final String messageId = firebaseMessaging.send(builder.build());
+            log.info("FCM sent (messageId={}, title={})", messageId, payload.title());
+            return PushSendResult.ok();
+        } catch (final FirebaseMessagingException exception) {
+            final MessagingErrorCode errorCode = exception.getMessagingErrorCode();
+            if (errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
+                log.warn("FCM token invalid (errorCode={}, token={})", errorCode, deviceToken);
+                return PushSendResult.tokenInvalid(exception.getMessage());
+            }
+            log.error("FCM send failed (errorCode={}, token={})", errorCode, deviceToken, exception);
+            return PushSendResult.failed(exception.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/push/NoOpPushSender.java
+++ b/src/main/java/com/ppiyaki/notification/push/NoOpPushSender.java
@@ -1,0 +1,15 @@
+package com.ppiyaki.notification.push;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NoOpPushSender implements PushSender {
+
+    private static final Logger log = LoggerFactory.getLogger(NoOpPushSender.class);
+
+    @Override
+    public PushSendResult send(final String deviceToken, final PushPayload payload) {
+        log.debug("FCM disabled — skip push (token={}, title={})", deviceToken, payload.title());
+        return PushSendResult.ok();
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/push/PushConfig.java
+++ b/src/main/java/com/ppiyaki/notification/push/PushConfig.java
@@ -1,0 +1,46 @@
+package com.ppiyaki.notification.push;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(FcmProperties.class)
+public class PushConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(PushConfig.class);
+
+    @Bean
+    public PushSender pushSender(final FcmProperties properties) {
+        if (!properties.isEnabled()) {
+            log.warn("FCM disabled — fcm.project-id or fcm.credentials-json-base64 missing. Push will be no-op.");
+            return new NoOpPushSender();
+        }
+        try {
+            final byte[] credentialsJson = Base64.getDecoder().decode(
+                    properties.credentialsJsonBase64().getBytes(StandardCharsets.UTF_8));
+            final GoogleCredentials credentials = GoogleCredentials.fromStream(
+                    new ByteArrayInputStream(credentialsJson));
+            final FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(credentials)
+                    .setProjectId(properties.projectId())
+                    .build();
+            final FirebaseApp app = FirebaseApp.getApps().isEmpty()
+                    ? FirebaseApp.initializeApp(options)
+                    : FirebaseApp.getInstance();
+            return new FcmPushSender(FirebaseMessaging.getInstance(app));
+        } catch (final Exception exception) {
+            log.error("FCM initialization failed — fallback to no-op push sender", exception);
+            return new NoOpPushSender();
+        }
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/push/PushPayload.java
+++ b/src/main/java/com/ppiyaki/notification/push/PushPayload.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.notification.push;
+
+import java.util.Map;
+
+public record PushPayload(
+        String title,
+        String body,
+        Map<String, String> data
+) {
+}

--- a/src/main/java/com/ppiyaki/notification/push/PushSendResult.java
+++ b/src/main/java/com/ppiyaki/notification/push/PushSendResult.java
@@ -1,0 +1,20 @@
+package com.ppiyaki.notification.push;
+
+public record PushSendResult(
+        boolean success,
+        boolean tokenInvalid,
+        String errorMessage
+) {
+
+    public static PushSendResult ok() {
+        return new PushSendResult(true, false, null);
+    }
+
+    public static PushSendResult tokenInvalid(final String message) {
+        return new PushSendResult(false, true, message);
+    }
+
+    public static PushSendResult failed(final String message) {
+        return new PushSendResult(false, false, message);
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/push/PushSender.java
+++ b/src/main/java/com/ppiyaki/notification/push/PushSender.java
@@ -1,0 +1,6 @@
+package com.ppiyaki.notification.push;
+
+public interface PushSender {
+
+    PushSendResult send(final String deviceToken, final PushPayload payload);
+}

--- a/src/main/java/com/ppiyaki/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/ppiyaki/notification/repository/DeviceTokenRepository.java
@@ -1,0 +1,13 @@
+package com.ppiyaki.notification.repository;
+
+import com.ppiyaki.notification.DeviceToken;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+
+    Optional<DeviceToken> findByToken(final String token);
+
+    List<DeviceToken> findByUserIdAndIsActiveTrue(final Long userId);
+}

--- a/src/main/java/com/ppiyaki/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/ppiyaki/notification/service/DeviceTokenService.java
@@ -1,0 +1,42 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.notification.DevicePlatform;
+import com.ppiyaki.notification.DeviceToken;
+import com.ppiyaki.notification.controller.dto.DeviceTokenResponse;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DeviceTokenService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public DeviceTokenService(final DeviceTokenRepository deviceTokenRepository) {
+        this.deviceTokenRepository = deviceTokenRepository;
+    }
+
+    @Transactional
+    public DeviceTokenResponse register(final Long userId, final String token, final DevicePlatform platform) {
+        final DeviceToken saved = deviceTokenRepository.findByToken(token)
+                .map(existing -> {
+                    existing.reactivate(LocalDateTime.now());
+                    return existing;
+                })
+                .orElseGet(() -> deviceTokenRepository.save(DeviceToken.register(userId, token, platform)));
+        return DeviceTokenResponse.from(saved);
+    }
+
+    @Transactional
+    public void deactivate(final Long userId, final Long tokenId) {
+        final DeviceToken deviceToken = deviceTokenRepository.findById(tokenId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DEVICE_TOKEN_NOT_FOUND));
+        if (!deviceToken.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.DEVICE_TOKEN_FORBIDDEN);
+        }
+        deviceToken.deactivate();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,3 +60,7 @@ mfds:
 openai:
   text-model: ${OPENAI_TEXT_MODEL:gpt-5.4-nano}
   vision-model: ${OPENAI_VISION_MODEL:gpt-5.4-mini}
+
+fcm:
+  project-id: ${FCM_PROJECT_ID:}
+  credentials-json-base64: ${FCM_CREDENTIALS_JSON_BASE64:}

--- a/src/test/java/com/ppiyaki/notification/controller/DeviceTokenControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/DeviceTokenControllerE2ETest.java
@@ -1,0 +1,114 @@
+package com.ppiyaki.notification.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class DeviceTokenControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        jdbcTemplate.update("DELETE FROM device_tokens WHERE user_id IN "
+                + "(SELECT id FROM users WHERE login_id IN ('dt_owner', 'dt_other'))");
+        jdbcTemplate.update("DELETE FROM refresh_tokens WHERE user_id IN "
+                + "(SELECT id FROM users WHERE login_id IN ('dt_owner', 'dt_other'))");
+        jdbcTemplate.update("DELETE FROM users WHERE login_id IN ('dt_owner', 'dt_other')");
+    }
+
+    @Test
+    @DisplayName("device token 등록 + 동일 token 재요청 멱등 + 본인 해제 + 타인 해제 시 403")
+    void device_token_flow() {
+        final String ownerToken = signupAndGetToken("dt_owner");
+        final String otherToken = signupAndGetToken("dt_other");
+
+        // when — 신규 등록
+        final Integer tokenId = RestAssured.given()
+                .header("Authorization", "Bearer " + ownerToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"token": "fcm-token-abc", "platform": "ANDROID"}
+                        """)
+                .when()
+                .post("/api/v1/users/me/devices")
+                .then()
+                .statusCode(201)
+                .body("tokenId", notNullValue())
+                .body("platform", is("ANDROID"))
+                .body("isActive", is(true))
+                .extract()
+                .path("tokenId");
+
+        // when — 동일 token 재요청 → 멱등 (같은 row)
+        RestAssured.given()
+                .header("Authorization", "Bearer " + ownerToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"token": "fcm-token-abc", "platform": "ANDROID"}
+                        """)
+                .when()
+                .post("/api/v1/users/me/devices")
+                .then()
+                .statusCode(201)
+                .body("tokenId", is(tokenId));
+
+        final Integer rowCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM device_tokens WHERE token = ?", Integer.class, "fcm-token-abc");
+        assert rowCount != null && rowCount == 1;
+
+        // when — 본인 해제
+        RestAssured.given()
+                .header("Authorization", "Bearer " + ownerToken)
+                .when()
+                .delete("/api/v1/users/me/devices/" + tokenId)
+                .then()
+                .statusCode(204);
+
+        final Boolean isActive = jdbcTemplate.queryForObject(
+                "SELECT is_active FROM device_tokens WHERE id = ?", Boolean.class, tokenId.longValue());
+        assert isActive != null && !isActive;
+
+        // when — 타인 해제 시 403 NOTIFICATION_004
+        RestAssured.given()
+                .header("Authorization", "Bearer " + otherToken)
+                .when()
+                .delete("/api/v1/users/me/devices/" + tokenId)
+                .then()
+                .statusCode(403)
+                .body("error.code", is("NOTIFICATION_004"));
+    }
+
+    private String signupAndGetToken(final String loginId) {
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "pass1234!",
+                            "nickname": "%s"
+                        }
+                        """.formatted(loginId, loginId))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("accessToken");
+    }
+}

--- a/src/test/java/com/ppiyaki/notification/service/DeviceTokenServiceTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/DeviceTokenServiceTest.java
@@ -1,0 +1,108 @@
+package com.ppiyaki.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.notification.DevicePlatform;
+import com.ppiyaki.notification.DeviceToken;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceTokenServiceTest {
+
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+
+    @InjectMocks
+    private DeviceTokenService deviceTokenService;
+
+    @Test
+    @DisplayName("신규 token이면 save 호출")
+    void register_new_token() {
+        // given
+        given(deviceTokenRepository.findByToken("token-123")).willReturn(Optional.empty());
+        final DeviceToken saved = mock(DeviceToken.class);
+        given(saved.getIsActive()).willReturn(true);
+        given(deviceTokenRepository.save(any(DeviceToken.class))).willReturn(saved);
+
+        // when
+        deviceTokenService.register(7L, "token-123", DevicePlatform.ANDROID);
+
+        // then
+        verify(deviceTokenRepository).save(any(DeviceToken.class));
+    }
+
+    @Test
+    @DisplayName("기존 token이면 reactivate 호출 + save 호출 안 함")
+    void register_existing_token_reactivates() {
+        // given
+        final DeviceToken existing = mock(DeviceToken.class);
+        given(existing.getIsActive()).willReturn(true);
+        given(deviceTokenRepository.findByToken("token-123")).willReturn(Optional.of(existing));
+
+        // when
+        deviceTokenService.register(7L, "token-123", DevicePlatform.ANDROID);
+
+        // then
+        verify(existing).reactivate(any(LocalDateTime.class));
+        verify(deviceTokenRepository, never()).save(any(DeviceToken.class));
+    }
+
+    @Test
+    @DisplayName("본인 token deactivate 시 entity.deactivate 호출")
+    void deactivate_owner_success() {
+        // given
+        final DeviceToken token = mock(DeviceToken.class);
+        given(token.getUserId()).willReturn(7L);
+        given(deviceTokenRepository.findById(1L)).willReturn(Optional.of(token));
+
+        // when
+        deviceTokenService.deactivate(7L, 1L);
+
+        // then
+        verify(token).deactivate();
+    }
+
+    @Test
+    @DisplayName("타인 token deactivate 시 DEVICE_TOKEN_FORBIDDEN")
+    void deactivate_nonOwner_throwsForbidden() {
+        // given — token.userId=7, requester=99
+        final DeviceToken token = mock(DeviceToken.class);
+        given(token.getUserId()).willReturn(7L);
+        given(deviceTokenRepository.findById(1L)).willReturn(Optional.of(token));
+
+        // when & then
+        assertThatThrownBy(() -> deviceTokenService.deactivate(99L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> Assertions.assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.DEVICE_TOKEN_FORBIDDEN));
+    }
+
+    @Test
+    @DisplayName("미존재 token deactivate 시 DEVICE_TOKEN_NOT_FOUND")
+    void deactivate_notFound() {
+        // given
+        given(deviceTokenRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> deviceTokenService.deactivate(7L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> Assertions.assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.DEVICE_TOKEN_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## TO-BE
복약 알림 Feature Spec(`docs/features/medication-notification.md`) §6 PR 4 작업.

푸시 발송 인프라 구축. 발송 트리거(시니어 복약시간/보호자 미복약 등)는 후속 PR(5~10)에서 본 PR의 `PushSender` 위에 구현.

### 신규 도메인
- `DeviceToken`/`DevicePlatform` 패키지 이전: `com.ppiyaki.medication` → `com.ppiyaki.notification`
- `DeviceToken` 도메인 메서드: `register` / `reactivate` / `deactivate`
- `DeviceTokenRepository` 신설
- `DeviceTokenService` — 등록 시 동일 token 멱등 (reactivate)
- `PushSender` 인터페이스 + `PushPayload` + `PushSendResult`
- `FcmPushSender` 구현 (firebase-admin SDK 9.4.3)
- `NoOpPushSender` — FCM 미설정 시 fallback
- `PushConfig` — `fcm.project-id` + `fcm.credentials-json-base64` 미설정/init 실패 시 NoOp으로 우아하게 폴백

### 신규 API
| Method | Path | 설명 | 인증 |
|---|---|---|---|
| POST | `/api/v1/users/me/devices` | device token 등록 (동일 token 재요청 시 멱등 — reactivate) | 필수 |
| DELETE | `/api/v1/users/me/devices/{tokenId}` | 본인 token 해제 (is_active=false) | 필수 (본인) |

### 신규 에러 코드
- `NOTIFICATION_003` (404): Device token not found
- `NOTIFICATION_004` (403): Cannot access another user's device token

### 환경변수 / 인프라
- `application.yml`: `fcm.project-id`, `fcm.credentials-json-base64` binding (default 빈값)
- `backend-cd.yml`: `docker run -e FCM_PROJECT_ID -e FCM_CREDENTIALS_JSON_BASE64` 동기화 (CD 환경변수 룰)
- `build.gradle`: `com.google.firebase:firebase-admin:9.4.3` dependency
- `.env` / `.env.example`: 사용자 채움 완료 (이전 PR)
- GitHub Actions secrets: `FCM_CREDENTIALS_JSON_BASE64` ✅ 등록 완료. **`FCM_PROJECT_ID` secret 등록 권장** (현재 미등록 시 빈값 → NoOp 폴백)

### FCM 동작
- `FcmPushSender.send`: 정상 전송 → ok / `UNREGISTERED` / `INVALID_ARGUMENT` → tokenInvalid (호출자가 device_token deactivate 가능) / 그 외 → failed
- 미설정 환경(테스트 / FCM_PROJECT_ID 누락) → `NoOpPushSender`로 자동 폴백 (Spring 부트는 정상 가동)

## 테스트
- 단위 (`DeviceTokenServiceTest` 5 케이스): 신규/멱등 register, deactivate 본인/타인/미존재
- E2E (`DeviceTokenControllerE2ETest`): 등록 + 동일 token 멱등 + 본인 해제 + 타인 해제 403 멀티 시나리오 1건
- FCM 실 발송은 단위 테스트에서 mock 또는 NoOpPushSender 활용 (실 전송은 후속 PR + 운영에서 검증)

## 비범위
- 알림 발송 트리거 (시니어 복약시간/보호자 미복약/DUR/가족안전망/복약완료) — PR 5~10
- 보호자 알림 설정 조회/갱신 API — PR 5
- last_active_at 추적 — PR 9

## AI 체크리스트
- [x] 도메인 모델 영향 — `DeviceToken` 패키지 이동, 도메인 메서드 캡슐화. `06-domain-model.md` follow-up
- [x] DB 마이그레이션 — schema 변경 없음 (device_tokens 테이블은 기존, 패키지만 이동)
- [x] 에러 코드 — `NOTIFICATION_003/004` 추가, `docs/error-codes.md` 갱신
- [x] CD 환경변수 동기화 — `backend-cd.yml` FCM env 추가
- [ ] **Notion API 명세 등록 (POST/DELETE devices)** — 머지 후 follow-up
- [x] 단위 + E2E 테스트
- [x] 외부 인프라 미설정 시 우아한 폴백 (NoOpPushSender)

## 참조
- spec: `docs/features/medication-notification.md` §5-3 외부 연동, §5-2 API, §6 PR 4
- 관련: PR #285 (알림함 영속화) 머지된 develop 위에서 작업

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 푸시 알림 기능 추가
  * 기기 토큰 등록 및 해제 API 추가

* **Documentation**
  * 알림 관련 오류 코드(NOTIFICATION_003, NOTIFICATION_004) 문서 업데이트

* **Tests**
  * 기기 토큰 관리 기능의 엔드-투-엔드 테스트 및 단위 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/289)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->