### PR TITLE
fix(user): JWT role 기반 인가 활성화 + 서비스 단 role 비교 제거

### DIFF
--- a/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
+++ b/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.ppiyaki.common.auth;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -12,6 +13,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -81,6 +82,13 @@ public class GlobalExceptionHandler {
         final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND,
                 "No endpoint " + exception.getHttpMethod() + " /" + exception.getResourcePath());
         return ResponseEntity.status(ErrorCode.NOT_FOUND.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(final AccessDeniedException exception) {
+        log.debug("Access denied: {}", exception.getMessage());
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.FORBIDDEN);
+        return ResponseEntity.status(ErrorCode.FORBIDDEN.getStatus()).body(errorResponse);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)

--- a/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
+++ b/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,6 +32,7 @@ public class CareRelationController {
     }
 
     @GetMapping("/care-relations/seniors")
+    @PreAuthorize("hasRole('CAREGIVER')")
     public ResponseEntity<List<SeniorSummaryResponse>> readSeniors(
             @AuthenticationPrincipal final Long userId
     ) {
@@ -39,6 +41,7 @@ public class CareRelationController {
     }
 
     @PostMapping("/care-relations/invite")
+    @PreAuthorize("hasRole('CAREGIVER')")
     public ResponseEntity<InviteCodeResponse> createInviteCode(
             @AuthenticationPrincipal final Long userId,
             @Valid @RequestBody final InviteCodeRequest inviteCodeRequest
@@ -60,6 +63,7 @@ public class CareRelationController {
     }
 
     @DeleteMapping("/seniors/{seniorId}/logout")
+    @PreAuthorize("hasRole('CAREGIVER')")
     public ResponseEntity<Void> forceLogoutSenior(
             @AuthenticationPrincipal final Long userId,
             @PathVariable final Long seniorId

--- a/src/main/java/com/ppiyaki/user/controller/OnboardingController.java
+++ b/src/main/java/com/ppiyaki/user/controller/OnboardingController.java
@@ -6,6 +6,7 @@ import com.ppiyaki.user.service.OnboardingService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +24,7 @@ public class OnboardingController {
     }
 
     @PostMapping("/onboarding")
+    @PreAuthorize("hasRole('CAREGIVER')")
     public ResponseEntity<OnboardingResponse> onboard(
             @AuthenticationPrincipal final Long userId,
             @Valid @RequestBody final OnboardingRequest onboardingRequest

--- a/src/main/java/com/ppiyaki/user/controller/SeniorController.java
+++ b/src/main/java/com/ppiyaki/user/controller/SeniorController.java
@@ -6,6 +6,7 @@ import com.ppiyaki.user.service.SeniorService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +24,7 @@ public class SeniorController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('CAREGIVER')")
     public ResponseEntity<SeniorCreateResponse> createSenior(
             @AuthenticationPrincipal final Long userId,
             @Valid @RequestBody final SeniorCreateRequest seniorCreateRequest

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -8,7 +8,6 @@ import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.InviteCode;
 import com.ppiyaki.user.InviteCode.InviteCodeWithRaw;
 import com.ppiyaki.user.User;
-import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
 import com.ppiyaki.user.controller.dto.SeniorSummaryResponse;
@@ -54,9 +53,6 @@ public class CareRelationService {
 
     @Transactional(readOnly = true)
     public List<SeniorSummaryResponse> readSeniors(final Long caregiverId) {
-        final User caregiver = findUserById(caregiverId);
-        validateRole(caregiver, UserRole.CAREGIVER);
-
         final List<CareRelation> careRelations = careRelationRepository.findByCaregiverIdAndDeletedAtIsNull(
                 caregiverId);
 
@@ -75,9 +71,6 @@ public class CareRelationService {
 
     @Transactional
     public InviteCodeResponse createInviteCode(final Long caregiverId, final Long seniorId) {
-        final User caregiver = findUserById(caregiverId);
-        validateRole(caregiver, UserRole.CAREGIVER);
-
         careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(caregiverId, seniorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
 
@@ -121,9 +114,6 @@ public class CareRelationService {
 
     @Transactional
     public void forceLogoutSenior(final Long caregiverId, final Long seniorId) {
-        final User caregiver = findUserById(caregiverId);
-        validateRole(caregiver, UserRole.CAREGIVER);
-
         careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(caregiverId, seniorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
 
@@ -133,11 +123,5 @@ public class CareRelationService {
     private User findUserById(final Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-    }
-
-    private void validateRole(final User user, final UserRole expectedRole) {
-        if (user.getRole() != expectedRole) {
-            throw new BusinessException(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
-        }
     }
 }

--- a/src/main/java/com/ppiyaki/user/service/OnboardingService.java
+++ b/src/main/java/com/ppiyaki/user/service/OnboardingService.java
@@ -9,7 +9,6 @@ import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.CareMode;
 import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.User;
-import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.OnboardingRequest;
 import com.ppiyaki.user.controller.dto.OnboardingResponse;
 import com.ppiyaki.user.controller.dto.OnboardingResponse.SeniorResult;
@@ -44,10 +43,6 @@ public class OnboardingService {
     public OnboardingResponse onboard(final Long caregiverId, final OnboardingRequest onboardingRequest) {
         final User caregiver = userRepository.findById(caregiverId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
-        if (caregiver.getRole() != UserRole.CAREGIVER) {
-            throw new BusinessException(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
-        }
 
         caregiver.updateNickname(onboardingRequest.nickname());
 

--- a/src/main/java/com/ppiyaki/user/service/SeniorService.java
+++ b/src/main/java/com/ppiyaki/user/service/SeniorService.java
@@ -1,12 +1,9 @@
 package com.ppiyaki.user.service;
 
-import com.ppiyaki.common.exception.BusinessException;
-import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.User;
-import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.SeniorCreateRequest;
 import com.ppiyaki.user.controller.dto.SeniorCreateResponse;
 import com.ppiyaki.user.repository.CareRelationRepository;
@@ -33,13 +30,6 @@ public class SeniorService {
 
     @Transactional
     public SeniorCreateResponse createSenior(final Long caregiverId, final SeniorCreateRequest seniorCreateRequest) {
-        final User caregiver = userRepository.findById(caregiverId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
-        if (caregiver.getRole() != UserRole.CAREGIVER) {
-            throw new BusinessException(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
-        }
-
         final User senior = userRepository.save(
                 User.createSenior(seniorCreateRequest.nickname(), seniorCreateRequest.dob()));
 

--- a/src/test/java/com/ppiyaki/common/auth/RoleAuthorizationE2ETest.java
+++ b/src/test/java/com/ppiyaki/common/auth/RoleAuthorizationE2ETest.java
@@ -1,0 +1,108 @@
+package com.ppiyaki.common.auth;
+
+import static org.hamcrest.Matchers.is;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("CAREGIVER 전용 엔드포인트에 SENIOR 토큰 호출 → 403 FORBIDDEN E2E")
+class RoleAuthorizationE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    private String seniorAccessToken;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        seniorAccessToken = jwtProvider.createAccessToken(999_999L, "SENIOR");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/care-relations/seniors → 403")
+    void readSeniors_with_senior_token_returns_403() {
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorAccessToken)
+                .when()
+                .get("/api/v1/care-relations/seniors")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("COMMON_004"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/care-relations/invite → 403")
+    void createInviteCode_with_senior_token_returns_403() {
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorAccessToken)
+                .contentType(ContentType.JSON)
+                .body("{\"seniorId\": 1}")
+                .when()
+                .post("/api/v1/care-relations/invite")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("COMMON_004"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/seniors/{seniorId}/logout → 403")
+    void forceLogoutSenior_with_senior_token_returns_403() {
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorAccessToken)
+                .when()
+                .delete("/api/v1/seniors/1/logout")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("COMMON_004"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/seniors → 403")
+    void createSenior_with_senior_token_returns_403() {
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorAccessToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "nickname": "할머니"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/seniors")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("COMMON_004"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/onboarding → 403")
+    void onboard_with_senior_token_returns_403() {
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorAccessToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "nickname": "보호자",
+                            "seniors": [
+                                {"nickname": "할머니", "gender": "FEMALE", "careMode": "AUTONOMOUS"}
+                            ]
+                        }
+                        """)
+                .when()
+                .post("/api/v1/onboarding")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("COMMON_004"));
+    }
+}

--- a/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
@@ -62,9 +62,6 @@ class CareRelationServiceTest {
     @DisplayName("보호자가 시니어의 초대 코드를 발급하면 6자리 코드를 반환한다")
     void createInviteCode_success() {
         // given
-        final User caregiver = mockUser(1L, UserRole.CAREGIVER);
-        given(userRepository.findById(1L)).willReturn(Optional.of(caregiver));
-
         final CareRelation existingRelation = CareRelation.createLinked(2L, 1L);
         given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(1L, 2L))
                 .willReturn(Optional.of(existingRelation));
@@ -83,8 +80,6 @@ class CareRelationServiceTest {
     @DisplayName("연동 관계가 없는 시니어의 코드 발급을 시도하면 CARE_RELATION_NOT_FOUND 에러")
     void createInviteCode_noRelation_throwsNotFound() {
         // given
-        final User caregiver = mockUser(1L, UserRole.CAREGIVER);
-        given(userRepository.findById(1L)).willReturn(Optional.of(caregiver));
         given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(1L, 2L))
                 .willReturn(Optional.empty());
 

--- a/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
@@ -1,15 +1,12 @@
 package com.ppiyaki.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.ppiyaki.common.exception.BusinessException;
-import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.notification.NotificationSettings;
 import com.ppiyaki.notification.repository.NotificationSettingsRepository;
 import com.ppiyaki.pet.Pet;
@@ -18,7 +15,6 @@ import com.ppiyaki.user.CareMode;
 import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.Gender;
 import com.ppiyaki.user.User;
-import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.OnboardingRequest;
 import com.ppiyaki.user.controller.dto.OnboardingRequest.SeniorEntry;
 import com.ppiyaki.user.controller.dto.OnboardingResponse;
@@ -56,7 +52,6 @@ class OnboardingServiceTest {
     void onboard_success() {
         // given
         final User caregiver = mock(User.class);
-        given(caregiver.getRole()).willReturn(UserRole.CAREGIVER);
         given(caregiver.getNickname()).willReturn("보호자닉네임");
         given(userRepository.findById(1L)).willReturn(Optional.of(caregiver));
 
@@ -100,25 +95,4 @@ class OnboardingServiceTest {
         verify(senior2).changeCareMode(CareMode.MANAGED);
     }
 
-    @Test
-    @DisplayName("시니어가 온보딩을 시도하면 ROLE_MISMATCH 에러가 발생한다")
-    void onboard_bySenior_throwsRoleMismatch() {
-        // given
-        final User senior = mock(User.class);
-        given(senior.getRole()).willReturn(UserRole.SENIOR);
-        given(userRepository.findById(1L)).willReturn(Optional.of(senior));
-
-        final OnboardingRequest onboardingRequest = new OnboardingRequest(
-                "닉네임",
-                List.of(new SeniorEntry("할머니", Gender.FEMALE, CareMode.AUTONOMOUS))
-        );
-
-        // when & then
-        assertThatThrownBy(() -> onboardingService.onboard(1L, onboardingRequest))
-                .isInstanceOf(BusinessException.class)
-                .satisfies(exception -> {
-                    final BusinessException businessException = (BusinessException) exception;
-                    assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
-                });
-    }
 }

--- a/src/test/java/com/ppiyaki/user/service/SeniorServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/SeniorServiceTest.java
@@ -1,25 +1,19 @@
 package com.ppiyaki.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
-import com.ppiyaki.common.exception.BusinessException;
-import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.User;
-import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.SeniorCreateRequest;
 import com.ppiyaki.user.controller.dto.SeniorCreateResponse;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDate;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,10 +40,6 @@ class SeniorServiceTest {
     @DisplayName("보호자가 시니어를 대리 생성하면 시니어 계정, CareRelation, Pet이 함께 생성된다")
     void createSenior_success() {
         // given
-        final User caregiver = mock(User.class);
-        given(caregiver.getRole()).willReturn(UserRole.CAREGIVER);
-        given(userRepository.findById(1L)).willReturn(Optional.of(caregiver));
-
         final User senior = mock(User.class);
         given(senior.getId()).willReturn(2L);
         given(userRepository.save(any(User.class))).willReturn(senior);
@@ -73,22 +63,4 @@ class SeniorServiceTest {
         assertThat(response.petId()).isEqualTo(1L);
     }
 
-    @Test
-    @DisplayName("시니어가 시니어 대리 생성을 시도하면 ROLE_MISMATCH 에러가 발생한다")
-    void createSenior_bySenior_throwsRoleMismatch() {
-        // given
-        final User senior = mock(User.class);
-        lenient().when(senior.getRole()).thenReturn(UserRole.SENIOR);
-        given(userRepository.findById(1L)).willReturn(Optional.of(senior));
-
-        final SeniorCreateRequest request = new SeniorCreateRequest("시니어", null);
-
-        // when & then
-        assertThatThrownBy(() -> seniorService.createSenior(1L, request))
-                .isInstanceOf(BusinessException.class)
-                .satisfies(exception -> {
-                    final BusinessException businessException = (BusinessException) exception;
-                    assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
-                });
-    }
 }


### PR DESCRIPTION
## AS-IS
- PR #314로 SecurityContext에 `ROLE_<role>` 권한이 주입되기 시작했지만, **그 권한을 검사하는 지점이 시스템에 없어** 실제 인가가 작동하지 않음
- `SecurityConfig`: `anyRequest().authenticated()` 만 — 로그인 여부만 검사
- `@EnableMethodSecurity` 미활성 → `@PreAuthorize` 사용 불가
- 서비스 단 5곳에서 `userRepository.findById(...).getRole()` 비교로 role 검증 우회 중
  - `CareRelationService#readSeniors` `#createInviteCode` `#forceLogoutSenior`
  - `SeniorService#createSenior`
  - `OnboardingService#onboard`
- 매 호출 DB 조회 + 인가 책임이 도메인 서비스에 흩어짐

## TO-BE
- `SecurityConfig`에 `@EnableMethodSecurity` 활성
- 5개 controller 메서드에 `@PreAuthorize(\"hasRole('CAREGIVER')\")` 부착
- 서비스 단 `validateRole`/`role != UserRole.CAREGIVER` 체크 + role-only 목적 `findUserById` 제거
- `OnboardingService.onboard`는 `caregiver.updateNickname()` 호출 때문에 `findById`는 유지, role 비교만 제거
- `GlobalExceptionHandler`에 `AccessDeniedException` 전용 핸들러 추가 → @PreAuthorize 거부 시 통일된 `403 + COMMON_004 FORBIDDEN` 응답
- E2E 음성 케이스 5건: SENIOR 토큰으로 5개 CAREGIVER 전용 endpoint 호출 → 403 검증
- 서비스 단 role 검증 이동에 따라 관련 service 단위 테스트의 unused stub과 ROLE_MISMATCH 시나리오 정리

## 작업 범위 외 (이번 PR 다루지 않음)
- `MedicineController/MedicineService.resolveOwnerId` — CAREGIVER/SENIOR 혼합 분기라 단순 `@PreAuthorize`로 커버 불가. 향후 endpoint 분리 검토 시 별도 처리
- `AuthService.refresh` DB 호출 제거 + `RefreshToken` 스키마 변경 — 후속 PR3

## 관련 이슈
- closes #315
- 선행: PR #314 (JWT role consumer, 머지 완료)
- 후속: AuthService.refresh 회귀 해소 (별도 PR)

## 리뷰어 참고 포인트
- `@PreAuthorize` 거부 시 `AccessDeniedException` → `GlobalExceptionHandler.handleAccessDenied`로 통일 처리. (Spring Security 기본 `AccessDeniedHandler` 대신 `@RestControllerAdvice` 경유)
- `CareRelationService.findUserById`는 `codeLogin`(시니어 토큰 발급)에서 여전히 사용 → 유지
- `CareRelationService`에서 `validateRole` private 메서드 + `import UserRole` 제거(호출처 0)
- `SeniorService.createSenior`: 기존에 `caregiver` 객체를 변수로 받았지만 어디서도 미사용 → `findById` 자체 제거 가능
- E2E `RoleAuthorizationE2ETest`는 `JwtProvider` bean 직접 주입해서 SENIOR role token 발급 (signup이 CAREGIVER 전용이므로). DB row 없이도 Filter는 토큰만 valid하면 권한 주입

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료 (`type:fix`)
- [x] `scope:*` 라벨 1개 부여 완료 (`scope:user`)
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` (전체 통과, 회귀 없음)
- [x] 변경 범위의 회귀 가능 구간을 확인했다. (CAREGIVER 정상 권한 E2E 모두 통과 + 신규 SENIOR 음성 케이스 5건 통과)
- [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다. — revert 1회로 즉시 롤백. 단 PR #314의 GrantedAuthority 부여는 그대로 남으므로 회로의 한쪽 단자만 다시 끊어진 상태로 복귀

## DDD/OOP 준수 체크
- [x] 도메인 용어가 기존 컨텍스트와 일치한다.
- [x] 계층 침범(Controller -> Repository 직접 호출 등)이 없다.
- [x] 객체 역할/책임이 명확하며, 과도한 God Object를 만들지 않았다. (인가 책임이 도메인 서비스 → 인프라 계층으로 적절히 이동)

## 보안/민감정보 체크
- [x] 시크릿 하드코딩이 없다.
- [x] 의료정보를 로그/스크린샷에 노출하지 않았다.
- [x] 민감정보 마스킹 — 해당 없음

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: PR #227 후속 작업 PR2 — SecurityConfig 메서드 보안 + 5개 controller @PreAuthorize + 서비스 단 role 검증 제거
- AI가 직접 수정한 파일/범위:
  - `SecurityConfig.java` — @EnableMethodSecurity
  - `GlobalExceptionHandler.java` — AccessDeniedException 핸들러
  - `CareRelationController/SeniorController/OnboardingController.java` — @PreAuthorize 5개
  - `CareRelationService.java` — 3개 메서드 정리, validateRole 메서드 삭제
  - `SeniorService.java` — createSenior에서 findById/role 비교 제거
  - `OnboardingService.java` — role 비교 제거
  - `RoleAuthorizationE2ETest.java` — 신규 음성 케이스 5건
  - 기존 service test 3건 — unused stub 제거, ROLE_MISMATCH 시나리오 삭제
- 사람이 수동 검증한 항목: PR 사이즈 합의(분할 안 함), MedicineController 범위 외 결정, ArgumentResolver 패턴 비교 후 @PreAuthorize 방향 확정
- 잔여 리스크/추가 확인 필요사항:
  - 새 endpoint 없음 → Notion API 명세 갱신 불필요
  - 응답 형식 변화: 기존 시니어→CAREGIVER endpoint 호출 시 `403 CARE_RELATION_ROLE_MISMATCH(CARE_008)` → 이제 `403 FORBIDDEN(COMMON_004)`. 프론트가 status code(403)로만 분기하면 영향 없음

</details>