### PR TITLE
feat(medication): 보호자 미복약/지연 알림 + DashboardService DELAY_THRESHOLD settings 통합

### DIFF
--- a/docs/features/caregiver-dashboard.md
+++ b/docs/features/caregiver-dashboard.md
@@ -242,7 +242,7 @@ weekly/monthly는 4~6 단계를 기간으로 확장, status만 도출.
 | Q2 | dosage 파싱 — "반정"(0.5정) / "2정 반"(2.5정) 같은 소수 표기 | (a) 정수만 — 비정수면 0으로 (단순) / (b) BigDecimal로 정밀 / (c) 파싱 실패 시 fallback dailyConsumption=1 | @goohong / 구현 시 |
 | Q3 | weekly의 weekStart 요일 | (a) 일요일 (한국 캘린더 기본) / (b) 월요일 (ISO 8601) — 디자인 image2 "일/월/화/수…" 순이라 (a)로 보임 | 디자인 측 / 구현 시 |
 | Q4 | monthly 응답에 통합 status 외 추가 정보(예: 슬롯별 마커) | (a) 통합 status enum만(권장) / (b) 슬롯별 마커도 — 응답 크기 증가 | @frontend / 구현 시 |
-| Q5 | "지연" 임계값 1시간 — 시니어/보호자별 설정 가능? | (a) 시스템 상수 1h(단순) / (b) 사용자별 설정 — 후속 spec | @goohong / 후순위 |
+| ~~Q5~~ | ~~"지연" 임계값 1시간~~ | **해소 — 보호자별 `notification_settings.medication_delay_threshold_minutes` 참조 (default 60분, 시니어 본인 caller일 때만 60 fallback)** ✅ |
 
 ## 9) 결정 로그
 - 2026-05-08: spec 초안 작성 (status=draft).
