### PR TITLE
feat(user): 보호자별 연동 시니어 목록 조회 API 구현 (#303)

### DIFF
--- a/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
+++ b/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
@@ -4,13 +4,16 @@ import com.ppiyaki.user.controller.dto.CodeLoginRequest;
 import com.ppiyaki.user.controller.dto.InviteCodeRequest;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
+import com.ppiyaki.user.controller.dto.SeniorSummaryResponse;
 import com.ppiyaki.user.service.CareRelationService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +28,14 @@ public class CareRelationController {
 
     public CareRelationController(final CareRelationService careRelationService) {
         this.careRelationService = careRelationService;
+    }
+
+    @GetMapping("/care-relations/seniors")
+    public ResponseEntity<List<SeniorSummaryResponse>> readSeniors(
+            @AuthenticationPrincipal final Long userId
+    ) {
+        final List<SeniorSummaryResponse> responses = careRelationService.readSeniors(userId);
+        return ResponseEntity.ok(responses);
     }
 
     @PostMapping("/care-relations/invite")

--- a/src/main/java/com/ppiyaki/user/controller/dto/SeniorSummaryResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/SeniorSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.Gender;
+import com.ppiyaki.user.User;
+import java.time.LocalDate;
+
+public record SeniorSummaryResponse(
+        Long id,
+        String nickname,
+        LocalDate dob,
+        Gender gender,
+        CareMode careMode
+) {
+
+    public static SeniorSummaryResponse from(final User user) {
+        return new SeniorSummaryResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getDob(),
+                user.getGender(),
+                user.getCareMode()
+        );
+    }
+}

--- a/src/main/java/com/ppiyaki/user/repository/CareRelationRepository.java
+++ b/src/main/java/com/ppiyaki/user/repository/CareRelationRepository.java
@@ -13,4 +13,6 @@ public interface CareRelationRepository extends JpaRepository<CareRelation, Long
     );
 
     List<CareRelation> findBySeniorIdAndDeletedAtIsNull(final Long seniorId);
+
+    List<CareRelation> findByCaregiverIdAndDeletedAtIsNull(final Long caregiverId);
 }

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -18,6 +18,8 @@ import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,8 +60,15 @@ public class CareRelationService {
         final List<CareRelation> careRelations = careRelationRepository.findByCaregiverIdAndDeletedAtIsNull(
                 caregiverId);
 
+        final List<Long> seniorIds = careRelations.stream()
+                .map(CareRelation::getSeniorId)
+                .toList();
+
+        final Map<Long, User> seniorsById = userRepository.findAllById(seniorIds).stream()
+                .collect(Collectors.toMap(User::getId, user -> user));
+
         return careRelations.stream()
-                .map(relation -> findUserById(relation.getSeniorId()))
+                .map(relation -> seniorsById.get(relation.getSeniorId()))
                 .map(SeniorSummaryResponse::from)
                 .toList();
     }

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -4,17 +4,20 @@ import com.ppiyaki.common.auth.JwtProvider;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.common.ratelimit.RateLimiter;
+import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.InviteCode;
 import com.ppiyaki.user.InviteCode.InviteCodeWithRaw;
 import com.ppiyaki.user.User;
 import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
+import com.ppiyaki.user.controller.dto.SeniorSummaryResponse;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.InviteCodeRepository;
 import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +48,20 @@ public class CareRelationService {
         this.jwtProvider = jwtProvider;
         this.authService = authService;
         this.rateLimiter = rateLimiter;
+    }
+
+    @Transactional(readOnly = true)
+    public List<SeniorSummaryResponse> readSeniors(final Long caregiverId) {
+        final User caregiver = findUserById(caregiverId);
+        validateRole(caregiver, UserRole.CAREGIVER);
+
+        final List<CareRelation> careRelations = careRelationRepository.findByCaregiverIdAndDeletedAtIsNull(
+                caregiverId);
+
+        return careRelations.stream()
+                .map(relation -> findUserById(relation.getSeniorId()))
+                .map(SeniorSummaryResponse::from)
+                .toList();
     }
 
     @Transactional

