### PR TITLE
feat(medication): 시니어 복약시간 알림 발송 트리거 (Scheduler)

### DIFF
--- a/src/main/java/com/ppiyaki/PpiyakiApplication.java
+++ b/src/main/java/com/ppiyaki/PpiyakiApplication.java
@@ -1,8 +1,11 @@
 package com.ppiyaki;
 
+import java.time.Clock;
+import java.time.ZoneId;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
@@ -12,6 +15,11 @@ public class PpiyakiApplication {
 
     public static void main(final String[] args) {
         SpringApplication.run(PpiyakiApplication.class, args);
+    }
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
     }
 
 }

--- a/src/main/java/com/ppiyaki/notification/Notification.java
+++ b/src/main/java/com/ppiyaki/notification/Notification.java
@@ -86,6 +86,26 @@ public class Notification extends BaseTimeEntity {
         this.scheduleId = scheduleId;
     }
 
+    public static Notification createForMedicationReminder(
+            final Long seniorUserId,
+            final String title,
+            final String body,
+            final LocalDate targetDate,
+            final String mealSlot
+    ) {
+        return new Notification(
+                seniorUserId,
+                null,
+                NotificationCategory.MEDICATION_REMINDER,
+                title,
+                body,
+                null,
+                targetDate,
+                mealSlot,
+                null
+        );
+    }
+
     public boolean isRead() {
         return this.readAt != null;
     }