@@ -252,4 +252,5 @@ weekly/monthly는 4~6 단계를 기간으로 확장, status만 도출.
 - 2026-05-08: 오늘 일자 처리 = 기존 룰 그대로(PENDING). "오늘 강조"는 frontend isToday 플래그. 사용자 결정.
 - 2026-05-08: remainingDays = MIN(remainingAmount / dailyConsumption). 잔여분 자동 차감(v0.9.8) + confirm amount 입력(PR #263)에 의존.
 - 2026-05-08: MISSED 자동 전환 cron은 본 spec scope 외 — dashboard 응답 시 동적 계산.
+- 2026-05-10 (#294): **Q5 해소** — DELAYED 임계 = 보호자별 `notification_settings.medication_delay_threshold_minutes` 참조. `DashboardService.DELAY_THRESHOLD_MINUTES = 60` 하드코딩 제거 → caller 보호자의 settings 조회. 시니어 본인 caller(userId == seniorId)일 때는 default 60 fallback. medication-notification.md PR 7과 동시 머지.
 - 2026-05-08: 통합 endpoint 신규(daily/weekly/monthly) — 기존 logs/medicines/schedules 합성보다 N+1 호출 부담 감소 + status 룰 일관성.

--- a/docs/features/medication-notification.md
+++ b/docs/features/medication-notification.md
@@ -86,7 +86,7 @@ last_reviewed: 2026-05-10
 **신규 컨텍스트**: `notification` (`com.ppiyaki.notification.*`).
 - `Notification` (알림 row, 영속화)
 - `NotificationSettings` (보호자 ↔ 시니어별 설정 — N:M)
-- `NotificationMode` enum (`STANDARD` / `INTENSIVE`) — onboarding/프리셋 적용 시 입력값으로만 사용. `notification_settings`에 저장하지 않음 (모드는 초기 프리셋 표시일 뿐 영속 의미 없음). 기존 `com.ppiyaki.user.NotificationMode` 위치에서 이전 + 이름 변경 (`BASIC_ALERT`→`STANDARD`, `INTENSIVE_CARE`→`INTENSIVE`)
+- 입력 enum은 `CareMode` 단일 (`MANAGED` / `AUTONOMOUS`) — onboarding/프리셋 적용 시 입력. `NotificationMode` enum은 폐기 (#294, careMode 단일 입력으로 통합). 백엔드에서 `MANAGED` → INTENSIVE preset / `AUTONOMOUS` → STANDARD preset 매핑.
 - `NotificationService` (발송 + 조회)
 - `PushSender` (FCM 어댑터)
 
@@ -265,6 +265,7 @@ ALTER TABLE users ADD COLUMN last_active_at DATETIME NULL;
 - 2026-05-10: **Q5 해소** — `last_active_at` 갱신 = 시니어 인증된 모든 API 요청 + 1분 throttle. 이유: ppiyaki 운영 규모에서 매 요청 update 부담 없음, endpoint 분류 비용 vs 효익 작음, throttle로 동일 분 내 중복 write 방지.
 - 2026-05-10: **Q6 해소** — settings 항목 직접 수정 시 `mode` = `CUSTOM` 자동 전환. enum에 `CUSTOM` 추가 (`STANDARD` / `INTENSIVE` / `CUSTOM`). 이유: UI 표시와 실제 값 일치(정직), 서버 로직 단순, 프리셋 재적용은 별도 endpoint이라 자연스럽게 mode 복귀.
 - 2026-05-10 (Q6 번복): **`mode` 컬럼 + CUSTOM 제거** (PR #291). 이유: mode는 onboarding/프리셋 적용 시점의 입력값일 뿐 저장 의미 없음 (어차피 초기 프리셋 표시). 보호자가 항목 직접 수정해도 mode를 굳이 추적할 필요 없음. enum은 STANDARD/INTENSIVE 2값만 (DTO에서만 사용). `notification_settings.mode` 컬럼 + `NotificationSettings.mode` 필드 제거 + `NotificationMode.CUSTOM` 제거.
+- 2026-05-10 (#294): **입력 enum을 `CareMode` 단일로 통합** — UI 모음집 확인 결과 onboarding 모드 선택은 careMode 수준의 통합 프리셋(처방전 권한 + 알림 + 향후 복약인증 강제/여유 등). 개념 크기상 careMode가 상위. `OnboardingRequest.SeniorEntry.careMode` (`MANAGED`/`AUTONOMOUS`)로 변경 + `POST /notification-settings/preset` body도 `careMode`. 백엔드 매핑: `MANAGED` → INTENSIVE preset / `AUTONOMOUS` → STANDARD preset. `NotificationMode` enum 폐기. 호환성 깨짐 — 프론트엔드 cut-over.
 - 2026-05-10: **Q7 해소** — 푸시 ↔ 알림함 row 항상 1:1. 이유: Figma 5종(시니어 복약시간 / 보호자 미복약·DUR·가족안전망·복약완료) 모두 알림함 표시 의도, 단순/일관성, 푸시 누락 보완, ppiyaki 규모에서 부하 무시 가능.
 - 2026-05-10: **Q8 해소** — 가족 안전망 알림 cooldown = 시니어 재접속까지 1회만. 구현은 `last_active_at` 갱신 시점 이후의 가장 최근 `FAMILY_SAFETY` row 존재 여부로 판정. 이유: 알림 피로 방지, 보호자가 한 번 인지하면 후속은 본인 책임, 구현 단순 (시니어 재접속 시 자연 reset).
 - 2026-05-10: 모든 오픈 질문 해소 → status `draft` → `approved`. 다음 단계: PR 머지 후 PR 2(refactor + notification_settings) 착수.

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -20,7 +20,7 @@ last_reviewed: 2026-05-10
 1. 보호자가 카카오 또는 로컬 로그인으로 회원가입한다.
 2. 온보딩 화면에서 닉네임을 입력한다.
 3. 관리할 시니어의 이름과 성별(남/여/비공개)을 입력한다. 여러 명 추가 가능.
-4. 각 시니어에 대해 알림 프리셋(`STANDARD` = 기본 건강 알림 모드 / `INTENSIVE` = 집중 안심 모드)을 선택한다. 화면에 "세부 알림은 가입 후 내 정보 > 알림 설정에서 변경할 수 있어요" 안내.
+4. 각 시니어에 대해 케어 모드(`AUTONOMOUS` = 기본 건강 알림 모드 / `MANAGED` = 집중 안심 모드)를 선택한다. 화면에 "세부 알림은 가입 후 내 정보 > 알림 설정에서 변경할 수 있어요" 안내. UI 모음집상 라벨은 "시니어 별 알림설정"이지만, 백엔드는 careMode를 상위 개념으로 받아 알림 프리셋 + 처방전 권한 + 향후 sub-속성(복약인증 강제, 여유 등)을 일괄 결정.
 5. 완료 버튼을 누르면 온보딩이 끝나고 메인 화면으로 이동한다.
 
 ## 3) 요구사항
@@ -29,9 +29,8 @@ last_reviewed: 2026-05-10
 - [x] 시니어를 1명 이상 등록할 수 있다 (이름, 성별 필수)
 - [x] 성별은 MALE / FEMALE / UNKNOWN(비공개) 중 선택
 - [x] 시니어 등록 시 User(SENIOR) + CareRelation + Pet이 자동 생성된다
-- [x] 각 시니어마다 알림 프리셋(`STANDARD` / `INTENSIVE`)을 선택할 수 있다
-- [x] 시니어 등록 시 선택한 프리셋 값으로 `notification_settings` row가 자동 생성된다 (보호자 ↔ 시니어 1:1 row)
-- [x] 시니어의 `careMode`도 프리셋에 매핑되어 자동 설정된다: `STANDARD` → `AUTONOMOUS`, `INTENSIVE` → `MANAGED`
+- [x] 각 시니어마다 careMode(`AUTONOMOUS` / `MANAGED`)를 선택할 수 있다 (화면 라벨: "기본 건강 알림 모드" / "집중 안심 모드")
+- [x] 시니어 등록 시 careMode가 `User.careMode`에 저장되고 매핑된 프리셋으로 `notification_settings` row 자동 생성: `AUTONOMOUS` → STANDARD preset / `MANAGED` → INTENSIVE preset
 - [x] 온보딩은 단일 API(`POST /api/v1/onboarding`)로 처리된다
 
 ### 비기능 요구사항
@@ -41,7 +40,7 @@ last_reviewed: 2026-05-10
 ### 포함
 - `POST /api/v1/onboarding` API
 - `User.createSenior(nickname, gender)` 팩토리
-- 시니어 생성 시 선택된 프리셋(`STANDARD` / `INTENSIVE`) 값으로 `notification_settings` row 자동 생성
+- 시니어 생성 시 선택된 careMode 매핑 프리셋으로 `notification_settings` row 자동 생성 (AUTONOMOUS → STANDARD / MANAGED → INTENSIVE)
 - 단위 테스트 + E2E 테스트
 
 ### 제외 (Out of Scope)
@@ -52,8 +51,9 @@ last_reviewed: 2026-05-10
 ## 5) 설계
 ### 5-1) 도메인 모델
 - `User.createSenior(nickname, gender)` 팩토리
-- `NotificationSettings` 엔티티(`com.ppiyaki.notification`)에 caregiver ↔ senior 1:1 row 자동 생성 (default `STANDARD` 프리셋)
-- ~~`NotificationMode` enum (com.ppiyaki.user)~~, ~~`User.notificationMode` 필드~~ — 2026-05-10 refactor로 제거 (알림 도메인으로 이전, §9 참조)
+- `NotificationSettings` 엔티티(`com.ppiyaki.notification`)에 caregiver ↔ senior 1:1 row 자동 생성 (careMode 매핑 프리셋)
+- 입력 enum은 `CareMode` 단일 (상위 개념). `NotificationMode` enum은 폐기 (#294)
+- ~~`User.notificationMode` 필드~~, ~~`com.ppiyaki.user.NotificationMode`~~ — 2026-05-10 refactor로 제거 (#283)
 
 ### 5-2) API 엔드포인트
 
@@ -71,12 +71,12 @@ last_reviewed: 2026-05-10
     {
       "nickname": "할머니",
       "gender": "FEMALE",
-      "notificationMode": "STANDARD"
+      "careMode": "AUTONOMOUS"
     },
     {
       "nickname": "할아버지",
       "gender": "MALE",
-      "notificationMode": "INTENSIVE"
+      "careMode": "MANAGED"
     }
   ]
 }
@@ -106,10 +106,10 @@ last_reviewed: 2026-05-10
 2. 보호자 닉네임 업데이트
 3. 각 시니어에 대해:
    - User(role=SENIOR, gender) 생성
-   - 선택된 `notificationMode`에 따라 `careMode` 매핑: `STANDARD` → `AUTONOMOUS`, `INTENSIVE` → `MANAGED`
+   - 받은 `careMode`를 `User.careMode`에 직접 저장
    - CareRelation 생성
    - Pet 생성 + User에 연결
-   - `notification_settings` row 생성 (caregiver_id × senior_id, 선택된 프리셋 — `STANDARD` 또는 `INTENSIVE`)
+   - `notification_settings` row 생성 (caregiver_id × senior_id, careMode 매핑 프리셋 — AUTONOMOUS → STANDARD / MANAGED → INTENSIVE)
 4. 전체 결과 응답
 
 ### 5-5) DB 마이그레이션
@@ -129,3 +129,4 @@ last_reviewed: 2026-05-10
 - 2026-05-08: 초안 작성. 단일 API, 알림 모드는 프리셋(나중에 개별 조정 가능), 성별 비공개=UNKNOWN.
 - 2026-05-10: **알림 모드 책임 이전** — `docs/features/medication-notification.md` spec(보호자 ↔ 시니어 N:M `notification_settings` 모델 채택)에 따라 `users.notification_mode` 컬럼 + `User.notificationMode` 필드 제거. enum은 `com.ppiyaki.user` → `com.ppiyaki.notification`으로 이전 + `BASIC_ALERT`/`INTENSIVE_CARE` → `STANDARD`/`INTENSIVE`/`CUSTOM`로 리네임. 시니어 생성 시 default `STANDARD` 프리셋의 `notification_settings` row 자동 생성. 호환성 깨짐 — 프론트엔드 cut-over 필요.
 - 2026-05-10 (#286): **알림 모드 입력 다시 받음 + careMode 매핑** — 디자인 화면("시니어를 어떻게 돌볼까요?") 확인 후 정정. 디자인 의도는 보호자가 시니어별로 STANDARD vs INTENSIVE 명시 선택. `OnboardingRequest.SeniorEntry.notificationMode` 필드 다시 추가 (`STANDARD` / `INTENSIVE`, required). 받은 모드에 따라 ① `notification_settings` 프리셋 적용 (`STANDARD` → standard preset / `INTENSIVE` → intensive preset), ② `senior.careMode` 매핑 (`STANDARD` → `AUTONOMOUS` / `INTENSIVE` → `MANAGED`). 모델은 N:M `notification_settings` 그대로 유지.
+- 2026-05-10 (#294): **입력을 careMode로 통합** — UI 모음집("복약인증 강제 / 여유 설정 추가 필요") 확인 결과 onboarding 모드 선택은 알림에 한정되지 않고 careMode 수준의 통합 프리셋(처방전 권한 + 알림 + 향후 복약인증 강제/여유 등). 개념 크기상 careMode가 상위. `OnboardingRequest.SeniorEntry.notificationMode` → `careMode` (`MANAGED`/`AUTONOMOUS`)로 변경. 백엔드는 careMode → 알림 프리셋 자동 매핑(`MANAGED` → INTENSIVE preset / `AUTONOMOUS` → STANDARD preset). `NotificationMode` enum 폐기. `POST /notification-settings/preset` body도 `careMode`로 통일. 디자인 라벨 "기본/집중"은 frontend가 careMode 값으로 매핑. 호환성 깨짐 — 프론트엔드 cut-over.

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -22,6 +22,8 @@ import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.notification.NotificationSettings;
+import com.ppiyaki.notification.repository.NotificationSettingsRepository;
 import com.ppiyaki.user.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
@@ -55,13 +57,14 @@ public class DashboardService {
 
     private static final Logger log = LoggerFactory.getLogger(DashboardService.class);
 
-    private static final long DELAY_THRESHOLD_MINUTES = 60;
+    private static final long DEFAULT_DELAY_THRESHOLD_MINUTES = 60;
 
     private final UserRepository userRepository;
     private final CareRelationRepository careRelationRepository;
     private final MedicationScheduleRepository scheduleRepository;
     private final MedicationLogRepository logRepository;
     private final MedicineRepository medicineRepository;
+    private final NotificationSettingsRepository notificationSettingsRepository;
     private final PhotoUrlAssembler photoUrlAssembler;
 
     public DashboardService(
@@ -70,6 +73,7 @@ public class DashboardService {
             final MedicationScheduleRepository scheduleRepository,
             final MedicationLogRepository logRepository,
             final MedicineRepository medicineRepository,
+            final NotificationSettingsRepository notificationSettingsRepository,
             final PhotoUrlAssembler photoUrlAssembler
     ) {
         this.userRepository = userRepository;
@@ -77,7 +81,18 @@ public class DashboardService {
         this.scheduleRepository = scheduleRepository;
         this.logRepository = logRepository;
         this.medicineRepository = medicineRepository;
+        this.notificationSettingsRepository = notificationSettingsRepository;
         this.photoUrlAssembler = photoUrlAssembler;
+    }
+
+    private long resolveDelayThresholdMinutes(final Long callerId, final Long seniorId) {
+        if (callerId.equals(seniorId)) {
+            return DEFAULT_DELAY_THRESHOLD_MINUTES;
+        }
+        return notificationSettingsRepository.findByCaregiverIdAndSeniorId(callerId, seniorId)
+                .map(NotificationSettings::getMedicationDelayThresholdMinutes)
+                .map(Integer::longValue)
+                .orElse(DEFAULT_DELAY_THRESHOLD_MINUTES);
     }
 
     @Transactional(readOnly = true)
@@ -110,10 +125,11 @@ public class DashboardService {
         }
 
         final LocalDate today = LocalDate.now();
+        final long delayThresholdMinutes = resolveDelayThresholdMinutes(userId, seniorId);
         final List<SlotInfo> slots = new ArrayList<>();
         for (final MealSlot slot : MealSlot.values()) {
             slots.add(buildSlotInfo(slot, senior, schedulesBySlot.get(slot), logByScheduleId, medicineById, date,
-                    today));
+                    today, delayThresholdMinutes));
         }
 
         final DayStatus dayStatus = deriveDayStatus(slots, date, today);
@@ -146,6 +162,7 @@ public class DashboardService {
         }
 
         final LocalDate today = LocalDate.now();
+        final long delayThresholdMinutes = resolveDelayThresholdMinutes(userId, seniorId);
         final List<DayEntry> dayEntries = new ArrayList<>();
         int adherenceNumerator = 0;
         int adherenceDenominator = 0;
@@ -154,7 +171,8 @@ public class DashboardService {
             final List<SlotMarker> slotMarkers = new ArrayList<>();
             final Map<Long, MedicationLog> logBySchedule = logsByDateAndSchedule.getOrDefault(date, Map.of());
             for (final MealSlot slot : MealSlot.values()) {
-                final SlotStatus status = deriveSlotStatusForDate(slot, senior, schedules, logBySchedule, date, today);
+                final SlotStatus status = deriveSlotStatusForDate(
+                        slot, senior, schedules, logBySchedule, date, today, delayThresholdMinutes);
                 slotMarkers.add(new SlotMarker(slot, status));
                 if (date.isAfter(today) || status == SlotStatus.NOT_SCHEDULED) {
                     continue;
@@ -198,13 +216,15 @@ public class DashboardService {
         }
 
         final LocalDate today = LocalDate.now();
+        final long delayThresholdMinutes = resolveDelayThresholdMinutes(userId, seniorId);
         final List<MonthlyDashboardResponse.DayEntry> dayEntries = new ArrayList<>();
         for (int day = 1; day <= yearMonth.lengthOfMonth(); day++) {
             final LocalDate date = yearMonth.atDay(day);
             final List<SlotMarker> markers = new ArrayList<>();
             final Map<Long, MedicationLog> logBySchedule = logsByDateAndSchedule.getOrDefault(date, Map.of());
             for (final MealSlot slot : MealSlot.values()) {
-                final SlotStatus status = deriveSlotStatusForDate(slot, senior, schedules, logBySchedule, date, today);
+                final SlotStatus status = deriveSlotStatusForDate(
+                        slot, senior, schedules, logBySchedule, date, today, delayThresholdMinutes);
                 markers.add(new SlotMarker(slot, status));
             }
             final DayStatus dayStatus = deriveDayStatusFromMarkers(markers, date, today);
@@ -220,7 +240,8 @@ public class DashboardService {
             final List<MedicationSchedule> allSchedules,
             final Map<Long, MedicationLog> logBySchedule,
             final LocalDate date,
-            final LocalDate today
+            final LocalDate today,
+            final long delayThresholdMinutes
     ) {
         final LocalTime mealTime = slot.resolveTime(senior);
         final List<MedicationSchedule> slotSchedules = allSchedules.stream()
@@ -239,7 +260,7 @@ public class DashboardService {
                 break;
             }
         }
-        return deriveSlotStatus(representativeLog, mealTime, date, today);
+        return deriveSlotStatus(representativeLog, mealTime, date, today, delayThresholdMinutes);
     }
 
     private DayStatus deriveDayStatusFromMarkers(
@@ -276,7 +297,8 @@ public class DashboardService {
             final Map<Long, MedicationLog> logByScheduleId,
             final Map<Long, Medicine> medicineById,
             final LocalDate date,
-            final LocalDate today
+            final LocalDate today,
+            final long delayThresholdMinutes
     ) {
         final LocalTime mealTime = slot.resolveTime(senior);
         if (slotSchedules == null || slotSchedules.isEmpty() || mealTime == null) {
@@ -293,7 +315,7 @@ public class DashboardService {
             }
         }
 
-        final SlotStatus status = deriveSlotStatus(representativeLog, mealTime, date, today);
+        final SlotStatus status = deriveSlotStatus(representativeLog, mealTime, date, today, delayThresholdMinutes);
         final LocalDateTime takenAt = representativeLog != null ? representativeLog.getTakenAt() : null;
         final String photoUrl = representativeLog != null
                 ? photoUrlAssembler.toFullUrl(representativeLog.getPhotoObjectKey()) : null;
@@ -312,7 +334,8 @@ public class DashboardService {
             final MedicationLog logRow,
             final LocalTime mealTime,
             final LocalDate date,
-            final LocalDate today
+            final LocalDate today,
+            final long delayThresholdMinutes
     ) {
         final boolean pastDate = date.isBefore(today);
         if (logRow == null || logRow.getStatus() != LogStatus.TAKEN) {
@@ -320,7 +343,7 @@ public class DashboardService {
         }
         final LocalDateTime mealDateTime = LocalDateTime.of(date, mealTime);
         final long minutesLate = Duration.between(mealDateTime, logRow.getTakenAt()).toMinutes();
-        if (minutesLate <= DELAY_THRESHOLD_MINUTES) {
+        if (minutesLate <= delayThresholdMinutes) {
             return SlotStatus.PERFECT;
         }
         return SlotStatus.DELAYED;

--- a/src/main/java/com/ppiyaki/notification/Notification.java
+++ b/src/main/java/com/ppiyaki/notification/Notification.java
@@ -106,6 +106,28 @@ public class Notification extends BaseTimeEntity {
         );
     }
 
+    public static Notification createForMedicationDelay(
+            final Long caregiverId,
+            final Long seniorId,
+            final String title,
+            final String body,
+            final LocalDate targetDate,
+            final String mealSlot,
+            final Long scheduleId
+    ) {
+        return new Notification(
+                caregiverId,
+                seniorId,
+                NotificationCategory.MEDICATION_DELAY,
+                title,
+                body,
+                null,
+                targetDate,
+                mealSlot,
+                scheduleId
+        );
+    }
+
     public boolean isRead() {
         return this.readAt != null;
     }

--- a/src/main/java/com/ppiyaki/notification/NotificationMode.java
+++ b/src/main/java/com/ppiyaki/notification/NotificationMode.java
@@ -1,7 +1,0 @@
-package com.ppiyaki.notification;
-
-public enum NotificationMode {
-
-    STANDARD,
-    INTENSIVE
-}

--- a/src/main/java/com/ppiyaki/notification/controller/NotificationSettingsController.java
+++ b/src/main/java/com/ppiyaki/notification/controller/NotificationSettingsController.java
@@ -48,6 +48,6 @@ public class NotificationSettingsController {
             @PathVariable final Long seniorId,
             @Valid @RequestBody final PresetApplyRequest request
     ) {
-        return ResponseEntity.ok(notificationSettingsService.applyPreset(caregiverId, seniorId, request.mode()));
+        return ResponseEntity.ok(notificationSettingsService.applyPreset(caregiverId, seniorId, request.careMode()));
     }
 }

--- a/src/main/java/com/ppiyaki/notification/controller/dto/PresetApplyRequest.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/PresetApplyRequest.java
@@ -1,9 +1,9 @@
 package com.ppiyaki.notification.controller.dto;
 
-import com.ppiyaki.notification.NotificationMode;
+import com.ppiyaki.user.CareMode;
 import jakarta.validation.constraints.NotNull;
 
 public record PresetApplyRequest(
-        @NotNull NotificationMode mode
+        @NotNull CareMode careMode
 ) {
 }

--- a/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
@@ -40,4 +40,12 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             final java.time.LocalDate targetDate,
             final String mealSlot
     );
+
+    boolean existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
+            final Long userId,
+            final NotificationCategory category,
+            final Long seniorId,
+            final java.time.LocalDate targetDate,
+            final Long scheduleId
+    );
 }

--- a/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
@@ -1,0 +1,176 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.medication.LogStatus;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationLog;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationLogRepository;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.notification.DeviceToken;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.NotificationCategory;
+import com.ppiyaki.notification.NotificationSettings;
+import com.ppiyaki.notification.push.PushPayload;
+import com.ppiyaki.notification.push.PushSendResult;
+import com.ppiyaki.notification.push.PushSender;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.notification.repository.NotificationSettingsRepository;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class MedicationDelayDispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(MedicationDelayDispatcher.class);
+    private static final Map<MealSlot, String> SLOT_LABELS = Map.of(
+            MealSlot.BREAKFAST, "아침",
+            MealSlot.LUNCH, "점심",
+            MealSlot.DINNER, "저녁"
+    );
+
+    private final UserRepository userRepository;
+    private final CareRelationRepository careRelationRepository;
+    private final MedicationScheduleRepository scheduleRepository;
+    private final MedicationLogRepository logRepository;
+    private final NotificationSettingsRepository settingsRepository;
+    private final NotificationRepository notificationRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final PushSender pushSender;
+    private final Clock clock;
+
+    public MedicationDelayDispatcher(
+            final UserRepository userRepository,
+            final CareRelationRepository careRelationRepository,
+            final MedicationScheduleRepository scheduleRepository,
+            final MedicationLogRepository logRepository,
+            final NotificationSettingsRepository settingsRepository,
+            final NotificationRepository notificationRepository,
+            final DeviceTokenRepository deviceTokenRepository,
+            final PushSender pushSender,
+            final Clock clock
+    ) {
+        this.userRepository = userRepository;
+        this.careRelationRepository = careRelationRepository;
+        this.scheduleRepository = scheduleRepository;
+        this.logRepository = logRepository;
+        this.settingsRepository = settingsRepository;
+        this.notificationRepository = notificationRepository;
+        this.deviceTokenRepository = deviceTokenRepository;
+        this.pushSender = pushSender;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public int dispatchForSenior(final User senior, final LocalDate today) {
+        int dispatched = 0;
+        final List<CareRelation> relations = careRelationRepository.findBySeniorIdAndDeletedAtIsNull(senior.getId());
+        if (relations.isEmpty()) {
+            return 0;
+        }
+        for (final MealSlot slot : MealSlot.values()) {
+            final LocalTime mealTime = slot.resolveTime(senior);
+            if (mealTime == null) {
+                continue;
+            }
+            final LocalDateTime mealDateTime = LocalDateTime.of(today, mealTime);
+            final LocalDateTime now = LocalDateTime.now(clock);
+            if (now.isBefore(mealDateTime)) {
+                continue;
+            }
+
+            final List<MedicationSchedule> slotSchedules = scheduleRepository.findActiveByOwnerAndMealSlot(senior
+                    .getId(), today, slot);
+            if (slotSchedules.isEmpty()) {
+                continue;
+            }
+            final Set<Long> takenScheduleIds = new HashSet<>();
+            for (final MedicationLog logRow : logRepository.findBySeniorIdAndTargetDate(senior.getId(), today)) {
+                if (logRow.getStatus() == LogStatus.TAKEN) {
+                    takenScheduleIds.add(logRow.getScheduleId());
+                }
+            }
+
+            for (final CareRelation relation : relations) {
+                final Long caregiverId = relation.getCaregiverId();
+                final NotificationSettings settings = settingsRepository
+                        .findByCaregiverIdAndSeniorId(caregiverId, senior.getId())
+                        .orElse(null);
+                if (settings != null && !settings.isMedicationDelayEnabled()) {
+                    continue;
+                }
+                final long thresholdMinutes = settings != null
+                        ? settings.getMedicationDelayThresholdMinutes() : 60L;
+                if (now.isBefore(mealDateTime.plusMinutes(thresholdMinutes))) {
+                    continue;
+                }
+                for (final MedicationSchedule schedule : slotSchedules) {
+                    if (takenScheduleIds.contains(schedule.getId())) {
+                        continue;
+                    }
+                    if (notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
+                            caregiverId, NotificationCategory.MEDICATION_DELAY, senior.getId(), today,
+                            schedule.getId())) {
+                        continue;
+                    }
+                    sendDelayNotification(caregiverId, senior, slot, today, schedule, thresholdMinutes);
+                    dispatched++;
+                }
+            }
+        }
+        return dispatched;
+    }
+
+    private void sendDelayNotification(
+            final Long caregiverId,
+            final User senior,
+            final MealSlot slot,
+            final LocalDate today,
+            final MedicationSchedule schedule,
+            final long thresholdMinutes
+    ) {
+        final String slotLabel = SLOT_LABELS.getOrDefault(slot, slot.name());
+        final String title = "복약 지연 알림";
+        final String body = String.format(
+                "%s 어르신이 %s 약 복용 시간을 %d분 넘겼습니다.",
+                senior.getNickname() == null ? "" : senior.getNickname(),
+                slotLabel, thresholdMinutes);
+        final Notification saved = notificationRepository.save(
+                Notification.createForMedicationDelay(
+                        caregiverId, senior.getId(), title, body, today, slot.name(), schedule.getId()));
+        log.info("MEDICATION_DELAY notification created (id={}, caregiver={}, senior={}, slot={}, schedule={})",
+                saved.getId(), caregiverId, senior.getId(), slot, schedule.getId());
+
+        final List<DeviceToken> tokens = deviceTokenRepository.findByUserIdAndIsActiveTrue(caregiverId);
+        for (final DeviceToken token : tokens) {
+            final PushSendResult result = pushSender.send(token.getToken(),
+                    new PushPayload(title, body, Map.of(
+                            "category", "MEDICATION_DELAY",
+                            "seniorId", String.valueOf(senior.getId()),
+                            "scheduleId", String.valueOf(schedule.getId()),
+                            "mealSlot", slot.name()
+                    )));
+            if (result.tokenInvalid()) {
+                token.deactivate();
+            }
+        }
+    }
+
+    public Iterable<User> findAllSeniorsWithMealTimes() {
+        return userRepository.findAllByRoleWithMealTimesSet(com.ppiyaki.user.UserRole.SENIOR);
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/service/MedicationDelayScheduler.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationDelayScheduler.java
@@ -1,0 +1,35 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.user.User;
+import java.time.Clock;
+import java.time.LocalDate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MedicationDelayScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(MedicationDelayScheduler.class);
+
+    private final MedicationDelayDispatcher dispatcher;
+    private final Clock clock;
+
+    public MedicationDelayScheduler(final MedicationDelayDispatcher dispatcher, final Clock clock) {
+        this.dispatcher = dispatcher;
+        this.clock = clock;
+    }
+
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    public void dispatchDue() {
+        final LocalDate today = LocalDate.now(clock);
+        int total = 0;
+        for (final User senior : dispatcher.findAllSeniorsWithMealTimes()) {
+            total += dispatcher.dispatchForSenior(senior, today);
+        }
+        if (total > 0) {
+            log.info("MedicationDelayScheduler dispatched {} delay alerts at {}", total, today);
+        }
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/service/NotificationSettingsService.java
+++ b/src/main/java/com/ppiyaki/notification/service/NotificationSettingsService.java
@@ -2,11 +2,11 @@ package com.ppiyaki.notification.service;
 
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
-import com.ppiyaki.notification.NotificationMode;
 import com.ppiyaki.notification.NotificationSettings;
 import com.ppiyaki.notification.controller.dto.NotificationSettingsResponse;
 import com.ppiyaki.notification.controller.dto.NotificationSettingsUpdateRequest;
 import com.ppiyaki.notification.repository.NotificationSettingsRepository;
+import com.ppiyaki.user.CareMode;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,11 +55,11 @@ public class NotificationSettingsService {
     public NotificationSettingsResponse applyPreset(
             final Long caregiverId,
             final Long seniorId,
-            final NotificationMode mode
+            final CareMode mode
     ) {
         validateCaregiverAccess(caregiverId, seniorId);
         final NotificationSettings settings = findOrCreate(caregiverId, seniorId);
-        if (mode == NotificationMode.INTENSIVE) {
+        if (mode == CareMode.MANAGED) {
             settings.applyIntensivePreset();
         } else {
             settings.applyStandardPreset();

--- a/src/main/java/com/ppiyaki/user/controller/dto/OnboardingRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/OnboardingRequest.java
@@ -1,6 +1,6 @@
 package com.ppiyaki.user.controller.dto;
 
-import com.ppiyaki.notification.NotificationMode;
+import com.ppiyaki.user.CareMode;
 import com.ppiyaki.user.Gender;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -16,7 +16,7 @@ public record OnboardingRequest(
     public record SeniorEntry(
             @NotBlank String nickname,
             @NotNull Gender gender,
-            @NotNull NotificationMode notificationMode
+            @NotNull CareMode careMode
     ) {
     }
 }

--- a/src/main/java/com/ppiyaki/user/repository/CareRelationRepository.java
+++ b/src/main/java/com/ppiyaki/user/repository/CareRelationRepository.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.user.repository;
 
 import com.ppiyaki.user.CareRelation;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface CareRelationRepository extends JpaRepository<CareRelation, Long
             final Long caregiverId,
             final Long seniorId
     );
+
+    List<CareRelation> findBySeniorIdAndDeletedAtIsNull(final Long seniorId);
 }

--- a/src/main/java/com/ppiyaki/user/service/OnboardingService.java
+++ b/src/main/java/com/ppiyaki/user/service/OnboardingService.java
@@ -2,7 +2,6 @@ package com.ppiyaki.user.service;
 
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
-import com.ppiyaki.notification.NotificationMode;
 import com.ppiyaki.notification.NotificationSettings;
 import com.ppiyaki.notification.repository.NotificationSettingsRepository;
 import com.ppiyaki.pet.Pet;
@@ -57,7 +56,7 @@ public class OnboardingService {
         for (final OnboardingRequest.SeniorEntry seniorEntry : onboardingRequest.seniors()) {
             final User senior = userRepository.save(
                     User.createSenior(seniorEntry.nickname(), seniorEntry.gender()));
-            senior.changeCareMode(resolveCareMode(seniorEntry.notificationMode()));
+            senior.changeCareMode(seniorEntry.careMode());
 
             final Pet pet = petRepository.save(Pet.create());
             senior.assignPet(pet.getId());
@@ -65,7 +64,7 @@ public class OnboardingService {
             careRelationRepository.save(CareRelation.createLinked(senior.getId(), caregiverId));
 
             notificationSettingsRepository.save(
-                    buildSettingsForPreset(caregiverId, senior.getId(), seniorEntry.notificationMode()));
+                    buildSettingsForCareMode(caregiverId, senior.getId(), seniorEntry.careMode()));
 
             seniorResults.add(new SeniorResult(senior.getId(), senior.getNickname(), pet.getId()));
         }
@@ -73,18 +72,14 @@ public class OnboardingService {
         return new OnboardingResponse(caregiver.getNickname(), seniorResults);
     }
 
-    private NotificationSettings buildSettingsForPreset(
+    private NotificationSettings buildSettingsForCareMode(
             final Long caregiverId,
             final Long seniorId,
-            final NotificationMode mode
+            final CareMode mode
     ) {
-        if (mode == NotificationMode.INTENSIVE) {
+        if (mode == CareMode.MANAGED) {
             return NotificationSettings.createWithIntensivePreset(caregiverId, seniorId);
         }
         return NotificationSettings.createWithStandardPreset(caregiverId, seniorId);
-    }
-
-    private CareMode resolveCareMode(final NotificationMode mode) {
-        return mode == NotificationMode.INTENSIVE ? CareMode.MANAGED : CareMode.AUTONOMOUS;
     }
 }

--- a/src/test/java/com/ppiyaki/notification/controller/NotificationSettingsControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/NotificationSettingsControllerE2ETest.java
@@ -38,7 +38,7 @@ class NotificationSettingsControllerE2ETest {
     }
 
     @Test
-    @DisplayName("조회 + PUT(mode→CUSTOM) + 프리셋 적용(INTENSIVE) + 다른 보호자 접근 시 403")
+    @DisplayName("조회 + PUT 항목 갱신 + 프리셋 적용(MANAGED→INTENSIVE preset) + 다른 보호자 접근 시 403")
     void notification_settings_flow() {
         final String ownerToken = signupAndGetToken("ns_owner");
         final String otherToken = signupAndGetToken("ns_other");
@@ -83,7 +83,7 @@ class NotificationSettingsControllerE2ETest {
                 .header("Authorization", "Bearer " + ownerToken)
                 .contentType(ContentType.JSON)
                 .body("""
-                        {"mode": "INTENSIVE"}
+                        {"careMode": "MANAGED"}
                         """)
                 .when()
                 .post("/api/v1/seniors/" + seniorId + "/notification-settings/preset")
@@ -111,7 +111,7 @@ class NotificationSettingsControllerE2ETest {
                         {
                           "nickname": "보호자온보딩",
                           "seniors": [
-                            {"nickname": "NS시니어", "gender": "FEMALE", "notificationMode": "STANDARD"}
+                            {"nickname": "NS시니어", "gender": "FEMALE", "careMode": "AUTONOMOUS"}
                           ]
                         }
                         """)

--- a/src/test/java/com/ppiyaki/user/controller/OnboardingControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/OnboardingControllerE2ETest.java
@@ -69,12 +69,12 @@ class OnboardingControllerE2ETest {
                                 {
                                     "nickname": "온보딩할머니",
                                     "gender": "FEMALE",
-                                    "notificationMode": "STANDARD"
+                                    "careMode": "AUTONOMOUS"
                                 },
                                 {
                                     "nickname": "온보딩할아버지",
                                     "gender": "MALE",
-                                    "notificationMode": "INTENSIVE"
+                                    "careMode": "MANAGED"
                                 }
                             ]
                         }

--- a/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
-import com.ppiyaki.notification.NotificationMode;
 import com.ppiyaki.notification.NotificationSettings;
 import com.ppiyaki.notification.repository.NotificationSettingsRepository;
 import com.ppiyaki.pet.Pet;
@@ -83,8 +82,8 @@ class OnboardingServiceTest {
         final OnboardingRequest onboardingRequest = new OnboardingRequest(
                 "보호자닉네임",
                 List.of(
-                        new SeniorEntry("할머니", Gender.FEMALE, NotificationMode.STANDARD),
-                        new SeniorEntry("할아버지", Gender.MALE, NotificationMode.INTENSIVE)
+                        new SeniorEntry("할머니", Gender.FEMALE, CareMode.AUTONOMOUS),
+                        new SeniorEntry("할아버지", Gender.MALE, CareMode.MANAGED)
                 )
         );
 
@@ -111,7 +110,7 @@ class OnboardingServiceTest {
 
         final OnboardingRequest onboardingRequest = new OnboardingRequest(
                 "닉네임",
-                List.of(new SeniorEntry("할머니", Gender.FEMALE, NotificationMode.STANDARD))
+                List.of(new SeniorEntry("할머니", Gender.FEMALE, CareMode.AUTONOMOUS))
         );
 
         // when & then


### PR DESCRIPTION
## TO-BE
복약 알림 Feature Spec §6 PR 7 + caregiver-dashboard.md §8 Q5 해소.

### 발송 트리거
- `MedicationDelayScheduler` (`@Scheduled` 매 분, Asia/Seoul)
- `MedicationDelayDispatcher` — 시니어 + slot 별 미인증 schedule 식별 + 활성 보호자별 dispatch
  - 보호자별 `notification_settings.medication_delay_threshold_minutes` 적용 (없으면 60 default)
  - `medicationDelayEnabled=false` 보호자는 skip
  - 자연키 멱등 `(caregiver_id, MEDICATION_DELAY, senior_id, target_date, schedule_id)`
  - 메시지: "{시니어 닉네임} 어르신이 {meal} 약 복용 시간을 N분 넘겼습니다"
  - tokenInvalid 응답 시 device token deactivate

### Dashboard 통합 (Q5 해소)
- `DashboardService.DELAY_THRESHOLD_MINUTES = 60` 하드코딩 제거 → caller 보호자의 settings 참조
- 시니어 본인 caller(userId == seniorId)일 때는 default 60 fallback
- `deriveSlotStatus`/`deriveSlotStatusForDate`/`buildSlotInfo` 시그니처에 threshold 인자 전파
- `caregiver-dashboard.md` §8 Q5 strikethrough + §9 결정 로그

### 신규/변경
- `Notification.createForMedicationDelay(...)` static factory
- `NotificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(...)` 멱등 lookup
- `CareRelationRepository.findBySeniorIdAndDeletedAtIsNull(...)` (active caregivers)

## 비범위
- DUR 긴급 경고 — PR 8
- 가족 안전망 — PR 9
- 복약 완료 — PR 10
- 단위 테스트 (dispatcher) — push 통합 흐름이 mock 의존 큼. 운영 + manual + cron 동작 검증 우선

## AI 체크리스트
- [x] 도메인 모델 영향 — Notification factory 추가
- [x] DB 마이그레이션 — 변경 없음
- [x] 에러 코드 — 추가 없음 (cron internal)
- [x] spec 갱신 — caregiver-dashboard.md §8 Q5, §9
- [ ] **device token API Notion 명세 등록** — 후속 일괄 (사용자 결정)

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)