### PR TITLE
feat(prescription): caregiver가 medicine candidate dosage 직접 수정 가능

### DIFF
--- a/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
+++ b/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
@@ -154,6 +154,10 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
         this.confirmedMealSlots = MealSlot.toCsv(slots);
     }
 
+    public void updateExtractedDosage(final String dosage) {
+        this.extractedDosage = dosage;
+    }
+
     public List<MealSlot> getSuggestedMealSlotsList() {
         return MealSlot.parseCsv(this.suggestedMealSlots);
     }

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record CandidateDecisionRequest(
         @NotNull CaregiverDecision decision,
         String chosenItemSeq,
-        List<MealSlot> confirmedMealSlots
+        List<MealSlot> confirmedMealSlots,
+        String dosage
 ) {
 }

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -228,6 +228,10 @@ public class PrescriptionService {
         if (request.confirmedMealSlots() != null) {
             candidate.updateConfirmedMealSlots(request.confirmedMealSlots());
         }
+
+        if (request.dosage() != null && !request.dosage().isBlank()) {
+            candidate.updateExtractedDosage(request.dosage());
+        }
     }
 
     @Transactional

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
@@ -149,6 +149,83 @@ class PrescriptionConfirmedMealSlotsE2ETest {
     }
 
     @Test
+    @DisplayName("PATCH로 dosage 갱신 후 GET 응답에 노출된다")
+    void patch_persists_and_exposes_dosage() {
+        // given — OCR이 dosage 누락한 candidate
+        final SignupResult senior = signup("dosage시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedCandidateWithDosage(prescriptionId, null);
+
+        // when — 보호자가 dosage 보강
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {
+                            "decision": "ACCEPTED",
+                            "dosage": "1정"
+                        }
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // then — GET 응답에 갱신된 dosage 노출
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/prescriptions/" + prescriptionId)
+                .then()
+                .statusCode(200)
+                .body("candidates[0].extractedDosage", is("1정"));
+    }
+
+    @Test
+    @DisplayName("PATCH 본문에 dosage 미포함/공백이면 기존 dosage 유지")
+    void patch_without_dosage_keepsExistingDosage() {
+        // given — 기존 dosage가 있는 candidate
+        final SignupResult senior = signup("dosage유지시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedCandidateWithDosage(prescriptionId, "1정");
+
+        // when — dosage 필드 미포함
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {"decision": "ACCEPTED"}
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // 공백 dosage 도 무시
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {"decision": "ACCEPTED", "dosage": "   "}
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // then — 기존 dosage 유지
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/prescriptions/" + prescriptionId)
+                .then()
+                .statusCode(200)
+                .body("candidates[0].extractedDosage", is("1정"));
+    }
+
+    @Test
     @DisplayName("잘못된 enum 값이면 400")
     void patch_invalidEnum_returns400() {
         final SignupResult senior = signup("잘못된슬롯시니어");
@@ -215,6 +292,20 @@ class PrescriptionConfirmedMealSlotsE2ETest {
                     prescriptionId, "raw", "타이레놀정", "1정", "1일 3회 식후",
                     "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
                     suggestedSlots
+            );
+            return candidateRepository.save(candidate).getId();
+        });
+    }
+
+    private Long seedCandidateWithDosage(
+            final Long prescriptionId,
+            final String dosage
+    ) {
+        return transactionTemplate.execute(status -> {
+            final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                    prescriptionId, "raw", "타이레놀정", dosage, "1일 3회 식후",
+                    "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
+                    List.of()
             );
             return candidateRepository.save(candidate).getId();
         });


### PR DESCRIPTION
## AS-IS
- OCR이 dosage(`1정`/`1캡슐` 등)를 인식하지 못한 candidate가 confirm 단계에서 schedule 생성을 skip (`PrescriptionService.java:325-334`)
- caregiver 수정 API(`PATCH /api/v1/prescriptions/{id}/medicines/{candidateId}`)의 `CandidateDecisionRequest`에 `decision`, `chosenItemSeq`, `confirmedMealSlots` 3개만 — **dosage 필드 부재**
- 결과: caregiver가 OCR 누락분의 dosage를 보강할 경로가 없어 schedule이 영구적으로 미생성, 시간 미정 고착