--- a/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
@@ -33,4 +33,11 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             WHERE n.userId = :userId AND n.readAt IS NULL
             """)
     int markAllAsRead(@Param("userId") final Long userId, @Param("readAt") final LocalDateTime readAt);
+
+    boolean existsByUserIdAndCategoryAndTargetDateAndMealSlot(
+            final Long userId,
+            final NotificationCategory category,
+            final java.time.LocalDate targetDate,
+            final String mealSlot
+    );
 }

--- a/src/main/java/com/ppiyaki/notification/service/MedicationReminderDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationReminderDispatcher.java
@@ -1,0 +1,76 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.notification.DeviceToken;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.NotificationCategory;
+import com.ppiyaki.notification.push.PushPayload;
+import com.ppiyaki.notification.push.PushSendResult;
+import com.ppiyaki.notification.push.PushSender;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.user.User;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class MedicationReminderDispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(MedicationReminderDispatcher.class);
+    private static final Map<MealSlot, String> SLOT_TITLES = Map.of(
+            MealSlot.BREAKFAST, "아침약 드실 시간이에요!",
+            MealSlot.LUNCH, "점심약 드실 시간이에요!",
+            MealSlot.DINNER, "저녁약 드실 시간이에요!"
+    );
+
+    private final MedicationScheduleRepository medicationScheduleRepository;
+    private final NotificationRepository notificationRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final PushSender pushSender;
+
+    public MedicationReminderDispatcher(
+            final MedicationScheduleRepository medicationScheduleRepository,
+            final NotificationRepository notificationRepository,
+            final DeviceTokenRepository deviceTokenRepository,
+            final PushSender pushSender
+    ) {
+        this.medicationScheduleRepository = medicationScheduleRepository;
+        this.notificationRepository = notificationRepository;
+        this.deviceTokenRepository = deviceTokenRepository;
+        this.pushSender = pushSender;
+    }
+
+    @Transactional
+    public boolean dispatchIfDue(final User senior, final MealSlot slot, final LocalDate today) {
+        if (notificationRepository.existsByUserIdAndCategoryAndTargetDateAndMealSlot(
+                senior.getId(), NotificationCategory.MEDICATION_REMINDER, today, slot.name())) {
+            return false;
+        }
+        if (medicationScheduleRepository.findActiveByOwnerAndMealSlot(senior.getId(), today, slot).isEmpty()) {
+            return false;
+        }
+
+        final String title = SLOT_TITLES.getOrDefault(slot, "약 드실 시간이에요");
+        final String body = "삐~약드실 시간이에요~";
+        final Notification notification = notificationRepository.save(
+                Notification.createForMedicationReminder(senior.getId(), title, body, today, slot.name()));
+        log.info("MEDICATION_REMINDER notification created (id={}, senior={}, slot={})",
+                notification.getId(), senior.getId(), slot);
+
+        final List<DeviceToken> tokens = deviceTokenRepository.findByUserIdAndIsActiveTrue(senior.getId());
+        for (final DeviceToken token : tokens) {
+            final PushSendResult result = pushSender.send(token.getToken(),
+                    new PushPayload(title, body, Map.of("category", "MEDICATION_REMINDER", "mealSlot", slot.name())));
+            if (result.tokenInvalid()) {
+                token.deactivate();
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/service/MedicationReminderScheduler.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationReminderScheduler.java
@@ -1,0 +1,62 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
+import com.ppiyaki.user.repository.UserRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MedicationReminderScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(MedicationReminderScheduler.class);
+
+    private final UserRepository userRepository;
+    private final MedicationReminderDispatcher dispatcher;
+    private final Clock clock;
+
+    public MedicationReminderScheduler(
+            final UserRepository userRepository,
+            final MedicationReminderDispatcher dispatcher,
+            final Clock clock
+    ) {
+        this.userRepository = userRepository;
+        this.dispatcher = dispatcher;
+        this.clock = clock;
+    }
+
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    public void dispatchDue() {
+        final LocalDate today = LocalDate.now(clock);
+        final LocalTime now = LocalTime.now(clock).withSecond(0).withNano(0);
+        log.info("MedicationReminderScheduler tick at {}", now);
+        run(today, now);
+    }
+
+    public int run(final LocalDate today, final LocalTime currentMinute) {
+        int dispatched = 0;
+        final List<User> seniors = userRepository.findAllByRoleWithMealTimesSet(UserRole.SENIOR);
+        for (final User senior : seniors) {
+            for (final MealSlot slot : MealSlot.values()) {
+                final LocalTime mealTime = slot.resolveTime(senior);
+                if (mealTime == null) {
+                    continue;
+                }
+                if (!mealTime.withSecond(0).withNano(0).equals(currentMinute)) {
+                    continue;
+                }
+                if (dispatcher.dispatchIfDue(senior, slot, today)) {
+                    dispatched++;
+                }
+            }
+        }
+        return dispatched;
+    }
+}

--- a/src/main/java/com/ppiyaki/user/repository/UserRepository.java
+++ b/src/main/java/com/ppiyaki/user/repository/UserRepository.java
@@ -1,12 +1,25 @@
 package com.ppiyaki.user.repository;
 
 import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByLoginId(final String loginId);
 
     Optional<User> findByLoginId(final String loginId);
+
+    @Query("""
+            SELECT u FROM User u
+            WHERE u.role = :role
+              AND u.breakfastTime IS NOT NULL
+              AND u.lunchTime IS NOT NULL
+              AND u.dinnerTime IS NOT NULL
+            """)
+    List<User> findAllByRoleWithMealTimesSet(@Param("role") final UserRole role);
 }

--- a/src/test/java/com/ppiyaki/notification/service/MedicationReminderDispatcherTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/MedicationReminderDispatcherTest.java
@@ -1,0 +1,138 @@
+package com.ppiyaki.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.NotificationCategory;
+import com.ppiyaki.notification.push.PushSendResult;
+import com.ppiyaki.notification.push.PushSender;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.user.User;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MedicationReminderDispatcherTest {
+
+    @Mock
+    private MedicationScheduleRepository medicationScheduleRepository;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+
+    @Mock
+    private PushSender pushSender;
+
+    @InjectMocks
+    private MedicationReminderDispatcher dispatcher;
+
+    @Test
+    @DisplayName("이미 발송된 알림이 있으면 skip")
+    void dispatch_skip_when_existing() {
+        // given
+        final User senior = mock(User.class);
+        given(senior.getId()).willReturn(7L);
+        given(notificationRepository.existsByUserIdAndCategoryAndTargetDateAndMealSlot(
+                7L, NotificationCategory.MEDICATION_REMINDER, LocalDate.now(), MealSlot.BREAKFAST.name()))
+                .willReturn(true);
+
+        // when
+        final boolean dispatched = dispatcher.dispatchIfDue(senior, MealSlot.BREAKFAST, LocalDate.now());
+
+        // then
+        assertThat(dispatched).isFalse();
+        verify(notificationRepository, never()).save(any(Notification.class));
+        verify(pushSender, never()).send(any(), any());
+    }
+
+    @Test
+    @DisplayName("active schedule 없으면 skip")
+    void dispatch_skip_when_no_active_schedule() {
+        // given
+        final User senior = mock(User.class);
+        given(senior.getId()).willReturn(7L);
+        given(medicationScheduleRepository.findActiveByOwnerAndMealSlot(anyLong(), any(LocalDate.class), any(
+                MealSlot.class)))
+                .willReturn(List.of());
+
+        // when
+        final boolean dispatched = dispatcher.dispatchIfDue(senior, MealSlot.BREAKFAST, LocalDate.now());
+
+        // then
+        assertThat(dispatched).isFalse();
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("active schedule 있고 미발송이면 발송 + 활성 device tokens에 push")
+    void dispatch_success() {
+        // given
+        final User senior = mock(User.class);
+        given(senior.getId()).willReturn(7L);
+
+        final MedicationSchedule schedule = mock(MedicationSchedule.class);
+        given(medicationScheduleRepository.findActiveByOwnerAndMealSlot(anyLong(), any(LocalDate.class), any(
+                MealSlot.class)))
+                .willReturn(List.of(schedule));
+
+        final Notification saved = mock(Notification.class);
+        given(saved.getId()).willReturn(101L);
+        given(notificationRepository.save(any(Notification.class))).willReturn(saved);
+
+        given(deviceTokenRepository.findByUserIdAndIsActiveTrue(7L)).willReturn(List.of());
+
+        // when
+        final boolean dispatched = dispatcher.dispatchIfDue(senior, MealSlot.BREAKFAST, LocalDate.now());
+
+        // then
+        assertThat(dispatched).isTrue();
+        verify(notificationRepository).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("push 응답이 tokenInvalid면 device token deactivate")
+    void dispatch_deactivates_invalid_token() {
+        // given
+        final User senior = mock(User.class);
+        given(senior.getId()).willReturn(7L);
+
+        final MedicationSchedule schedule = mock(MedicationSchedule.class);
+        given(medicationScheduleRepository.findActiveByOwnerAndMealSlot(anyLong(), any(LocalDate.class), any(
+                MealSlot.class)))
+                .willReturn(List.of(schedule));
+
+        final Notification saved = mock(Notification.class);
+        given(saved.getId()).willReturn(101L);
+        given(notificationRepository.save(any(Notification.class))).willReturn(saved);
+
+        final com.ppiyaki.notification.DeviceToken token = mock(com.ppiyaki.notification.DeviceToken.class);
+        given(token.getToken()).willReturn("invalid-fcm-token");
+        given(deviceTokenRepository.findByUserIdAndIsActiveTrue(7L)).willReturn(List.of(token));
+        given(pushSender.send(any(), any())).willReturn(PushSendResult.tokenInvalid("UNREGISTERED"));
+
+        // when
+        dispatcher.dispatchIfDue(senior, MealSlot.BREAKFAST, LocalDate.now());
+
+        // then
+        verify(token).deactivate();
+    }
+}


### PR DESCRIPTION
## TO-BE
복약 알림 Feature Spec(`docs/features/medication-notification.md`) §6 PR 6 작업.

PR #285 Notification entity + PR #289 PushSender 위에서 시니어 복약시간 알림 발송 트리거 구현. 시니어 mealTime 도래 시 자동으로 인앱 알림 row + FCM 푸시 발송.

### 구조
- `MedicationReminderScheduler` (`@Scheduled` cron 매 분, zone `Asia/Seoul`)
  - `User.role=SENIOR` 중 mealTime 모두 설정된 시니어 조회
  - 현재 분에 매칭되는 mealSlot 식별 → dispatcher 호출
- `MedicationReminderDispatcher`
  - 자연키 멱등 — 같은 (senior, MEDICATION_REMINDER, today, slot)에 row 있으면 skip
  - active `MedicationSchedule` (해당 slot, today within startDate~endDate) 1건 이상이어야 발송
  - mealSlot별 한국어 메시지 ("아침/점심/저녁약 드실 시간이에요!")
  - 시니어의 활성 `DeviceToken`별 PushSender 호출
  - PushSender가 `tokenInvalid` 응답 → device token deactivate

### 신규/변경
- `Notification.createForMedicationReminder(...)` static factory
- `UserRepository.findAllByRoleWithMealTimesSet(role)`
- `NotificationRepository.existsByUserIdAndCategoryAndTargetDateAndMealSlot(...)` (멱등 lookup)
- `Clock` bean 등록 (zone `Asia/Seoul`, scheduler 시간 주입용)

### 운영
- PushSender 미설정 시 `NoOpPushSender` 폴백 → 인앱 알림함은 정상 누적, 실 푸시는 미발송. FCM env 설정 시 자동 활성.
- `dispatcher.dispatchIfDue(senior, slot, date)` 메서드는 별도 호출 가능 (테스트 / manual 트리거).

## 테스트
- 단위 (`MedicationReminderDispatcherTest`, 4 케이스): 멱등 skip / 빈 schedule skip / 정상 발송 / tokenInvalid 시 deactivate

## 비범위
- 보호자 미복약/지연 알림 — PR 7 (DELAY_THRESHOLD 통합 포함)
- DUR 긴급 경고 — PR 8
- 가족 안전망 + last_active_at — PR 9
- 복약 완료 알림 — PR 10
- 알림 재전송(snooze) — out of scope (medication-notification.md §4)

## AI 체크리스트
- [x] 도메인 모델 영향 — `Notification` factory 추가 (스키마 변경 없음)
- [x] DB 마이그레이션 — 변경 없음
- [x] 에러 코드 — 추가 없음 (스케줄러 internal — 사용자 응답 없음)
- [x] 단위 테스트 (멱등, 분기 4 케이스)
- [x] FCM 미설정 시 NoOp 폴백 검증

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)