### PR TITLE
feat(medication): 보호자 가족 안전망 알림 + 시니어 last_active_at 추적

### DIFF
--- a/src/main/java/com/ppiyaki/notification/Notification.java
+++ b/src/main/java/com/ppiyaki/notification/Notification.java
@@ -148,6 +148,26 @@ public class Notification extends BaseTimeEntity {
         );
     }
 
+    public static Notification createForFamilySafety(
+            final Long caregiverId,
+            final Long seniorId,
+            final String title,
+            final String body,
+            final LocalDate targetDate
+    ) {
+        return new Notification(
+                caregiverId,
+                seniorId,
+                NotificationCategory.FAMILY_SAFETY,
+                title,
+                body,
+                null,
+                targetDate,
+                null,
+                null
+        );
+    }
+
     public boolean isRead() {
         return this.readAt != null;
     }

--- a/src/main/java/com/ppiyaki/notification/NotificationWebMvcConfig.java
+++ b/src/main/java/com/ppiyaki/notification/NotificationWebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.ppiyaki.notification;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class NotificationWebMvcConfig implements WebMvcConfigurer {
+
+    private final SeniorActivityInterceptor seniorActivityInterceptor;
+
+    public NotificationWebMvcConfig(final SeniorActivityInterceptor seniorActivityInterceptor) {
+        this.seniorActivityInterceptor = seniorActivityInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(seniorActivityInterceptor)
+                .addPathPatterns("/api/**");
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/SeniorActivityInterceptor.java
+++ b/src/main/java/com/ppiyaki/notification/SeniorActivityInterceptor.java
@@ -1,0 +1,82 @@
+package com.ppiyaki.notification;
+
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
+import com.ppiyaki.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class SeniorActivityInterceptor implements HandlerInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(SeniorActivityInterceptor.class);
+    private static final long THROTTLE_SECONDS = 60;
+
+    private final UserRepository userRepository;
+    private final TransactionTemplate transactionTemplate;
+    private final Clock clock;
+    private final ConcurrentMap<Long, LocalDateTime> lastTouchInMemory = new ConcurrentHashMap<>();
+
+    public SeniorActivityInterceptor(
+            final UserRepository userRepository,
+            final PlatformTransactionManager transactionManager,
+            final Clock clock
+    ) {
+        this.userRepository = userRepository;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
+        this.clock = clock;
+    }
+
+    @Override
+    public boolean preHandle(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Object handler
+    ) {
+        final Long userId = resolveAuthenticatedUserId();
+        if (userId == null) {
+            return true;
+        }
+        final LocalDateTime now = LocalDateTime.now(clock);
+        final LocalDateTime cached = lastTouchInMemory.get(userId);
+        if (cached != null && cached.plusSeconds(THROTTLE_SECONDS).isAfter(now)) {
+            return true;
+        }
+        lastTouchInMemory.put(userId, now);
+        try {
+            transactionTemplate.executeWithoutResult(status -> {
+                final User user = userRepository.findById(userId).orElse(null);
+                if (user != null && user.getRole() == UserRole.SENIOR) {
+                    user.touchActiveAt(now);
+                }
+            });
+        } catch (final RuntimeException ex) {
+            log.warn("SeniorActivityInterceptor failed to touch lastActiveAt for userId={}", userId, ex);
+        }
+        return true;
+    }
+
+    private Long resolveAuthenticatedUserId() {
+        final Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            return null;
+        }
+        final Object principal = auth.getPrincipal();
+        if (principal instanceof Long longId) {
+            return longId;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
@@ -48,4 +48,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             final java.time.LocalDate targetDate,
             final Long scheduleId
     );
+
+    java.util.Optional<Notification> findFirstByUserIdAndCategoryAndSeniorIdOrderByCreatedAtDesc(
+            final Long userId,
+            final NotificationCategory category,
+            final Long seniorId
+    );
 }

--- a/src/main/java/com/ppiyaki/notification/service/FamilySafetyDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/FamilySafetyDispatcher.java
@@ -1,0 +1,130 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.notification.DeviceToken;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.NotificationCategory;
+import com.ppiyaki.notification.NotificationSettings;
+import com.ppiyaki.notification.push.PushPayload;
+import com.ppiyaki.notification.push.PushSendResult;
+import com.ppiyaki.notification.push.PushSender;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.notification.repository.NotificationSettingsRepository;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class FamilySafetyDispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(FamilySafetyDispatcher.class);
+    private static final int DEFAULT_THRESHOLD_HOURS = 48;
+
+    private final UserRepository userRepository;
+    private final CareRelationRepository careRelationRepository;
+    private final NotificationSettingsRepository settingsRepository;
+    private final NotificationRepository notificationRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final PushSender pushSender;
+    private final Clock clock;
+
+    public FamilySafetyDispatcher(
+            final UserRepository userRepository,
+            final CareRelationRepository careRelationRepository,
+            final NotificationSettingsRepository settingsRepository,
+            final NotificationRepository notificationRepository,
+            final DeviceTokenRepository deviceTokenRepository,
+            final PushSender pushSender,
+            final Clock clock
+    ) {
+        this.userRepository = userRepository;
+        this.careRelationRepository = careRelationRepository;
+        this.settingsRepository = settingsRepository;
+        this.notificationRepository = notificationRepository;
+        this.deviceTokenRepository = deviceTokenRepository;
+        this.pushSender = pushSender;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public int run() {
+        final LocalDateTime now = LocalDateTime.now(clock);
+        final LocalDate today = LocalDate.now(clock);
+        int dispatched = 0;
+        for (final User senior : userRepository.findAllByRoleWithMealTimesSet(UserRole.SENIOR)) {
+            dispatched += dispatchForSenior(senior, now, today);
+        }
+        if (dispatched > 0) {
+            log.info("FamilySafetyDispatcher dispatched {} alerts", dispatched);
+        }
+        return dispatched;
+    }
+
+    private int dispatchForSenior(final User senior, final LocalDateTime now, final LocalDate today) {
+        final LocalDateTime lastActive = senior.getLastActiveAt();
+        if (lastActive == null) {
+            return 0;
+        }
+        final List<CareRelation> relations = careRelationRepository.findBySeniorIdAndDeletedAtIsNull(senior.getId());
+        if (relations.isEmpty()) {
+            return 0;
+        }
+        int sent = 0;
+        for (final CareRelation relation : relations) {
+            final Long caregiverId = relation.getCaregiverId();
+            final NotificationSettings settings = settingsRepository
+                    .findByCaregiverIdAndSeniorId(caregiverId, senior.getId())
+                    .orElse(null);
+            if (settings != null && !settings.isFamilySafetyEnabled()) {
+                continue;
+            }
+            final int thresholdHours = settings != null
+                    ? settings.getFamilySafetyThresholdHours() : DEFAULT_THRESHOLD_HOURS;
+            if (now.isBefore(lastActive.plusHours(thresholdHours))) {
+                continue;
+            }
+            // 시니어가 재접속할 때까지 1회만 (Q8) — last_active_at 갱신 후의 가장 최근 row 확인
+            final var lastSent = notificationRepository
+                    .findFirstByUserIdAndCategoryAndSeniorIdOrderByCreatedAtDesc(
+                            caregiverId, NotificationCategory.FAMILY_SAFETY, senior.getId());
+            if (lastSent.isPresent() && lastSent.get().getCreatedAt() != null
+                    && lastSent.get().getCreatedAt().isAfter(lastActive)) {
+                continue;
+            }
+
+            final String title = "가족 안전망 알림";
+            final String body = String.format(
+                    "%s 어르신이 %d시간 이상 앱에 접속하지 않았습니다.",
+                    senior.getNickname() == null ? "" : senior.getNickname(), thresholdHours);
+            final Notification saved = notificationRepository.save(
+                    Notification.createForFamilySafety(caregiverId, senior.getId(), title, body, today));
+            log.info("FAMILY_SAFETY notification created (id={}, caregiver={}, senior={}, lastActive={})",
+                    saved.getId(), caregiverId, senior.getId(), lastActive);
+
+            final List<DeviceToken> tokens = deviceTokenRepository.findByUserIdAndIsActiveTrue(caregiverId);
+            for (final DeviceToken token : tokens) {
+                final PushSendResult result = pushSender.send(token.getToken(),
+                        new PushPayload(title, body, Map.of(
+                                "category", "FAMILY_SAFETY",
+                                "seniorId", String.valueOf(senior.getId())
+                        )));
+                if (result.tokenInvalid()) {
+                    token.deactivate();
+                }
+            }
+            sent++;
+        }
+        return sent;
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/service/FamilySafetyScheduler.java
+++ b/src/main/java/com/ppiyaki/notification/service/FamilySafetyScheduler.java
@@ -1,0 +1,19 @@
+package com.ppiyaki.notification.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FamilySafetyScheduler {
+
+    private final FamilySafetyDispatcher dispatcher;
+
+    public FamilySafetyScheduler(final FamilySafetyDispatcher dispatcher) {
+        this.dispatcher = dispatcher;
+    }
+
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+    public void runHourly() {
+        dispatcher.run();
+    }
+}

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -66,6 +66,9 @@ public class User extends BaseTimeEntity {
     @Column(name = "dinner_time")
     private LocalTime dinnerTime;
 
+    @Column(name = "last_active_at")
+    private java.time.LocalDateTime lastActiveAt;
+
     public User(
             final String loginId,
             final String password,
@@ -119,5 +122,9 @@ public class User extends BaseTimeEntity {
         this.breakfastTime = Objects.requireNonNull(breakfastTime, "breakfastTime must not be null");
         this.lunchTime = Objects.requireNonNull(lunchTime, "lunchTime must not be null");
         this.dinnerTime = Objects.requireNonNull(dinnerTime, "dinnerTime must not be null");
+    }
+
+    public void touchActiveAt(final java.time.LocalDateTime now) {
+        this.lastActiveAt = Objects.requireNonNull(now, "now must not be null");
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -232,6 +232,7 @@
         dinner_time time(6),
         created_at datetime(6),
         id bigint not null auto_increment,
+        last_active_at datetime(6),
         pet bigint,
         updated_at datetime(6),
         login_id varchar(255),


### PR DESCRIPTION
## TO-BE
spec §6 PR 9.

시니어가 보호자별 임계 시간 동안 앱 미접속 시 보호자에 자동 푸시 + 인앱 알림. 시니어 인증 요청 시 `last_active_at` 자동 갱신.

### 구조
- `users.last_active_at` 컬럼 추가 (보호 영역, 마이그레이션 필요)
- `User.touchActiveAt(now)` 도메인 메서드
- `SeniorActivityInterceptor` (`/api/**`)
  - 시니어 인증 요청 시 last_active_at 갱신
  - 1분 in-memory throttle (`ConcurrentHashMap`) → DB write 부하 없음
  - 별도 트랜잭션 (`TransactionTemplate`) — main request에 영향 X
- `FamilySafetyScheduler` (`@Scheduled` 매 시간, Asia/Seoul)
- `FamilySafetyDispatcher`
  - 보호자별 `settings.familySafetyEnabled` + `familySafetyThresholdHours` 적용
  - 자연키 멱등 — 시니어 `last_active_at` 갱신 시점 이후 가장 최근 `FAMILY_SAFETY` row 존재 여부 (Q8 — 시니어 재접속까지 1회만)
  - 메시지: "{시니어 닉네임} 어르신이 N시간 이상 앱에 접속하지 않았습니다."

### 신규
- `Notification.createForFamilySafety` factory
- `NotificationRepository.findFirstByUserIdAndCategoryAndSeniorIdOrderByCreatedAtDesc` 멱등 lookup

## DB 마이그레이션 (보호 영역)
```sql
ALTER TABLE users ADD COLUMN last_active_at DATETIME(6) NULL;
```
release 시 prod 적용.

## 비범위
- 복약 완료 알림 — PR 10

## AI 체크리스트
- [x] 도메인 영향 — User.lastActiveAt 추가
- [x] DB 마이그레이션 — `users.last_active_at` ADD (보호 영역)
- [x] 에러 코드 — 추가 없음
- [x] 인덱스 — 변경 없음 (last_active_at 단순 read)
- [x] interceptor 등록
- [ ] **Notion API 명세** — 신규 endpoint 없음 (interceptor + cron). N/A

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)