### PR TITLE
feat(medication): 보호자 DUR 긴급 경고 알림 발송

### DIFF
--- a/src/main/java/com/ppiyaki/health/service/DurCheckService.java
+++ b/src/main/java/com/ppiyaki/health/service/DurCheckService.java
@@ -50,19 +50,22 @@ public class DurCheckService {
     private final MedicationScheduleRepository medicationScheduleRepository;
     private final CareRelationRepository careRelationRepository;
     private final MfdsApiClient mfdsApiClient;
+    private final com.ppiyaki.notification.service.DurWarningDispatcher durWarningDispatcher;
 
     public DurCheckService(
             final DurCheckRepository durCheckRepository,
             final MedicineRepository medicineRepository,
             final MedicationScheduleRepository medicationScheduleRepository,
             final CareRelationRepository careRelationRepository,
-            final MfdsApiClient mfdsApiClient
+            final MfdsApiClient mfdsApiClient,
+            final com.ppiyaki.notification.service.DurWarningDispatcher durWarningDispatcher
     ) {
         this.durCheckRepository = durCheckRepository;
         this.medicineRepository = medicineRepository;
         this.medicationScheduleRepository = medicationScheduleRepository;
         this.careRelationRepository = careRelationRepository;
         this.mfdsApiClient = mfdsApiClient;
+        this.durWarningDispatcher = durWarningDispatcher;
     }
 
     @Transactional
@@ -115,6 +118,8 @@ public class DurCheckService {
 
         log.info("DUR check completed: medicineId={} level={} warnings={}",
                 medicineId, warningLevel, warnings.size());
+
+        durWarningDispatcher.dispatch(medicine.getOwnerId(), medicineId, warningLevel);
 
         return DurCheckResponse.from(durCheck, warnings, false);
     }

--- a/src/main/java/com/ppiyaki/notification/Notification.java
+++ b/src/main/java/com/ppiyaki/notification/Notification.java
@@ -128,6 +128,26 @@ public class Notification extends BaseTimeEntity {
         );
     }
 
+    public static Notification createForDurWarning(
+            final Long caregiverId,
+            final Long seniorId,
+            final String title,
+            final String body,
+            final Long medicineId
+    ) {
+        return new Notification(
+                caregiverId,
+                seniorId,
+                NotificationCategory.DUR_WARNING,
+                title,
+                body,
+                null,
+                null,
+                null,
+                medicineId
+        );
+    }
+
     public boolean isRead() {
         return this.readAt != null;
     }

