### PR TITLE
fix(user): JwtAuthenticationFilter에서 JWT role 클레임 소비

### DIFF
--- a/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -16,6 +18,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final String ROLE_PREFIX = "ROLE_";
 
     private final JwtProvider jwtProvider;
 
@@ -33,8 +36,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null && jwtProvider.isValid(token)) {
             final Long userId = jwtProvider.extractUserId(token);
+            final String role = jwtProvider.extractRole(token);
+            final List<GrantedAuthority> authorities = role == null
+                    ? List.of()
+                    : List.of(new SimpleGrantedAuthority(ROLE_PREFIX + role));
             final UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId,
-                    null, List.of());
+                    null, authorities);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/test/java/com/ppiyaki/common/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/ppiyaki/common/auth/JwtAuthenticationFilterTest.java
@@ -1,0 +1,95 @@
+package com.ppiyaki.common.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@DisplayName("JwtAuthenticationFilter")
+class JwtAuthenticationFilterTest {
+
+    private static final String TEST_SECRET = "test-secret-key-must-be-at-least-32-bytes-long!!";
+
+    private final JwtProvider jwtProvider = new JwtProvider(
+            new JwtProperties(TEST_SECRET, 1800000L, 1209600000L));
+    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtProvider);
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("role claim이 있는 토큰 → ROLE_<role> 권한이 부착된 Authentication이 생성된다")
+    void token_with_role_attaches_authority() throws ServletException, IOException {
+        // given
+        final Long userId = 100L;
+        final String token = jwtProvider.createAccessToken(userId, "CAREGIVER");
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        // then
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getPrincipal()).isEqualTo(userId);
+        assertThat(authentication.getAuthorities())
+                .extracting(Object::toString)
+                .containsExactly("ROLE_CAREGIVER");
+    }
+
+    @Test
+    @DisplayName("role claim이 없는 deprecated 토큰 → 빈 권한으로 인증되어 하위 호환된다")
+    void token_without_role_keeps_empty_authorities() throws ServletException, IOException {
+        // given
+        @SuppressWarnings("deprecation") final String token = jwtProvider.createAccessToken(200L);
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        // then
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getPrincipal()).isEqualTo(200L);
+        assertThat(authentication.getAuthorities()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더 없음 → SecurityContext가 비어 있다")
+    void no_authorization_header_leaves_context_empty() throws ServletException, IOException {
+        // given
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        // then
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("invalid 토큰 → SecurityContext가 비어 있다")
+    void invalid_token_leaves_context_empty() throws ServletException, IOException {
+        // given
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer invalid.token.value");
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        // then
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+}


### PR DESCRIPTION
## AS-IS
- PR #227에서 JWT access token에 `role` claim을 발행하는 producer는 추가됐으나, **소비 측이 비어 있는 회로 단선** 상태
- `JwtAuthenticationFilter#doFilterInternal`이 `extractUserId`만 호출하고 `extractRole` 미호출
- `UsernamePasswordAuthenticationToken(userId, null, List.of())` — 권한 항상 빈 리스트
- 결과: `SecurityContext.Authentication.getAuthorities()`가 항상 비어 있어 **시스템 전체에서 `hasRole`/`@PreAuthorize` 인가 불가능**, 서비스 단에서 매 호출 `userRepository.findById(...).getRole()` 비교로 우회 중

## TO-BE
- `JwtAuthenticationFilter`에서 토큰의 `role`을 추출해 `SimpleGrantedAuthority("ROLE_" + role)`로 변환 후 authorities 주입
- Spring Security `hasRole("CAREGIVER")` 표기가 정상 동작 (내부적으로 `ROLE_CAREGIVER` 권한 매칭)
- `role == null`인 deprecated `createAccessToken(Long)` 발급분은 빈 권한 유지 → 토큰 만료까지 자연 호환

## 작업 범위 (이 PR 한정)
- `JwtAuthenticationFilter` 변경 + 단위 테스트 4건
- **이번 PR에서는 `SecurityConfig` hasRole 적용 / 서비스 단 인가 리팩토링 / refresh DB 호출 제거는 다루지 않음** (별도 PR로 분리)

## 관련 이슈
- closes #313
- 선행: PR #227 (박도현, 머지 완료)
- 후속 PR2: SecurityConfig + 서비스 단 인가 통합
- 후속 PR3: AuthService.refresh DB 호출 제거 + RefreshToken 스키마

## 리뷰어 참고 포인트
- `ROLE_` prefix는 Filter에서 부여(`UserRole` enum은 그대로). 추후 `hasAuthority` 사용을 원하면 prefix 정책 재검토 가능
- 단위 테스트는 mock 없이 실제 `JwtProvider` 사용 (기존 `JwtProviderTest` 스타일과 일치)
- `clearSecurityContext()` `@AfterEach` — 테스트 간 SecurityContext 누수 방지

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료 (`type:fix`)
- [x] `scope:*` 라벨 1개 부여 완료 (`scope:user`)
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` (전체 통과, 회귀 없음)
- [x] 변경 범위의 회귀 가능 구간을 확인했다. (Filter 동작이 모든 인증 요청에 영향 → 전체 테스트 통과로 확인)
- [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다. — revert 1회로 즉시 롤백 가능. role 미주입 상태로 회귀하면 deprecated와 동일한 빈 권한 동작

## DDD/OOP 준수 체크
- [x] 도메인 용어가 기존 컨텍스트와 일치한다.
- [x] 계층 침범(Controller -> Repository 직접 호출 등)이 없다.
- [x] 객체 역할/책임이 명확하며, 과도한 God Object를 만들지 않았다. (Filter 단일 책임 유지)

## 보안/민감정보 체크
- [x] 시크릿 하드코딩이 없다. (테스트 시크릿은 별도 상수)
- [x] 의료정보를 로그/스크린샷에 노출하지 않았다.
- [x] 민감정보 마스킹 — 해당 없음

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: PR #227 후속 작업 — Filter에서 role 추출 + ROLE_ prefix 부여하여 인가 회로 잇기
- AI가 직접 수정한 파일/범위:
  - `src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java` — extractRole 호출 + GrantedAuthority 채우기
  - `src/test/java/com/ppiyaki/common/auth/JwtAuthenticationFilterTest.java` — 신규 단위 테스트 4건
- 사람이 수동 검증한 항목: blame으로 PR #227 미완료 부분 식별, 작업 범위 합의 (3 PR 분할 중 PR1)
- 잔여 리스크/추가 확인 필요사항:
  - 본 PR 단독으로는 인가 동작 변화 없음 (SecurityConfig hasRole 미적용 → 권한이 채워져도 검사 지점이 없음). PR2와 함께 동작 활성화 예정
  - 새 endpoint 없음 → Notion API 명세 갱신 불필요

</details>