### PR TITLE
feat(pet): BadgeType 전체 리스트 조회 API 구현 (#305)

### DIFF
--- a/src/main/java/com/ppiyaki/pet/controller/PetController.java
+++ b/src/main/java/com/ppiyaki/pet/controller/PetController.java
@@ -1,7 +1,11 @@
 package com.ppiyaki.pet.controller;
 
+import com.ppiyaki.pet.BadgeType;
+import com.ppiyaki.pet.controller.dto.BadgeTypeResponse;
 import com.ppiyaki.pet.controller.dto.PetResponse;
 import com.ppiyaki.pet.service.PetService;
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,5 +26,13 @@ public class PetController {
     public ResponseEntity<PetResponse> readMyPet(@AuthenticationPrincipal final Long userId) {
         final PetResponse petResponse = petService.readMyPet(userId);
         return ResponseEntity.ok(petResponse);
+    }
+
+    @GetMapping("/badges/types")
+    public ResponseEntity<List<BadgeTypeResponse>> readBadgeTypes() {
+        final List<BadgeTypeResponse> responses = Arrays.stream(BadgeType.values())
+                .map(BadgeTypeResponse::from)
+                .toList();
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/ppiyaki/pet/controller/dto/BadgeTypeResponse.java
+++ b/src/main/java/com/ppiyaki/pet/controller/dto/BadgeTypeResponse.java
@@ -1,0 +1,18 @@
+package com.ppiyaki.pet.controller.dto;
+
+import com.ppiyaki.pet.BadgeType;
+
+public record BadgeTypeResponse(
+        String badgeType,
+        String displayName,
+        String description
+) {
+
+    public static BadgeTypeResponse from(final BadgeType badgeType) {
+        return new BadgeTypeResponse(
+                badgeType.name(),
+                badgeType.getDisplayName(),
+                badgeType.getDescription()
+        );
+    }
+}

--- a/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
@@ -1,9 +1,9 @@
 package com.ppiyaki.pet.controller;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import com.ppiyaki.pet.BadgeType;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeEach;
@@ -103,7 +103,7 @@ class PetControllerE2ETest {
                 .get("/api/v1/pets/badges/types")
                 .then()
                 .statusCode(200)
-                .body("$.size()", greaterThanOrEqualTo(5))
+                .body("$.size()", is(BadgeType.values().length))
                 .body("[0].badgeType", is(notNullValue()))
                 .body("[0].displayName", is(notNullValue()))
                 .body("[0].description", is(notNullValue()));

--- a/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
@@ -1,5 +1,6 @@
 package com.ppiyaki.pet.controller;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -73,5 +74,38 @@ class PetControllerE2ETest {
                 .body("streak", is(0))
                 .body("badges", is(notNullValue()))
                 .body("badges.size()", is(0));
+    }
+
+    @Test
+    @DisplayName("BadgeType 전체 리스트를 조회한다")
+    void readBadgeTypes_success() {
+        // given — 회원가입 (인증 필요)
+        final String accessToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "pet_e2e_user",
+                            "password": "pass1234!",
+                            "nickname": "뱃지유저"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("accessToken");
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .get("/api/v1/pets/badges/types")
+                .then()
+                .statusCode(200)
+                .body("$.size()", greaterThanOrEqualTo(5))
+                .body("[0].badgeType", is(notNullValue()))
+                .body("[0].displayName", is(notNullValue()))
+                .body("[0].description", is(notNullValue()));
     }
 }


### PR DESCRIPTION

  본문:
  ## AS-IS
  - BadgeType 전체 목록을 조회하는 API 없음
  - 프론트에서 뱃지 UI 구성 시 전체 종류를 알 수 없음

  ## TO-BE
  - `GET /api/v1/pets/badges/types` 엔드포인트 추가
  - BadgeType enum 전체를 리스트로 반환 (badgeType, displayName, description)
  - 인증 필수

  ## 관련 이슈
  - closes #305

  ## 리뷰어 참고 포인트
  - enum 값을 그대로 반환하므로 별도 서비스 로직 없이 컨트롤러에서 처리
  - BadgeTypeResponse DTO 신설 (기존 BadgeResponse는 획득한 뱃지용,
  BadgeTypeResponse는 전체 목록용)
  - E2E 테스트 포함

  ## 라벨 부여 확인
  - [x] `type:feat` 라벨 1개 부여 완료
  - [x] `scope:pet` 라벨 1개 부여 완료
  - [x] `ai-generated` 라벨 부여 완료
  - [x] (보호 영역 변경 시) `needs-human-review` — 해당 없음

  <details>
  <summary>AI Agent 전용 체크리스트 (해당 시 작성)</summary>

  ## AI 작업 여부
  - [x] AI 보조/생성 사용

  ## 품질 게이트 체크 (AI 작성 시)
  - [x] `./gradlew checkstyleMain spotlessCheck`
  - [x] `./gradlew test`
  - [x] 변경 범위의 회귀 가능 구간을 확인했다.
  - [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다. — 신규 엔드포인트
   추가이므로 기존 기능에 영향 없음, 롤백 시 해당 커밋 revert

  ## DDD/OOP 준수 체크 (AI 작성 시)
  - [x] 도메인 용어가 기존 컨텍스트와 일치한다.
  - [x] 계층 침범(Controller -> Repository 직접 호출 등)이 없다.
  - [x] 객체 역할/책임이 명확하며, 과도한 God Object를 만들지 않았다.

  ## 보안/민감정보 체크 (AI 작성 시)
  - [x] 시크릿(API 키/토큰/비밀번호) 하드코딩이 없다.
  - [x] 복약 기록/건강 프로필 등 의료정보를 로그/스크린샷에 노출하지 않았다.
  - [x] 민감정보가 필요한 경우 마스킹 처리했다.

  ## 예외 머지 여부 (AI 작성 시)
  - [x] 예외 머지 아님

  ## AI 작업 기록
  - 사용한 프롬프트/지시 요약: BadgeType 전체 리스트 조회 API 구현 요청
  - AI가 직접 수정한 파일/범위: PetController(엔드포인트 추가),
  BadgeTypeResponse(신설), PetControllerE2ETest(테스트 추가)
  - 사람이 수동 검증한 항목: 품질 게이트 실행(checkstyle, spotless, test)
  - 잔여 리스크/추가 확인 필요사항: 없음

  </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 배지 타입 조회 API 엔드포인트 추가

## 테스트
* 배지 타입 조회 기능에 대한 엔드투엔드 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/306)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->