--- a/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
@@ -1,5 +1,6 @@
 package com.ppiyaki.user.controller;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -108,5 +109,51 @@ class CareRelationControllerE2ETest {
                 .body("accessToken", notNullValue())
                 .body("refreshToken", notNullValue())
                 .body("isOnboarded", is(true));
+    }
+
+    @Test
+    @DisplayName("보호자가 연동된 시니어 목록을 조회한다")
+    void readSeniors_success() {
+        // given — 보호자 회원가입
+        final String caregiverToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "cg_code_e2e",
+                            "password": "pass1234!",
+                            "nickname": "보호자코드E2E"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("accessToken");
+
+        // given — 시니어 대리 생성
+        RestAssured.given()
+                .header("Authorization", "Bearer " + caregiverToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "nickname": "시니어코드E2E",
+                            "dob": "1945-03-15"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/seniors")
+                .then()
+                .statusCode(201);
+
+        // when & then — 시니어 목록 조회
+        RestAssured.given()
+                .header("Authorization", "Bearer " + caregiverToken)
+                .when()
+                .get("/api/v1/care-relations/seniors")
+                .then()
+                .statusCode(200)
+                .body("$", hasSize(1))
+                .body("[0].nickname", is("시니어코드E2E"));
     }
 }


### PR DESCRIPTION

  ## AS-IS
  - 보호자가 본인에게 연동된 시니어 목록을 조회하는 API 없음

  ## TO-BE
  - `GET /api/v1/care-relations/seniors` 엔드포인트 추가
  - 보호자 인증 필수, 역할 검증 (CAREGIVER만 호출 가능)
  - 연동된 활성 시니어의 기본 정보 반환 (id, nickname, dob, gender, careMode)

  ## 관련 이슈
  - closes #303

  ## 리뷰어 참고 포인트
  - 기존 CareRelationService/Controller에 메서드 추가
  - CareRelationRepository에 `findByCaregiverIdAndDeletedAtIsNull` 쿼리 추가
  - SeniorSummaryResponse DTO 신설
  - E2E 테스트 포함 (보호자 가입 → 시니어 생성 → 목록 조회)

  ## 라벨 부여 확인
  - [x] `type:feat` 라벨 1개 부여 완료
  - [x] `scope:user` 라벨 1개 부여 완료
  - [x] `ai-generated` 라벨 부여 완료
  - [x] (보호 영역 변경 시) `needs-human-review` — 해당 없음

  <details>
  <summary>AI Agent 전용 체크리스트 (해당 시 작성)</summary>

  ## AI 작업 여부
  - [x] AI 보조/생성 사용

  ## 품질 게이트 체크 (AI 작성 시)
  - [x] `./gradlew checkstyleMain spotlessCheck`
  - [x] `./gradlew test`
  - [x] 변경 범위의 회귀 가능 구간을 확인했다.
  - [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다. — 신규 엔드포인트
   추가이므로 기존 기능에 영향 없음, 롤백 시 해당 커밋 revert

  ## DDD/OOP 준수 체크 (AI 작성 시)
  - [x] 도메인 용어가 기존 컨텍스트와 일치한다.
  - [x] 계층 침범(Controller -> Repository 직접 호출 등)이 없다.
  - [x] 객체 역할/책임이 명확하며, 과도한 God Object를 만들지 않았다.

  ## 보안/민감정보 체크 (AI 작성 시)
  - [x] 시크릿(API 키/토큰/비밀번호) 하드코딩이 없다.
  - [x] 복약 기록/건강 프로필 등 의료정보를 로그/스크린샷에 노출하지 않았다.
  - [x] 민감정보가 필요한 경우 마스킹 처리했다.

  ## 예외 머지 여부 (AI 작성 시)
  - [x] 예외 머지 아님

  ## AI 작업 기록
  - 사용한 프롬프트/지시 요약: 보호자별 연동 시니어 목록 조회 API 구현 요청
  - AI가 직접 수정한 파일/범위: CareRelationRepository, CareRelationService,
  CareRelationController, SeniorSummaryResponse(신설),
  CareRelationControllerE2ETest
  - 사람이 수동 검증한 항목: 품질 게이트 실행(checkstyle, spotless, test)
  - 잔여 리스크/추가 확인 필요사항: 없음

  </details>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 주요 변경사항

* **새로운 기능**
  * 보호자가 자신이 돌보고 있는 시니어 목록을 조회할 수 있는 API가 추가되었습니다. 시니어의 ID, 닉네임, 생년월일, 성별, 돌봄 모드 정보를 반환합니다.

* **테스트**
  * 보호자가 연동된 시니어 목록을 정상 조회하는 엔드투엔드 테스트가 추가되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/304)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->