### PR TITLE
fix(infra): HTTP 405 메서드 미허용 글로벌 예외 핸들러 추가

### DIFF
--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_004", "Access denied"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_005", "Resource not found"),
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "COMMON_006", "Too many requests"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_007", "Method not allowed"),
 
     // Auth
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "Invalid token"),

--- a/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,14 @@
 package com.ppiyaki.common.exception;
 
 import jakarta.validation.ConstraintViolationException;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -78,6 +81,20 @@ public class GlobalExceptionHandler {
         final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND,
                 "No endpoint " + exception.getHttpMethod() + " /" + exception.getResourcePath());
         return ResponseEntity.status(ErrorCode.NOT_FOUND.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotSupported(
+            final HttpRequestMethodNotSupportedException exception) {
+        log.debug("Method not allowed: {}", exception.getMessage());
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED,
+                "Method " + exception.getMethod() + " not allowed");
+        final ResponseEntity.BodyBuilder builder = ResponseEntity.status(ErrorCode.METHOD_NOT_ALLOWED.getStatus());
+        final Set<HttpMethod> supportedMethods = exception.getSupportedHttpMethods();
+        if (supportedMethods != null && !supportedMethods.isEmpty()) {
+            builder.allow(supportedMethods.toArray(new HttpMethod[0]));
+        }
+        return builder.body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/test/java/com/ppiyaki/common/exception/GlobalExceptionHandlerMethodNotAllowedE2ETest.java
+++ b/src/test/java/com/ppiyaki/common/exception/GlobalExceptionHandlerMethodNotAllowedE2ETest.java
@@ -1,0 +1,77 @@
+package com.ppiyaki.common.exception;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("405 응답 정규화 E2E")
+class GlobalExceptionHandlerMethodNotAllowedE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("permitAll POST-only 경로에 GET 호출 → 405 METHOD_NOT_ALLOWED + Allow 헤더")
+    void wrong_method_on_permitall_path_returns_405() {
+        RestAssured.given()
+                .when()
+                .get("/api/v1/auth/signup")
+                .then()
+                .statusCode(405)
+                .header("Allow", containsString("POST"))
+                .body("error.code", is("COMMON_007"))
+                .body("error.message", containsString("GET"));
+    }
+
+    @Test
+    @DisplayName("인증된 사용자가 GET-only 경로에 POST 호출 → 405 METHOD_NOT_ALLOWED + Allow 헤더")
+    void wrong_method_on_authenticated_path_returns_405() {
+        final String accessToken = signupAndGetToken();
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body("{}")
+                .when()
+                .post("/api/v1/users/me")
+                .then()
+                .statusCode(405)
+                .header("Allow", notNullValue())
+                .body("error.code", is("COMMON_007"))
+                .body("error.message", containsString("POST"));
+    }
+
+    private String signupAndGetToken() {
+        final String loginId = "method405" + System.nanoTime();
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "테스트"
+                        }
+                        """.formatted(loginId))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        return io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+    }
+}


### PR DESCRIPTION
## AS-IS
- 지원하지 않는 HTTP 메서드 호출 시 `HttpRequestMethodNotSupportedException`이 `GlobalExceptionHandler`의 일반 `Exception` 핸들러로 폴백
- **500 Internal Server Error** + `COMMON_003 INTERNAL_SERVER_ERROR`로 응답되어, 클라이언트가 재현/디버깅 시 서버 장애로 오인 가능
- `Allow` 헤더 부재로 RFC 9110 §15.5.6 위반

## TO-BE
- `HttpRequestMethodNotSupportedException` 전용 핸들러 추가 → **405 Method Not Allowed** 응답
- 신규 `ErrorCode.METHOD_NOT_ALLOWED` (`COMMON_007`)
- 응답에 `Allow` 헤더 부여 (지원 메서드가 알려진 경우)
- 기존 404 핸들러와 동일한 응답 포맷·로그 레벨 유지

## 관련 이슈
- closes #311

## 리뷰어 참고 포인트
- `Allow` 헤더 값은 Spring이 핸들러 메타데이터에서 도출. 알 수 없는 경우(`getSupportedHttpMethods() == null`) 헤더 생략
- E2E 2건: permitAll POST-only 경로(`/api/v1/auth/signup`)에 GET, 인증 GET-only 경로(`/api/v1/users/me`)에 POST

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료 (`type:fix`)
- [x] `scope:*` 라벨 1개 부여 완료 (`scope:infra`)
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` (전체 테스트 통과)
- [x] 변경 범위의 회귀 가능 구간을 확인했다. (404 핸들러 E2E 동일 포맷 유지 확인)
- [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다. — 단순 핸들러 추가로 revert 1회로 롤백 가능

## DDD/OOP 준수 체크
- [x] 도메인 용어가 기존 컨텍스트와 일치한다.
- [x] 계층 침범(Controller -> Repository 직접 호출 등)이 없다.
- [x] 객체 역할/책임이 명확하며, 과도한 God Object를 만들지 않았다.

## 보안/민감정보 체크
- [x] 시크릿 하드코딩이 없다.
- [x] 의료정보를 로그/스크린샷에 노출하지 않았다.
- [x] 민감정보 마스킹 — 해당 없음

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: HTTP 405 핸들러 누락을 정규화하는 글로벌 예외 핸들러 추가 (단일 PR)
- AI가 직접 수정한 파일/범위:
  - `src/main/java/com/ppiyaki/common/exception/ErrorCode.java` — METHOD_NOT_ALLOWED 추가
  - `src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java` — handleMethodNotSupported 추가
  - `src/test/java/com/ppiyaki/common/exception/GlobalExceptionHandlerMethodNotAllowedE2ETest.java` — 신규
- 사람이 수동 검증한 항목: 사용자 합의(타입/스코프), 코드 리뷰 전 `./gradlew test` 통과 확인
- 잔여 리스크/추가 확인 필요사항: 없음. 새 endpoint 추가 없으므로 Notion API 명세 갱신 불필요

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 잘못된 HTTP 메서드로 요청 시 표준화된 405 상태 코드 응답 추가
  * 응답에 허용 가능한 메서드 정보를 포함한 헤더 추가

* **테스트**
  * 잘못된 HTTP 메서드 요청 처리에 대한 E2E 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/312)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->