### PR TITLE
fix(infra): NCP Object Storage GET presigned URL — 403 Forbidden hotfix

### DIFF
--- a/src/main/java/com/ppiyaki/common/storage/PhotoUrlAssembler.java
+++ b/src/main/java/com/ppiyaki/common/storage/PhotoUrlAssembler.java
@@ -1,23 +1,38 @@
 package com.ppiyaki.common.storage;
 
+import java.time.Duration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 @Component
 @ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")
 public class PhotoUrlAssembler {
 
-    private final NcpStorageProperties properties;
+    private static final Duration DOWNLOAD_URL_TTL = Duration.ofMinutes(30);
 
-    public PhotoUrlAssembler(final NcpStorageProperties properties) {
+    private final NcpStorageProperties properties;
+    private final S3Presigner s3Presigner;
+
+    public PhotoUrlAssembler(final NcpStorageProperties properties, final S3Presigner s3Presigner) {
         this.properties = properties;
+        this.s3Presigner = s3Presigner;
     }
 
     public String toFullUrl(final String objectKey) {
         if (objectKey == null || objectKey.isBlank()) {
             return null;
         }
-        final String trimmedEndpoint = properties.endpoint().replaceAll("/+$", "");
-        return trimmedEndpoint + "/" + properties.bucketName() + "/" + objectKey;
+        final GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(properties.bucketName())
+                .key(objectKey)
+                .build();
+        final GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(DOWNLOAD_URL_TTL)
+                .getObjectRequest(getObjectRequest)
+                .build();
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
     }
 }

--- a/src/main/java/com/ppiyaki/common/storage/StorageConfig.java
+++ b/src/main/java/com/ppiyaki/common/storage/StorageConfig.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -21,6 +22,7 @@ public class StorageConfig {
                 .region(Region.of(properties.region()))
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(properties.accessKey(), properties.secretKey())))
+                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
                 .build();
     }
 
@@ -31,6 +33,7 @@ public class StorageConfig {
                 .region(Region.of(properties.region()))
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(properties.accessKey(), properties.secretKey())))
+                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
                 .build();
     }
 }

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
@@ -89,7 +89,8 @@ class MedicationLogControllerE2ETest {
                 .body("status", is("TAKEN"))
                 .body("isProxy", is(false))
                 .body("confirmedByUserId", equalTo(senior.userId().intValue()))
-                .body("photoUrl", is("https://kr.object.ncloudstorage.com/ppiyaki-test/" + objectKey));
+                .body("photoUrl", org.hamcrest.Matchers.startsWith(
+                        "https://kr.object.ncloudstorage.com/ppiyaki-test/" + objectKey + "?"));
 
         // then — GET
         RestAssured.given()


### PR DESCRIPTION
## AS-IS
프론트엔드 보고 (2026-05-12) — `GET /api/v1/prescriptions/{id}` 응답의 `maskedImageUrl` 다운로드 시 403 Forbidden.

원인: NCP 버킷이 private이라 인증 없는 GET 거절. `PhotoUrlAssembler.toFullUrl`이 단순 경로 조립만 하고 서명 단계가 없었음.

## TO-BE
- `PhotoUrlAssembler` — `S3Presigner` 주입 + `presignGetObject` 30분 만료
- `StorageConfig` — `S3Presigner`/`S3Client`에 `pathStyleAccessEnabled(true)` 추가
  - default virtual-hosted-style이라 URL 호스트가 `{bucket}.{endpoint}` 형태로 깨짐 (NCP 호환 X)
  - path-style로 강제 (`{endpoint}/{bucket}/{key}?signature`)
- 만료: **30분** (의료 데이터 보안 vs 클라이언트 캐시 편의 균형)

## 영향 endpoint (모두 같은 PhotoUrlAssembler 경유, 일괄 fix)
- `GET /api/v1/prescriptions/{id}` (maskedImageUrl) — 사용자 보고 케이스
- `PUT /api/v1/medication-logs` (photoUrl)
- `GET /api/v1/seniors/{id}/dashboard/daily` (slots[].photoUrl)

## 테스트
- `MedicationLogControllerE2ETest` — photoUrl assertion startsWith로 변경 (presigned URL은 query string 포함)

## Hotfix Release v0.10.1 예정
PR 머지 후 즉시 release `v0.10.1` (develop → main, prod 자동 배포)

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선**
  * 사진 URL이 시간 제한이 있는 서명된 임시 링크로 변경되었습니다. 생성된 사진 URL은 30분 후 자동으로 만료되어 더욱 안전한 접근 제어를 제공합니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/309)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->