### PR TITLE
release: v0.10.1

### DIFF
--- a/src/main/java/com/ppiyaki/common/storage/PhotoUrlAssembler.java
+++ b/src/main/java/com/ppiyaki/common/storage/PhotoUrlAssembler.java
@@ -1,23 +1,38 @@
 package com.ppiyaki.common.storage;
 
+import java.time.Duration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 @Component
 @ConditionalOnProperty(prefix = "ncp.storage", name = "bucket-name")
 public class PhotoUrlAssembler {
 
-    private final NcpStorageProperties properties;
+    private static final Duration DOWNLOAD_URL_TTL = Duration.ofMinutes(30);
 
-    public PhotoUrlAssembler(final NcpStorageProperties properties) {
+    private final NcpStorageProperties properties;
+    private final S3Presigner s3Presigner;
+
+    public PhotoUrlAssembler(final NcpStorageProperties properties, final S3Presigner s3Presigner) {
         this.properties = properties;
+        this.s3Presigner = s3Presigner;
     }
 
     public String toFullUrl(final String objectKey) {
         if (objectKey == null || objectKey.isBlank()) {
             return null;
         }
-        final String trimmedEndpoint = properties.endpoint().replaceAll("/+$", "");
-        return trimmedEndpoint + "/" + properties.bucketName() + "/" + objectKey;
+        final GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(properties.bucketName())
+                .key(objectKey)
+                .build();
+        final GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(DOWNLOAD_URL_TTL)
+                .getObjectRequest(getObjectRequest)
+                .build();
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
     }
 }

--- a/src/main/java/com/ppiyaki/common/storage/StorageConfig.java
+++ b/src/main/java/com/ppiyaki/common/storage/StorageConfig.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -21,6 +22,7 @@ public class StorageConfig {
                 .region(Region.of(properties.region()))
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(properties.accessKey(), properties.secretKey())))
+                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
                 .build();
     }
 
@@ -31,6 +33,7 @@ public class StorageConfig {
                 .region(Region.of(properties.region()))
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(properties.accessKey(), properties.secretKey())))
+                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
                 .build();
     }
 }

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
@@ -89,7 +89,8 @@ class MedicationLogControllerE2ETest {
                 .body("status", is("TAKEN"))
                 .body("isProxy", is(false))
                 .body("confirmedByUserId", equalTo(senior.userId().intValue()))
-                .body("photoUrl", is("https://kr.object.ncloudstorage.com/ppiyaki-test/" + objectKey));
+                .body("photoUrl", org.hamcrest.Matchers.startsWith(
+                        "https://kr.object.ncloudstorage.com/ppiyaki-test/" + objectKey + "?"));
 
         // then — GET
         RestAssured.given()


### PR DESCRIPTION
## v0.10.1 Hotfix Release

NCP Object Storage GET 403 Forbidden 핫픽스 + develop에 누적된 사이드 변경.

### fix (infra)
- NCP Object Storage GET presigned URL — 403 Forbidden hotfix (#309)
  - PhotoUrlAssembler에 S3Presigner 주입 + 30분 만료 presigned URL
  - StorageConfig에 pathStyleAccessEnabled(true) 추가
  - 영향: prescription maskedImageUrl / medication-log photoUrl / dashboard slot photoUrl

### feat (user)
- 보호자별 연동 시니어 목록 조회 API (#303) + N+1 개선

### feat (pet)
- BadgeType 전체 리스트 조회 API (#305)

## Post-merge Checklist
- [ ] CD 자동 배포 완료 검증
- [ ] prod 마스킹 이미지 GET 200 검증 (사용자 신고 케이스)
- [ ] git tag v0.10.1 + push + gh release create