--- a/src/main/java/com/ppiyaki/notification/service/DurWarningDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/DurWarningDispatcher.java
@@ -1,0 +1,109 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.health.DurWarningLevel;
+import com.ppiyaki.notification.DeviceToken;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.NotificationCategory;
+import com.ppiyaki.notification.NotificationSettings;
+import com.ppiyaki.notification.push.PushPayload;
+import com.ppiyaki.notification.push.PushSendResult;
+import com.ppiyaki.notification.push.PushSender;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.notification.repository.NotificationSettingsRepository;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DurWarningDispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(DurWarningDispatcher.class);
+
+    private final UserRepository userRepository;
+    private final CareRelationRepository careRelationRepository;
+    private final NotificationSettingsRepository settingsRepository;
+    private final NotificationRepository notificationRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final PushSender pushSender;
+
+    public DurWarningDispatcher(
+            final UserRepository userRepository,
+            final CareRelationRepository careRelationRepository,
+            final NotificationSettingsRepository settingsRepository,
+            final NotificationRepository notificationRepository,
+            final DeviceTokenRepository deviceTokenRepository,
+            final PushSender pushSender
+    ) {
+        this.userRepository = userRepository;
+        this.careRelationRepository = careRelationRepository;
+        this.settingsRepository = settingsRepository;
+        this.notificationRepository = notificationRepository;
+        this.deviceTokenRepository = deviceTokenRepository;
+        this.pushSender = pushSender;
+    }
+
+    @Transactional
+    public int dispatch(final Long seniorId, final Long medicineId, final DurWarningLevel level) {
+        if (level != DurWarningLevel.WARN && level != DurWarningLevel.BLOCK) {
+            return 0;
+        }
+        final List<CareRelation> relations = careRelationRepository.findBySeniorIdAndDeletedAtIsNull(seniorId);
+        if (relations.isEmpty()) {
+            return 0;
+        }
+        final User senior = userRepository.findById(seniorId).orElse(null);
+        if (senior == null) {
+            return 0;
+        }
+
+        final String title = "처방전 안전 경고";
+        final String body = String.format(
+                "%s 어르신의 처방전에 %s 주의 약물이 포함되어 있습니다.",
+                senior.getNickname() == null ? "" : senior.getNickname(),
+                level == DurWarningLevel.BLOCK ? "복용 금기" : "주의 필요");
+
+        int dispatched = 0;
+        for (final CareRelation relation : relations) {
+            final Long caregiverId = relation.getCaregiverId();
+            final NotificationSettings settings = settingsRepository
+                    .findByCaregiverIdAndSeniorId(caregiverId, seniorId)
+                    .orElse(null);
+            if (settings != null && !settings.isDurWarningEnabled()) {
+                continue;
+            }
+            if (notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
+                    caregiverId, NotificationCategory.DUR_WARNING, seniorId, null, medicineId)) {
+                continue;
+            }
+
+            final Notification saved = notificationRepository.save(
+                    Notification.createForDurWarning(caregiverId, seniorId, title, body, medicineId));
+            log.info("DUR_WARNING notification created (id={}, caregiver={}, senior={}, medicine={}, level={})",
+                    saved.getId(), caregiverId, seniorId, medicineId, level);
+
+            final List<DeviceToken> tokens = deviceTokenRepository.findByUserIdAndIsActiveTrue(caregiverId);
+            for (final DeviceToken token : tokens) {
+                final PushSendResult result = pushSender.send(token.getToken(),
+                        new PushPayload(title, body, Map.of(
+                                "category", "DUR_WARNING",
+                                "seniorId", String.valueOf(seniorId),
+                                "medicineId", String.valueOf(medicineId),
+                                "level", level.name()
+                        )));
+                if (result.tokenInvalid()) {
+                    token.deactivate();
+                }
+            }
+            dispatched++;
+        }
+        return dispatched;
+    }
+}


### PR DESCRIPTION
## TO-BE
spec §6 PR 8.

`DurCheckService.check` 후 위험 등급(WARN/BLOCK) 검출 시 시니어의 활성 보호자에게 자동 푸시 + 인앱 알림.

### 구조
- `DurWarningDispatcher` (notification 도메인)
  - WARN/BLOCK만 처리 (NONE/INFO skip)
  - 보호자별 `settings.durWarningEnabled` 체크 (false면 skip)
  - 자연키 멱등 (`caregiver_id`, `DUR_WARNING`, `senior_id`, `schedule_id=medicineId`) — 같은 약 위험에 중복 발송 방지
  - 메시지: "{시니어 닉네임} 어르신의 처방전에 {복용 금기/주의 필요} 약물이 포함되어 있습니다."
- `DurCheckService.check` 끝에서 `dispatcher.dispatch(medicine.getOwnerId(), medicineId, warningLevel)` 호출

### 신규/변경
- `Notification.createForDurWarning(...)` static factory
- `DurCheckService` — `DurWarningDispatcher` 주입 + check 후 호출

## 비범위
- 처방전 confirm 시점 자동 DUR check 트리거 — 현재는 `DurCheckController.check` (사용자 호출) 흐름 그대로 활용. 디자인이 처방전 등록 시점 발송이라면 별도 PR에서 hookup
- 가족 안전망 알림 — PR 9
- 복약 완료 — PR 10

## AI 체크리스트
- [x] 도메인 영향 — Notification factory 추가 (스키마 변경 없음)
- [x] DB 마이그레이션 — 변경 없음
- [x] 에러 코드 — 추가 없음
- [x] DurCheckService 시그니처 변경 — 생성자에 DurWarningDispatcher 주입
- [ ] **Notion API 명세** — 신규 endpoint 없음 (internal cron + DUR check hook). N/A

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 약물 상호작용 위험도 평가 결과에 따라 보호자에게 자동으로 알림을 전송하는 기능이 추가되었습니다. 고위험 약물 조합 감지 시 관련 보호자가 실시간으로 푸시 알림을 받을 수 있습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/297)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->