## TO-BE
- `CandidateDecisionRequest`에 `dosage` 필드(String, 선택) 추가
- `PrescriptionMedicineCandidate.updateExtractedDosage` 도메인 메서드 추가
- `PrescriptionService.updateCandidateDecision`에서 dosage가 null/blank이 아닌 경우 갱신
- caregiver 수정 → confirm 흐름에서 정상적으로 schedule 생성

## 작업 범위 외 (별도 follow-up)
- `MedicationLogService.java:124-125`의 fallback 1개 차감 — dosage 파싱 실패 케이스(예: `한 정`, `PRN`, `30mg`) 보호용으로 유지. 근본 해결은 핸드오프 메모의 **"dosage 컬럼 정수+단위 분리"** follow-up과 묶어 별도 PR로 진행 권장

## 관련 이슈
- closes #317

## 리뷰어 참고 포인트
- dosage가 null이면 필드 자체 미전달, blank이면 무시 → 기존 dosage 유지 정책. E2E로 두 케이스 모두 검증
- DTO 추가 + 도메인 setter + Service 한 줄 + 테스트 2건. 기존 동작 영향 없음 (필드 미전달 = 기존 동작)
- Notion 명세 갱신 완료 (페이지 `35255690-fbc7-8107-935f-fdb9967b9462`, `# 🔄 변경 (#317, 2026-05-12)` 섹션 추가)

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료 (`type:feat`)
- [x] `scope:*` 라벨 1개 부여 완료 (`scope:prescription`)
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` (전체 통과, 회귀 없음)
- [x] 변경 범위의 회귀 가능 구간을 확인했다. (기존 PATCH 호출에 dosage 필드 미전달 = 기존 동작 그대로)
- [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다. — revert 1회로 즉시 롤백. 신규 컬럼/마이그레이션 없음

## DDD/OOP 준수 체크
- [x] 도메인 용어가 기존 컨텍스트와 일치한다.
- [x] 계층 침범(Controller -> Repository 직접 호출 등)이 없다.
- [x] 객체 역할/책임이 명확하며, 과도한 God Object를 만들지 않았다. (도메인 메서드 setter 한 개)

## 보안/민감정보 체크
- [x] 시크릿 하드코딩이 없다.
- [x] 의료정보를 로그/스크린샷에 노출하지 않았다.
- [x] 민감정보 마스킹 — 해당 없음

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 운영 보고(OCR dosage 누락 → 시간 미정 고착) 처리. 사용자가 옵션 (1) PATCH에 dosage 필드 추가로 결정
- AI가 직접 수정한 파일/범위:
  - `CandidateDecisionRequest.java` — dosage 필드 추가
  - `PrescriptionMedicineCandidate.java` — updateExtractedDosage 메서드
  - `PrescriptionService.java` — updateCandidateDecision에서 dosage 갱신 호출
  - `PrescriptionConfirmedMealSlotsE2ETest.java` — dosage 케이스 2건 추가, seedCandidateWithDosage helper 추가
- 사람이 수동 검증한 항목: 옵션 (1) vs (2) 결정, fallback 1개 차감 제거 여부 (별도 follow-up으로 분리 결정)
- 잔여 리스크/추가 확인 필요사항:
  - Notion 명세 갱신 완료
  - dosage 정수+단위 분리 follow-up과 함께 fallback 제거 검토 필요

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 처방약 용량 업데이트 기능 추가: 의료진이 처방약 결정을 업데이트할 때 약물 용량을 수정할 수 있습니다. 빈 값 또는 공백이 입력된 경우에는 기존 용량이 유지됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/318)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->