### PR TITLE
feat(prescription): dosage 정수+단위 분리 cut-over (PR 2+3 통합)

### DIFF
--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.medication.MealSlot;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -99,7 +100,7 @@ public class OpenAiClient {
                     - 약물이 없으면 빈 배열 반환.
 
                     ## 출력 형식
-                    {"medicines": [{"name": "약물명", "manufacturer": "제약사명", "ingredientName": "성분명", "dosage": "용량", "schedule": "복약주기", "mealSlots": ["BREAKFAST","LUNCH","DINNER"]}]}
+                    {"medicines": [{"name": "약물명", "manufacturer": "제약사명", "ingredientName": "성분명", "dosageQuantity": 1, "dosageUnit": "정", "schedule": "복약주기", "mealSlots": ["BREAKFAST","LUNCH","DINNER"]}]}
                     - name: 제품명+제형+용량. 제약사명과 괄호 안 내용은 **제외**.
                       예: "위더스세파클러캡슐250밀리그람" → name: "세파클러캡슐250밀리그람", manufacturer: "위더스"
                       예: "에빅사정(메만틴염산염)_(10mg/1정)" → name: "에빅사정10밀리그램"
@@ -109,7 +110,16 @@ public class OpenAiClient {
                       예: "에빅사정(메만틴염산염)" → ingredientName: "메만틴염산염"
                       예: "타이레놀정500밀리그람" → ingredientName: null (텍스트에 성분명 없음)
                       주의: "(10mg/1정)" 같은 용량 표기는 성분명이 아님. 성분명은 한글 화학명.
-                    - dosage: 1회 투약량 (예: "1정", "0.5정", "2캡슐"). 모르면 null.
+                    - **dosageQuantity (number, nullable)**: 1회 투약 수치. 정수 또는 소수.
+                      * "1정"/"한 정"/"1캡슐" → 1
+                      * "2정"/"두 정" → 2
+                      * "반정"/"0.5정" → 0.5
+                      * 한국어 수량 표현(한/두/세/네/다섯 …)도 반드시 숫자로 변환
+                      * "PRN", "필요시", 횟수가 정의되지 않은 경우 → null
+                    - **dosageUnit (string, nullable)**: 단위 문자열. dosageQuantity 옆에 표기된 단위 그대로.
+                      * "1정" → "정", "2캡슐" → "캡슐", "5ml" → "ml", "30mg" → "mg"
+                      * "PRN"/"필요시" → "PRN" (단위 자리에 표기, dosageQuantity는 null)
+                      * 모르면 null
                     - schedule: 복약주기 (예: "1일 3회 식후 30분"). 모르면 null.
                     - mealSlots: schedule을 식사 슬롯으로 매핑한 배열. 가능한 값은 "BREAKFAST", "LUNCH", "DINNER"만.
                       매핑 규칙:
@@ -159,13 +169,19 @@ public class OpenAiClient {
 
             final List<ExtractedMedicine> result = new ArrayList<>();
             for (final JsonNode item : medicines) {
+                final BigDecimal dosageQuantity = item.path("dosageQuantity").isNumber()
+                        ? item.path("dosageQuantity").decimalValue()
+                        : null;
+                final String dosageUnit = item.path("dosageUnit").asText(null);
                 result.add(new ExtractedMedicine(
                         item.path("name").asText(null),
                         item.path("manufacturer").asText(null),
                         item.path("ingredientName").asText(null),
                         item.path("dosage").asText(null),
                         item.path("schedule").asText(null),
-                        parseMealSlots(item.path("mealSlots"))
+                        parseMealSlots(item.path("mealSlots")),
+                        dosageQuantity,
+                        dosageUnit
                 ));
             }
 
@@ -291,7 +307,9 @@ public class OpenAiClient {
             String ingredientName,
             String dosage,
             String schedule,
-            List<MealSlot> mealSlots
+            List<MealSlot> mealSlots,
+            BigDecimal dosageQuantity,
+            String dosageUnit
     ) {
     }
 }

--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.medication.DosageUnit;
 import com.ppiyaki.medication.MealSlot;
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -172,16 +173,16 @@ public class OpenAiClient {
                 final BigDecimal dosageQuantity = item.path("dosageQuantity").isNumber()
                         ? item.path("dosageQuantity").decimalValue()
                         : null;
-                final String dosageUnit = item.path("dosageUnit").asText(null);
+                final DosageUnit dosageUnit = DosageUnit.fromInput(item.path("dosageUnit").asText(null))
+                        .orElse(null);
                 result.add(new ExtractedMedicine(
                         item.path("name").asText(null),
                         item.path("manufacturer").asText(null),
                         item.path("ingredientName").asText(null),
-                        item.path("dosage").asText(null),
-                        item.path("schedule").asText(null),
-                        parseMealSlots(item.path("mealSlots")),
                         dosageQuantity,
-                        dosageUnit
+                        dosageUnit,
+                        item.path("schedule").asText(null),
+                        parseMealSlots(item.path("mealSlots"))
                 ));
             }
 
@@ -305,11 +306,10 @@ public class OpenAiClient {
             String name,
             String manufacturer,
             String ingredientName,
-            String dosage,
-            String schedule,
-            List<MealSlot> mealSlots,
             BigDecimal dosageQuantity,
-            String dosageUnit
+            DosageUnit dosageUnit,
+            String schedule,
+            List<MealSlot> mealSlots
     ) {
     }
 }

--- a/src/main/java/com/ppiyaki/medication/DosageUnit.java
+++ b/src/main/java/com/ppiyaki/medication/DosageUnit.java
@@ -1,0 +1,114 @@
+package com.ppiyaki.medication;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 처방전·복약 일정의 단위 표기 정규화 enum.
+ * spec docs/features/dosage-quantity-unit-split.md.
+ *
+ * 입력 변형(영문 약어/한국어/대소문자 차이)을 fromInput으로 정규화하여 저장한다.
+ * 매칭 안 되는 입력은 OTHER로 흡수 (raw 텍스트 손실, 운영 모니터링으로 enum 추가 검토).
+ */
+public enum DosageUnit {
+
+    /** 정/알 */
+    TABLET("정"),
+    /** 캡슐 */
+    CAPSULE("캡슐"),
+    /** 포 (산제) */
+    PACKET("포"),
+    /** 방울 */
+    DROP("방울"),
+    /** 밀리그램 */
+    MG("mg"),
+    /** 마이크로그램 */
+    MCG("mcg"),
+    /** 그램 */
+    G("g"),
+    /** 밀리리터 */
+    ML("ml"),
+    /** International Unit */
+    IU("IU"),
+    /** PRN — 필요 시 복용 (수량 정의 없음) */
+    PRN("PRN"),
+    /** 매칭 실패한 raw 입력 흡수용. 운영 데이터 보고 enum 추가 검토 */
+    OTHER("");
+
+    private final String displayValue;
+
+    DosageUnit(final String displayValue) {
+        this.displayValue = displayValue;
+    }
+
+    /**
+     * 프론트 응답용 대표 표기. 프론트 변경 없이 그대로 표시 가능.
+     * OTHER는 빈 문자열 (운영 데이터 보고 정책 정정).
+     */
+    public String getDisplayValue() {
+        return displayValue;
+    }
+
+    private static final Map<String, DosageUnit> ALIASES = Map.ofEntries(
+            // TABLET
+            Map.entry("정", TABLET),
+            Map.entry("알", TABLET),
+            Map.entry("tab", TABLET),
+            Map.entry("tablet", TABLET),
+            // CAPSULE
+            Map.entry("캡슐", CAPSULE),
+            Map.entry("cap", CAPSULE),
+            Map.entry("capsule", CAPSULE),
+            // PACKET
+            Map.entry("포", PACKET),
+            Map.entry("pack", PACKET),
+            Map.entry("packet", PACKET),
+            // DROP
+            Map.entry("방울", DROP),
+            Map.entry("drop", DROP),
+            // MG
+            Map.entry("mg", MG),
+            Map.entry("밀리그람", MG),
+            Map.entry("밀리그램", MG),
+            // MCG
+            Map.entry("mcg", MCG),
+            Map.entry("ug", MCG),
+            Map.entry("μg", MCG),
+            Map.entry("마이크로그람", MCG),
+            Map.entry("마이크로그램", MCG),
+            // G
+            Map.entry("g", G),
+            Map.entry("그람", G),
+            Map.entry("그램", G),
+            // ML
+            Map.entry("ml", ML),
+            Map.entry("밀리리터", ML),
+            // IU
+            Map.entry("iu", IU),
+            Map.entry("단위", IU),
+            // PRN
+            Map.entry("prn", PRN),
+            Map.entry("필요시", PRN),
+            Map.entry("필요 시", PRN)
+    );
+
+    /**
+     * 자유 입력 String을 DosageUnit으로 정규화. null/blank → Optional.empty.
+     * 정확 매칭(소문자 비교) → 그 enum, 매칭 실패 → OTHER (raw 입력은 손실).
+     */
+    public static Optional<DosageUnit> fromInput(final String input) {
+        if (input == null || input.isBlank()) {
+            return Optional.empty();
+        }
+        final String key = input.trim().toLowerCase(Locale.ROOT);
+        // 우선 enum.name() 자체 매칭 시도 (이미 정규화된 값 재처리 안전)
+        try {
+            return Optional.of(DosageUnit.valueOf(input.trim().toUpperCase(Locale.ROOT)));
+        } catch (final IllegalArgumentException ignored) {
+            // 별칭 매칭 시도
+        }
+        final DosageUnit matched = ALIASES.get(key);
+        return Optional.of(matched != null ? matched : OTHER);
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
+++ b/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
@@ -12,8 +12,6 @@ import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,8 +21,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "medication_schedules")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MedicationSchedule extends CreatedTimeEntity {
-
-    private static final Pattern DOSAGE_INT_PATTERN = Pattern.compile("\\d+");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,8 +39,9 @@ public class MedicationSchedule extends CreatedTimeEntity {
     @Column(name = "dosage_quantity", precision = 5, scale = 2)
     private BigDecimal dosageQuantity;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "dosage_unit", length = 16)
-    private String dosageUnit;
+    private DosageUnit dosageUnit;
 
     @Column(name = "days_of_week")
     private String daysOfWeek;
@@ -58,14 +55,17 @@ public class MedicationSchedule extends CreatedTimeEntity {
     public MedicationSchedule(
             final Long medicineId,
             final MealSlot mealSlot,
-            final String dosage,
+            final BigDecimal dosageQuantity,
+            final DosageUnit dosageUnit,
             final String daysOfWeek,
             final LocalDate startDate,
             final LocalDate endDate
     ) {
         this.medicineId = Objects.requireNonNull(medicineId, "medicineId must not be null");
         this.mealSlot = Objects.requireNonNull(mealSlot, "mealSlot must not be null");
-        this.dosage = Objects.requireNonNull(dosage, "dosage must not be null");
+        this.dosageQuantity = dosageQuantity;
+        this.dosageUnit = dosageUnit;
+        this.dosage = composeLegacyDosage(dosageQuantity, dosageUnit);
         this.daysOfWeek = daysOfWeek;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -73,7 +73,8 @@ public class MedicationSchedule extends CreatedTimeEntity {
 
     public void update(
             final MealSlot mealSlot,
-            final String dosage,
+            final BigDecimal dosageQuantity,
+            final DosageUnit dosageUnit,
             final String daysOfWeek,
             final LocalDate startDate,
             final LocalDate endDate
@@ -81,8 +82,14 @@ public class MedicationSchedule extends CreatedTimeEntity {
         if (mealSlot != null) {
             this.mealSlot = mealSlot;
         }
-        if (dosage != null) {
-            this.dosage = dosage;
+        if (dosageQuantity != null) {
+            this.dosageQuantity = dosageQuantity;
+        }
+        if (dosageUnit != null) {
+            this.dosageUnit = dosageUnit;
+        }
+        if (dosageQuantity != null || dosageUnit != null) {
+            this.dosage = composeLegacyDosage(this.dosageQuantity, this.dosageUnit);
         }
         if (daysOfWeek != null) {
             this.daysOfWeek = daysOfWeek;
@@ -96,21 +103,15 @@ public class MedicationSchedule extends CreatedTimeEntity {
     }
 
     /**
-     * dosage 문자열에서 첫 정수를 추출. 예: "1정" → 1, "2정" → 2, "반정"/null → 0.
-     * spec docs/features/caregiver-dashboard.md §8 Q2 default 룰. 잔여분 차감 / 일일 소요량 계산 공용.
+     * 옛 dosage String 컬럼은 PR 4(다음 release)에서 drop 예정. 그때까지 호환성을 위해
+     * 분리 두 필드로부터 합성. quantity와 unit이 둘 다 null이면 dosage도 null.
      */
-    public static int parseDosageInt(final String dosage) {
-        if (dosage == null) {
-            return 0;
+    private static String composeLegacyDosage(final BigDecimal quantity, final DosageUnit unit) {
+        if (quantity == null && unit == null) {
+            return null;
         }
-        final Matcher matcher = DOSAGE_INT_PATTERN.matcher(dosage);
-        if (matcher.find()) {
-            try {
-                return Integer.parseInt(matcher.group());
-            } catch (final NumberFormatException e) {
-                return 0;
-            }
-        }
-        return 0;
+        final String quantityText = quantity != null ? quantity.stripTrailingZeros().toPlainString() : "";
+        final String unitText = unit != null ? unit.getDisplayValue() : "";
+        return quantityText + unitText;
     }
 }

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleCreateRequest.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleCreateRequest.java
@@ -1,14 +1,15 @@
 package com.ppiyaki.medication.controller.dto;
 
 import com.ppiyaki.medication.MealSlot;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record ScheduleCreateRequest(
         @NotNull MealSlot mealSlot,
-        @NotBlank String dosage,
+        @NotNull BigDecimal dosageQuantity,
+        String dosageUnit,
         @Pattern(
                 regexp = "^(DAILY|(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN))*)$", message = "daysOfWeek must be 'DAILY' or a comma-separated list of MON,TUE,WED,THU,FRI,SAT,SUN"
         ) String daysOfWeek,

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleResponse.java
@@ -3,6 +3,7 @@ package com.ppiyaki.medication.controller.dto;
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.user.User;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -13,6 +14,8 @@ public record ScheduleResponse(
         MealSlot mealSlot,
         LocalTime scheduledTime,
         String dosage,
+        BigDecimal dosageQuantity,
+        String dosageUnit,
         String daysOfWeek,
         LocalDate startDate,
         LocalDate endDate,
@@ -26,6 +29,10 @@ public record ScheduleResponse(
                 schedule.getMealSlot(),
                 schedule.getMealSlot().resolveTime(owner),
                 schedule.getDosage(),
+                schedule.getDosageQuantity() != null
+                        ? schedule.getDosageQuantity().stripTrailingZeros()
+                        : null,
+                schedule.getDosageUnit() != null ? schedule.getDosageUnit().getDisplayValue() : null,
                 schedule.getDaysOfWeek(),
                 schedule.getStartDate(),
                 schedule.getEndDate(),

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleUpdateRequest.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleUpdateRequest.java
@@ -2,11 +2,13 @@ package com.ppiyaki.medication.controller.dto;
 
 import com.ppiyaki.medication.MealSlot;
 import jakarta.validation.constraints.Pattern;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record ScheduleUpdateRequest(
         MealSlot mealSlot,
-        String dosage,
+        BigDecimal dosageQuantity,
+        String dosageUnit,
         @Pattern(
                 regexp = "^(DAILY|(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN))*)$", message = "daysOfWeek must be 'DAILY' or a comma-separated list of MON,TUE,WED,THU,FRI,SAT,SUN"
         ) String daysOfWeek,

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -410,7 +410,10 @@ public class DashboardService {
                     .toList();
             int dailyConsumption = 0;
             for (final MedicationSchedule s : activeSchedules) {
-                dailyConsumption += MedicationSchedule.parseDosageInt(s.getDosage());
+                final java.math.BigDecimal q = s.getDosageQuantity();
+                if (q != null) {
+                    dailyConsumption += q.setScale(0, java.math.RoundingMode.CEILING).intValueExact();
+                }
             }
             if (dailyConsumption == 0) {
                 continue;

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -5,7 +5,6 @@ import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.common.storage.NcpStorageProperties;
 import com.ppiyaki.common.storage.PhotoUrlAssembler;
-import com.ppiyaki.medication.DosageParser;
 import com.ppiyaki.medication.LogAiStatus;
 import com.ppiyaki.medication.LogStatus;
 import com.ppiyaki.medication.MedicationLog;
@@ -19,6 +18,7 @@ import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -119,10 +119,16 @@ public class MedicationLogService {
         }
 
         // 새로 TAKEN으로 전환되는 케이스에만 잔여분 차감 (멱등성: 이미 TAKEN이던 row 재호출 시 중복 차감 방지).
-        // 차감 단위 = schedule.dosage 정수 파싱. 비정수("반정" 등)면 1 fallback (인증했으니 최소 1정 차감).
+        // 차감 단위 = schedule.dosageQuantity (BigDecimal). null이면 차감 skip
+        // (옛 schedule이거나 PRN 같은 정의 안 된 케이스. spec dosage-quantity-unit-split.md Q7 결정).
         if (request.status() == LogStatus.TAKEN && previousStatus != LogStatus.TAKEN) {
-            final int dosageCount = MedicationSchedule.parseDosageInt(schedule.getDosage());
-            medicine.decreaseRemainingAmount(dosageCount > 0 ? dosageCount : 1);
+            final BigDecimal dosageQuantity = schedule.getDosageQuantity();
+            if (dosageQuantity != null) {
+                final int dosageCount = dosageQuantity.setScale(0, java.math.RoundingMode.CEILING).intValueExact();
+                if (dosageCount > 0) {
+                    medicine.decreaseRemainingAmount(dosageCount);
+                }
+            }
         }
 
         // 복약 성공 이벤트 발행 (TAKEN→TAKEN 중복 방지)
@@ -155,11 +161,11 @@ public class MedicationLogService {
 
         int expected = 0;
         for (final MedicationSchedule s : schedules) {
-            final Optional<Integer> parsed = DosageParser.parsePillCount(s.getDosage());
-            if (parsed.isEmpty()) {
+            final BigDecimal quantity = s.getDosageQuantity();
+            if (quantity == null) {
                 return LogAiStatus.COUNT_UNKNOWN;
             }
-            expected += parsed.get();
+            expected += quantity.setScale(0, java.math.RoundingMode.CEILING).intValueExact();
         }
         if (schedules.isEmpty()) {
             return LogAiStatus.COUNT_UNKNOWN;

--- a/src/main/java/com/ppiyaki/medication/service/MedicationScheduleService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationScheduleService.java
@@ -56,7 +56,8 @@ public class MedicationScheduleService {
         final MedicationSchedule schedule = new MedicationSchedule(
                 medicine.getId(),
                 scheduleCreateRequest.mealSlot(),
-                scheduleCreateRequest.dosage(),
+                scheduleCreateRequest.dosageQuantity(),
+                com.ppiyaki.medication.DosageUnit.fromInput(scheduleCreateRequest.dosageUnit()).orElse(null),
                 daysOfWeek,
                 startDate,
                 scheduleCreateRequest.endDate()
@@ -107,7 +108,8 @@ public class MedicationScheduleService {
 
         schedule.update(
                 scheduleUpdateRequest.mealSlot(),
-                scheduleUpdateRequest.dosage(),
+                scheduleUpdateRequest.dosageQuantity(),
+                com.ppiyaki.medication.DosageUnit.fromInput(scheduleUpdateRequest.dosageUnit()).orElse(null),
                 scheduleUpdateRequest.daysOfWeek(),
                 scheduleUpdateRequest.startDate(),
                 scheduleUpdateRequest.endDate()

--- a/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
+++ b/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.prescription;
 
 import com.ppiyaki.common.entity.CreatedTimeEntity;
+import com.ppiyaki.medication.DosageUnit;
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medicine.service.MatchType;
 import jakarta.persistence.Column;
@@ -44,8 +45,9 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
     @Column(name = "extracted_dosage_quantity", precision = 5, scale = 2)
     private BigDecimal extractedDosageQuantity;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "extracted_dosage_unit", length = 16)
-    private String extractedDosageUnit;
+    private DosageUnit extractedDosageUnit;
 
     @Column(name = "extracted_schedule")
     private String extractedSchedule;
@@ -89,7 +91,8 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
             final Long prescriptionId,
             final String ocrRawText,
             final String extractedName,
-            final String extractedDosage,
+            final BigDecimal extractedDosageQuantity,
+            final DosageUnit extractedDosageUnit,
             final String extractedSchedule,
             final String matchedItemSeq,
             final String matchedItemName,
@@ -100,7 +103,9 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
         this.prescriptionId = Objects.requireNonNull(prescriptionId, "prescriptionId must not be null");
         this.ocrRawText = ocrRawText;
         this.extractedName = extractedName;
-        this.extractedDosage = extractedDosage;
+        this.extractedDosageQuantity = extractedDosageQuantity;
+        this.extractedDosageUnit = extractedDosageUnit;
+        this.extractedDosage = composeLegacyDosage(extractedDosageQuantity, extractedDosageUnit);
         this.extractedSchedule = extractedSchedule;
         this.matchedItemSeq = matchedItemSeq;
         this.matchedItemName = matchedItemName;
@@ -114,7 +119,8 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
             final Long prescriptionId,
             final String itemSeq,
             final String itemName,
-            final String dosage,
+            final BigDecimal dosageQuantity,
+            final DosageUnit dosageUnit,
             final String schedule
     ) {
         Objects.requireNonNull(itemSeq, "itemSeq must not be null");
@@ -123,7 +129,8 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
                 prescriptionId,
                 MANUAL_ADD_RAW_TEXT,
                 itemName,
-                dosage,
+                dosageQuantity,
+                dosageUnit,
                 schedule,
                 itemSeq,
                 itemName,
@@ -135,6 +142,19 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
         candidate.caregiverChosenItemSeq = itemSeq;
         candidate.reviewedAt = LocalDateTime.now();
         return candidate;
+    }
+
+    /**
+     * 옛 extracted_dosage String 컬럼은 PR 4(다음 release)에서 drop 예정. 그때까지 분리
+     * 두 필드로부터 합성하여 쓰기 호환을 유지한다.
+     */
+    private static String composeLegacyDosage(final BigDecimal quantity, final DosageUnit unit) {
+        if (quantity == null && unit == null) {
+            return null;
+        }
+        final String quantityText = quantity != null ? quantity.stripTrailingZeros().toPlainString() : "";
+        final String unitText = unit != null ? unit.getDisplayValue() : "";
+        return quantityText + unitText;
     }
 
     public void accept() {
@@ -161,8 +181,16 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
         this.confirmedMealSlots = MealSlot.toCsv(slots);
     }
 
-    public void updateExtractedDosage(final String dosage) {
-        this.extractedDosage = dosage;
+    public void updateExtractedDosage(final BigDecimal dosageQuantity, final DosageUnit dosageUnit) {
+        if (dosageQuantity != null) {
+            this.extractedDosageQuantity = dosageQuantity;
+        }
+        if (dosageUnit != null) {
+            this.extractedDosageUnit = dosageUnit;
+        }
+        if (dosageQuantity != null || dosageUnit != null) {
+            this.extractedDosage = composeLegacyDosage(this.extractedDosageQuantity, this.extractedDosageUnit);
+        }
     }
 
     public List<MealSlot> getSuggestedMealSlotsList() {

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
@@ -3,12 +3,14 @@ package com.ppiyaki.prescription.controller.dto;
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.prescription.CaregiverDecision;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.List;
 
 public record CandidateDecisionRequest(
         @NotNull CaregiverDecision decision,
         String chosenItemSeq,
         List<MealSlot> confirmedMealSlots,
-        String dosage
+        BigDecimal dosageQuantity,
+        String dosageUnit
 ) {
 }

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineAddRequest.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineAddRequest.java
@@ -1,11 +1,13 @@
 package com.ppiyaki.prescription.controller.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import java.math.BigDecimal;
 
 public record PrescriptionMedicineAddRequest(
         @NotBlank String itemSeq,
         @NotBlank String itemName,
-        String dosage,
+        BigDecimal dosageQuantity,
+        String dosageUnit,
         String schedule
 ) {
 }

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineCandidateResponse.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineCandidateResponse.java
@@ -2,6 +2,7 @@ package com.ppiyaki.prescription.controller.dto;
 
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.prescription.PrescriptionMedicineCandidate;
+import java.math.BigDecimal;
 import java.util.List;
 
 public record PrescriptionMedicineCandidateResponse(
@@ -9,6 +10,8 @@ public record PrescriptionMedicineCandidateResponse(
         String ocrRawText,
         String extractedName,
         String extractedDosage,
+        BigDecimal extractedDosageQuantity,
+        String extractedDosageUnit,
         String extractedSchedule,
         String matchedItemSeq,
         String matchedItemName,
@@ -27,6 +30,11 @@ public record PrescriptionMedicineCandidateResponse(
                 candidate.getOcrRawText(),
                 candidate.getExtractedName(),
                 candidate.getExtractedDosage(),
+                candidate.getExtractedDosageQuantity() != null
+                        ? candidate.getExtractedDosageQuantity().stripTrailingZeros()
+                        : null,
+                candidate.getExtractedDosageUnit() != null ? candidate.getExtractedDosageUnit().getDisplayValue()
+                        : null,
                 candidate.getExtractedSchedule(),
                 candidate.getMatchedItemSeq(),
                 candidate.getMatchedItemName(),

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -9,6 +9,7 @@ import com.ppiyaki.common.ocr.ClovaOcrClient.OcrResult;
 import com.ppiyaki.common.ocr.ClovaOcrClient.OcrToken;
 import com.ppiyaki.common.storage.NcpStorageProperties;
 import com.ppiyaki.common.storage.PhotoUrlAssembler;
+import com.ppiyaki.medication.DosageUnit;
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
@@ -38,6 +39,7 @@ import com.ppiyaki.user.repository.UserRepository;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -143,14 +145,16 @@ public class PrescriptionService {
 
                 final String mfr = med.manufacturer() != null ? med.manufacturer() : "";
                 final String namePrefix = mfr.isEmpty() || med.name().startsWith(mfr) ? "" : mfr;
+                final String dosageDisplay = formatDosageDisplay(med.dosageQuantity(), med.dosageUnit());
                 final String rawText = namePrefix + med.name()
-                        + (med.dosage() != null ? " " + med.dosage() : "");
+                        + (dosageDisplay != null ? " " + dosageDisplay : "");
 
                 candidateRepository.save(new PrescriptionMedicineCandidate(
                         prescription.getId(),
                         rawText,
                         med.name(),
-                        med.dosage(),
+                        med.dosageQuantity(),
+                        med.dosageUnit(),
                         med.schedule(),
                         matched != null ? matched.itemSeq() : null,
                         matched != null ? matched.itemName() : null,
@@ -158,6 +162,7 @@ public class PrescriptionService {
                         matchResult.reason(),
                         med.mealSlots()
                 ));
+                // (note) med.dosageUnit()은 OpenAiClient에서 이미 DosageUnit으로 정규화됨
             }
 
             prescription.complete(maskedObjectKey);
@@ -229,8 +234,9 @@ public class PrescriptionService {
             candidate.updateConfirmedMealSlots(request.confirmedMealSlots());
         }
 
-        if (request.dosage() != null && !request.dosage().isBlank()) {
-            candidate.updateExtractedDosage(request.dosage());
+        final DosageUnit normalizedUnit = DosageUnit.fromInput(request.dosageUnit()).orElse(null);
+        if (request.dosageQuantity() != null || normalizedUnit != null) {
+            candidate.updateExtractedDosage(request.dosageQuantity(), normalizedUnit);
         }
     }
 
@@ -252,7 +258,8 @@ public class PrescriptionService {
                 prescription.getId(),
                 request.itemSeq(),
                 request.itemName(),
-                request.dosage(),
+                request.dosageQuantity(),
+                DosageUnit.fromInput(request.dosageUnit()).orElse(null),
                 request.schedule()
         ));
 
@@ -326,15 +333,16 @@ public class PrescriptionService {
             medicineRepository.save(medicine);
             candidate.linkMedicine(medicine.getId());
 
-            // dosage가 비어있으면 schedule 자동 생성 skip — Medicine만 등록.
+            // dosage_quantity가 비어있으면 schedule 자동 생성 skip — Medicine만 등록.
             // 보호자가 후속으로 schedule CRUD API로 보완 (spec §3 Q2).
-            final String dosage = candidate.getExtractedDosage();
-            if (dosage == null || dosage.isBlank()) {
+            final BigDecimal dosageQuantity = candidate.getExtractedDosageQuantity();
+            final DosageUnit dosageUnit = candidate.getExtractedDosageUnit();
+            if (dosageQuantity == null) {
                 continue;
             }
             for (final MealSlot slot : candidate.getConfirmedMealSlotsList()) {
                 medicationScheduleRepository.save(new MedicationSchedule(
-                        medicine.getId(), slot, dosage, "DAILY", today, null));
+                        medicine.getId(), slot, dosageQuantity, dosageUnit, "DAILY", today, null));
             }
         }
 
@@ -346,6 +354,18 @@ public class PrescriptionService {
     private boolean isAcceptedOrCorrected(final PrescriptionMedicineCandidate candidate) {
         return candidate.getCaregiverDecision() == CaregiverDecision.ACCEPTED
                 || candidate.getCaregiverDecision() == CaregiverDecision.MANUALLY_CORRECTED;
+    }
+
+    /**
+     * candidate raw text 표시용 dosage 합성. 양쪽 다 null이면 null.
+     */
+    private static String formatDosageDisplay(final BigDecimal quantity, final DosageUnit unit) {
+        if (quantity == null && unit == null) {
+            return null;
+        }
+        final String quantityText = quantity != null ? quantity.stripTrailingZeros().toPlainString() : "";
+        final String unitText = unit != null ? unit.getDisplayValue() : "";
+        return quantityText + unitText;
     }
 
     @Transactional

--- a/src/test/java/com/ppiyaki/medication/MedicationScheduleTest.java
+++ b/src/test/java/com/ppiyaki/medication/MedicationScheduleTest.java
@@ -3,6 +3,7 @@ package com.ppiyaki.medication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,29 +15,30 @@ class MedicationScheduleTest {
     @DisplayName("mealSlot null이면 NPE")
     void nullMealSlot_throws() {
         assertThatThrownBy(() -> new MedicationSchedule(
-                1L, null, "1정", "DAILY", LocalDate.now(), null))
+                1L, null, BigDecimal.ONE, DosageUnit.TABLET, "DAILY", LocalDate.now(), null))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    @DisplayName("update에 mealSlot null이면 기존 값 유지")
+    @DisplayName("update에 mealSlot null이면 기존 값 유지하고 dosageQuantity는 갱신")
     void update_keepsMealSlotWhenNull() {
         final MedicationSchedule schedule = new MedicationSchedule(
-                1L, MealSlot.BREAKFAST, "1정", "DAILY", LocalDate.now(), null);
+                1L, MealSlot.BREAKFAST, BigDecimal.ONE, DosageUnit.TABLET, "DAILY", LocalDate.now(), null);
 
-        schedule.update(null, "2정", null, null, null);
+        schedule.update(null, new BigDecimal("2"), null, null, null, null);
 
         assertThat(schedule.getMealSlot()).isEqualTo(MealSlot.BREAKFAST);
-        assertThat(schedule.getDosage()).isEqualTo("2정");
+        assertThat(schedule.getDosageQuantity()).isEqualByComparingTo(new BigDecimal("2"));
+        assertThat(schedule.getDosageUnit()).isEqualTo(DosageUnit.TABLET);
     }
 
     @Test
     @DisplayName("update로 슬롯 변경 가능")
     void update_changesMealSlot() {
         final MedicationSchedule schedule = new MedicationSchedule(
-                1L, MealSlot.BREAKFAST, "1정", "DAILY", LocalDate.now(), null);
+                1L, MealSlot.BREAKFAST, BigDecimal.ONE, DosageUnit.TABLET, "DAILY", LocalDate.now(), null);
 
-        schedule.update(MealSlot.DINNER, null, null, null, null);
+        schedule.update(MealSlot.DINNER, null, null, null, null, null);
 
         assertThat(schedule.getMealSlot()).isEqualTo(MealSlot.DINNER);
     }

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
@@ -51,7 +51,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "BREAKFAST",
-                            "dosage": "1정",
+                            "dosageQuantity": 1, "dosageUnit": "정",
                             "daysOfWeek": "DAILY",
                             "startDate": "2026-04-11"
                         }
@@ -64,7 +64,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("medicineId", is(medicineId))
                 .body("mealSlot", is("BREAKFAST"))
                 .body("scheduledTime", is("08:00:00"))
-                .body("dosage", is("1정"))
+                .body("dosageQuantity", is(1)).body("dosageUnit", is("정"))
                 .body("daysOfWeek", is("DAILY"));
     }
 
@@ -82,7 +82,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "LUNCH",
-                            "dosage": "1정"
+                            "dosageQuantity": 1, "dosageUnit": "정"
                         }
                         """)
                 .when()
@@ -107,7 +107,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "MIDNIGHT",
-                            "dosage": "1정"
+                            "dosageQuantity": 1, "dosageUnit": "정"
                         }
                         """)
                 .when()
@@ -175,7 +175,7 @@ class MedicationScheduleControllerE2ETest {
                 .get("/api/v1/medicines/" + medicineId + "/schedules/" + scheduleId)
                 .then()
                 .statusCode(200)
-                .body("dosage", is("2정"))
+                .body("dosageQuantity", is(2)).body("dosageUnit", is("정"))
                 .body("mealSlot", is("LUNCH"))
                 .body("scheduledTime", is("12:30:00"));
     }
@@ -196,7 +196,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "DINNER",
-                            "dosage": "2정"
+                            "dosageQuantity": 2, "dosageUnit": "정"
                         }
                         """)
                 .when()
@@ -205,7 +205,7 @@ class MedicationScheduleControllerE2ETest {
                 .statusCode(200)
                 .body("mealSlot", is("DINNER"))
                 .body("scheduledTime", is("18:30:00"))
-                .body("dosage", is("2정"));
+                .body("dosageQuantity", is(2)).body("dosageUnit", is("정"));
     }
 
     @Test
@@ -247,7 +247,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "BREAKFAST",
-                            "dosage": "1정",
+                            "dosageQuantity": 1, "dosageUnit": "정",
                             "daysOfWeek": "DAILY"
                         }
                         """)
@@ -266,7 +266,7 @@ class MedicationScheduleControllerE2ETest {
                 .get("/api/v1/medicines/" + medicineId + "/schedules/" + scheduleId)
                 .then()
                 .statusCode(200)
-                .body("dosage", is("1정"))
+                .body("dosageQuantity", is(1)).body("dosageUnit", is("정"))
                 .body("scheduledTime", is("08:00:00"));
     }
 
@@ -288,7 +288,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "BREAKFAST",
-                            "dosage": "1정"
+                            "dosageQuantity": 1, "dosageUnit": "정"
                         }
                         """)
                 .when()
@@ -367,15 +367,28 @@ class MedicationScheduleControllerE2ETest {
             final String mealSlot,
             final String dosage
     ) {
+        // legacy "1정" 등의 raw 입력을 dosageQuantity/dosageUnit으로 분리
+        final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
+                .matcher(dosage);
+        final String quantity;
+        final String unit;
+        if (m.find()) {
+            quantity = m.group(1);
+            unit = m.group(2).trim();
+        } else {
+            quantity = "1";
+            unit = "정";
+        }
         return RestAssured.given()
                 .contentType(ContentType.JSON)
                 .header("Authorization", "Bearer " + token)
                 .body("""
                         {
                             "mealSlot": "%s",
-                            "dosage": "%s"
+                            "dosageQuantity": %s,
+                            "dosageUnit": "%s"
                         }
-                        """.formatted(mealSlot, dosage))
+                        """.formatted(mealSlot, quantity, unit))
                 .when()
                 .post("/api/v1/medicines/" + medicineId + "/schedules")
                 .then()

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -377,6 +377,15 @@ class DashboardServiceTest {
         setField(s, "medicineId", medicineId);
         setField(s, "mealSlot", slot);
         setField(s, "dosage", dosage);
+        if (dosage != null) {
+            final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
+                    .matcher(dosage);
+            if (m.find()) {
+                setField(s, "dosageQuantity", new java.math.BigDecimal(m.group(1)));
+                setField(s, "dosageUnit",
+                        com.ppiyaki.medication.DosageUnit.fromInput(m.group(2).trim()).orElse(null));
+            }
+        }
         return s;
     }
 

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -223,6 +223,16 @@ class MedicationLogServicePhase2Test {
         setField(s, "medicineId", MEDICINE_ID);
         setField(s, "dosage", dosage);
         setField(s, "mealSlot", MEAL_SLOT);
+        // legacy raw 입력을 정수+단위로 정규화. 정수 매칭 안 되면 quantity null (PRN/반알 등)
+        if (dosage != null) {
+            final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
+                    .matcher(dosage);
+            if (m.find()) {
+                setField(s, "dosageQuantity", new java.math.BigDecimal(m.group(1)));
+                setField(s, "dosageUnit",
+                        com.ppiyaki.medication.DosageUnit.fromInput(m.group(2).trim()).orElse(null));
+            }
+        }
         return s;
     }
 

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -312,10 +312,10 @@ class MedicationLogServiceTest {
     }
 
     @Test
-    @DisplayName("신규 TAKEN 업서트 시 Medicine.remainingAmount 1 차감")
+    @DisplayName("신규 TAKEN 업서트 시 schedule.dosage_quantity 기준으로 잔여분 차감 (1정 → 1)")
     void 신규_TAKEN_시_잔여분_차감() throws Exception {
-        // given
-        final Medicine medicine = givenScheduleAndMedicineReturning(30, 30);
+        // given — schedule.dosage_quantity=1, unit=TABLET (default)
+        final Medicine medicine = givenScheduleAndMedicineReturning(30, 30, "1정");
         when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
                 .thenReturn(Optional.empty());
         when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
@@ -397,9 +397,9 @@ class MedicationLogServiceTest {
     }
 
     @Test
-    @DisplayName("dosage 정수 추출 불가(\"반정\")이면 1 fallback 차감")
-    void TAKEN_시_dosage_비정수면_1_fallback() throws Exception {
-        // given
+    @DisplayName("schedule.dosage_quantity가 null이면 차감 skip (PRN/옛 schedule 보호) — spec dosage-quantity-unit-split Q7")
+    void TAKEN_시_dosage_quantity_null이면_차감_skip() throws Exception {
+        // given — quantity 추출 실패 케이스 ("반정"은 분수라 정규식에서 quantity null로 둠)
         final Medicine medicine = givenScheduleAndMedicineReturning(30, 30, "반정");
         when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
                 .thenReturn(Optional.empty());
@@ -413,8 +413,8 @@ class MedicationLogServiceTest {
         // when
         medicationLogService.upsert(SENIOR_ID, request);
 
-        // then
-        assertThat(medicine.getRemainingAmount()).isEqualTo(29);
+        // then — 차감 skip
+        assertThat(medicine.getRemainingAmount()).isEqualTo(30);
     }
 
     @Test
@@ -471,8 +471,16 @@ class MedicationLogServiceTest {
         final MedicationSchedule schedule = ctor.newInstance();
         setField(schedule, "id", SCHEDULE_ID);
         setField(schedule, "medicineId", MEDICINE_ID);
+        // legacy "1정"/"2정"/"반정" raw 입력을 정수+단위로 정규화
         if (dosage != null) {
             setField(schedule, "dosage", dosage);
+            final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
+                    .matcher(dosage);
+            if (m.find()) {
+                setField(schedule, "dosageQuantity", new java.math.BigDecimal(m.group(1)));
+                setField(schedule, "dosageUnit",
+                        com.ppiyaki.medication.DosageUnit.fromInput(m.group(2).trim()).orElse(null));
+            }
         }
         when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(schedule));
 
@@ -489,6 +497,9 @@ class MedicationLogServiceTest {
         final MedicationSchedule schedule = ctor.newInstance();
         setField(schedule, "id", SCHEDULE_ID);
         setField(schedule, "medicineId", MEDICINE_ID);
+        // 기본 dosage = 1정
+        setField(schedule, "dosageQuantity", java.math.BigDecimal.ONE);
+        setField(schedule, "dosageUnit", com.ppiyaki.medication.DosageUnit.TABLET);
         when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(schedule));
 
         final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", 30, 30, "ITEM-1", null);

--- a/src/test/java/com/ppiyaki/medicine/controller/MedicineControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medicine/controller/MedicineControllerE2ETest.java
@@ -191,10 +191,12 @@ class MedicineControllerE2ETest {
 
         medicationScheduleRepository.save(
                 new MedicationSchedule(Long.valueOf(medicineId), MealSlot.BREAKFAST,
-                        "1정", "DAILY", LocalDate.now(), null));
+                        java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET,
+                        "DAILY", LocalDate.now(), null));
         medicationScheduleRepository.save(
                 new MedicationSchedule(Long.valueOf(medicineId), MealSlot.DINNER,
-                        "1정", "DAILY", LocalDate.now(), null));
+                        java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET,
+                        "DAILY", LocalDate.now(), null));
 
         // when & then
         RestAssured.given()

--- a/src/test/java/com/ppiyaki/prescription/PrescriptionMedicineCandidateMealSlotsTest.java
+++ b/src/test/java/com/ppiyaki/prescription/PrescriptionMedicineCandidateMealSlotsTest.java
@@ -15,7 +15,7 @@ class PrescriptionMedicineCandidateMealSlotsTest {
     @DisplayName("생성 시 suggestedMealSlots는 CSV로 직렬화되고, 리스트 게터로 복원된다")
     void constructor_persistsSuggestedSlotsAsCsv() {
         final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                1L, "raw", "타이레놀정", "1정", "1일 3회 식후",
+                1L, "raw", "타이레놀정", java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET, "1일 3회 식후",
                 "ITEM-1", "타이레놀", MatchType.EXACT, "matched",
                 List.of(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER)
         );
@@ -30,7 +30,7 @@ class PrescriptionMedicineCandidateMealSlotsTest {
     @DisplayName("suggestedMealSlots null/empty → CSV는 null, 리스트 게터는 빈 리스트")
     void constructor_emptySuggestedSlots() {
         final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                1L, "raw", "약", "1정", "취침 전",
+                1L, "raw", "약", java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET, "취침 전",
                 null, null, MatchType.NO_MATCH, "no match",
                 List.of()
         );
@@ -43,7 +43,7 @@ class PrescriptionMedicineCandidateMealSlotsTest {
     @DisplayName("updateConfirmedMealSlots: 리스트 → CSV 저장")
     void updateConfirmedMealSlots_persistsCsv() {
         final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                1L, "raw", "약", "1정", "1일 2회",
+                1L, "raw", "약", java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET, "1일 2회",
                 null, null, MatchType.NO_MATCH, null,
                 List.of(MealSlot.BREAKFAST, MealSlot.DINNER)
         );
@@ -59,7 +59,7 @@ class PrescriptionMedicineCandidateMealSlotsTest {
     @DisplayName("updateConfirmedMealSlots: 빈 리스트 → null로 초기화")
     void updateConfirmedMealSlots_emptyClearsField() {
         final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                1L, "raw", "약", "1정", "1일 2회",
+                1L, "raw", "약", java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET, "1일 2회",
                 null, null, MatchType.NO_MATCH, null,
                 List.of(MealSlot.BREAKFAST)
         );
@@ -76,7 +76,7 @@ class PrescriptionMedicineCandidateMealSlotsTest {
     @DisplayName("manualAdd factory: suggestedMealSlots는 비어있음")
     void manualAdd_emptySuggestedSlots() {
         final PrescriptionMedicineCandidate candidate = PrescriptionMedicineCandidate.manualAdd(
-                1L, "ITEM-1", "타이레놀정", "1정", "1일 3회"
+                1L, "ITEM-1", "타이레놀정", java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET, "1일 3회"
         );
 
         assertThat(candidate.getSuggestedMealSlots()).isNull();

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
@@ -107,7 +107,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         final List<MedicationSchedule> schedules = medicationScheduleRepository.findByMedicineId(medicineId);
         assertThat(schedules).extracting(MedicationSchedule::getMealSlot)
                 .containsExactlyInAnyOrder(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER);
-        assertThat(schedules).allMatch(s -> "1정".equals(s.getDosage()));
+        assertThat(schedules).allMatch(s -> java.math.BigDecimal.ONE.compareTo(s.getDosageQuantity()) == 0
+                && com.ppiyaki.medication.DosageUnit.TABLET == s.getDosageUnit());
         assertThat(schedules).allMatch(s -> "DAILY".equals(s.getDaysOfWeek()));
 
         // candidate에 created_medicine_id 채워짐
@@ -297,9 +298,26 @@ class PrescriptionConfirmAutoScheduleE2ETest {
             final String dosage,
             final List<MealSlot> confirmedSlots
     ) {
+        // dosage="1정"/"2정"/null 등 raw 입력을 BigDecimal+DosageUnit으로 정규화
+        final java.math.BigDecimal quantity;
+        final com.ppiyaki.medication.DosageUnit unit;
+        if (dosage == null) {
+            quantity = null;
+            unit = null;
+        } else {
+            final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$").matcher(
+                    dosage);
+            if (m.find()) {
+                quantity = new java.math.BigDecimal(m.group(1));
+                unit = com.ppiyaki.medication.DosageUnit.fromInput(m.group(2).trim()).orElse(null);
+            } else {
+                quantity = null;
+                unit = com.ppiyaki.medication.DosageUnit.fromInput(dosage).orElse(null);
+            }
+        }
         return transactionTemplate.execute(status -> {
             final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                    prescriptionId, "raw", "타이레놀정", dosage, "1일 3회 식후",
+                    prescriptionId, "raw", "타이레놀정", quantity, unit, "1일 3회 식후",
                     "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
                     confirmedSlots
             );

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
@@ -149,22 +149,23 @@ class PrescriptionConfirmedMealSlotsE2ETest {
     }
 
     @Test
-    @DisplayName("PATCH로 dosage 갱신 후 GET 응답에 노출된다")
+    @DisplayName("PATCH로 dosage 갱신 후 GET 응답에 노출된다 (정수+단위 분리, unit은 displayValue)")
     void patch_persists_and_exposes_dosage() {
         // given — OCR이 dosage 누락한 candidate
         final SignupResult senior = signup("dosage시니어");
         setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
         final Long prescriptionId = seedPrescription(senior.userId());
-        final Long candidateId = seedCandidateWithDosage(prescriptionId, null);
+        final Long candidateId = seedCandidateWithDosage(prescriptionId, null, null);
 
-        // when — 보호자가 dosage 보강
+        // when — 보호자가 dosage 보강 (입력은 자유 텍스트, 서버에서 enum 정규화)
         RestAssured.given()
                 .contentType(ContentType.JSON)
                 .header("Authorization", "Bearer " + senior.accessToken())
                 .body("""
                         {
                             "decision": "ACCEPTED",
-                            "dosage": "1정"
+                            "dosageQuantity": 1,
+                            "dosageUnit": "정"
                         }
                         """)
                 .when()
@@ -172,24 +173,26 @@ class PrescriptionConfirmedMealSlotsE2ETest {
                 .then()
                 .statusCode(200);
 
-        // then — GET 응답에 갱신된 dosage 노출
+        // then — GET 응답에 분리 두 필드 노출. unit은 enum.name() 대신 displayValue 문자열
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
                 .when()
                 .get("/api/v1/prescriptions/" + prescriptionId)
                 .then()
                 .statusCode(200)
-                .body("candidates[0].extractedDosage", is("1정"));
+                .body("candidates[0].extractedDosageQuantity", is(1))
+                .body("candidates[0].extractedDosageUnit", is("정"));
     }
 
     @Test
-    @DisplayName("PATCH 본문에 dosage 미포함/공백이면 기존 dosage 유지")
+    @DisplayName("PATCH 본문에 dosage 미포함이면 기존 dosage 유지")
     void patch_without_dosage_keepsExistingDosage() {
         // given — 기존 dosage가 있는 candidate
         final SignupResult senior = signup("dosage유지시니어");
         setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
         final Long prescriptionId = seedPrescription(senior.userId());
-        final Long candidateId = seedCandidateWithDosage(prescriptionId, "1정");
+        final Long candidateId = seedCandidateWithDosage(prescriptionId,
+                java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET);
 
         // when — dosage 필드 미포함
         RestAssured.given()
@@ -203,18 +206,6 @@ class PrescriptionConfirmedMealSlotsE2ETest {
                 .then()
                 .statusCode(200);
 
-        // 공백 dosage 도 무시
-        RestAssured.given()
-                .contentType(ContentType.JSON)
-                .header("Authorization", "Bearer " + senior.accessToken())
-                .body("""
-                        {"decision": "ACCEPTED", "dosage": "   "}
-                        """)
-                .when()
-                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
-                .then()
-                .statusCode(200);
-
         // then — 기존 dosage 유지
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
@@ -222,7 +213,8 @@ class PrescriptionConfirmedMealSlotsE2ETest {
                 .get("/api/v1/prescriptions/" + prescriptionId)
                 .then()
                 .statusCode(200)
-                .body("candidates[0].extractedDosage", is("1정"));
+                .body("candidates[0].extractedDosageQuantity", is(1))
+                .body("candidates[0].extractedDosageUnit", is("정"));
     }
 
     @Test
@@ -289,7 +281,9 @@ class PrescriptionConfirmedMealSlotsE2ETest {
     ) {
         return transactionTemplate.execute(status -> {
             final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                    prescriptionId, "raw", "타이레놀정", "1정", "1일 3회 식후",
+                    prescriptionId, "raw", "타이레놀정",
+                    java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET,
+                    "1일 3회 식후",
                     "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
                     suggestedSlots
             );
@@ -299,11 +293,14 @@ class PrescriptionConfirmedMealSlotsE2ETest {
 
     private Long seedCandidateWithDosage(
             final Long prescriptionId,
-            final String dosage
+            final java.math.BigDecimal quantity,
+            final com.ppiyaki.medication.DosageUnit unit
     ) {
         return transactionTemplate.execute(status -> {
             final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                    prescriptionId, "raw", "타이레놀정", dosage, "1일 3회 식후",
+                    prescriptionId, "raw", "타이레놀정",
+                    quantity, unit,
+                    "1일 3회 식후",
                     "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
                     List.of()
             );

--- a/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
+++ b/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
@@ -91,7 +91,9 @@ class PrescriptionServiceManualAddTest {
         when(candidateRepository.findByPrescriptionId(prescriptionId)).thenReturn(List.of());
 
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
-                "199500096", "타이레놀정 500mg", "1정", "1일 3회 식후");
+                "199500096", "타이레놀정 500mg",
+                java.math.BigDecimal.ONE, "정",
+                "1일 3회 식후");
 
         // when
         prescriptionService.addManualMedicine(ownerId, prescriptionId, request);
@@ -126,7 +128,7 @@ class PrescriptionServiceManualAddTest {
         when(candidateRepository.findByPrescriptionId(prescriptionId)).thenReturn(List.of());
 
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
-                "199500096", "타이레놀정 500mg", null, null);
+                "199500096", "타이레놀정 500mg", null, null, null);
 
         // when
         prescriptionService.addManualMedicine(caregiverId, prescriptionId, request);
@@ -148,7 +150,7 @@ class PrescriptionServiceManualAddTest {
                 .thenReturn(Optional.empty());
 
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
-                "199500096", "타이레놀정 500mg", null, null);
+                "199500096", "타이레놀정 500mg", null, null, null);
 
         // when & then
         assertThatThrownBy(() -> prescriptionService.addManualMedicine(otherUserId, prescriptionId, request))
@@ -169,7 +171,7 @@ class PrescriptionServiceManualAddTest {
         when(userRepository.findById(ownerId)).thenReturn(Optional.of(givenSenior(ownerId, CareMode.AUTONOMOUS)));
 
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
-                "199500096", "타이레놀정 500mg", null, null);
+                "199500096", "타이레놀정 500mg", null, null, null);
 
         // when & then
         assertThatThrownBy(() -> prescriptionService.addManualMedicine(ownerId, prescriptionId, request))
@@ -185,7 +187,7 @@ class PrescriptionServiceManualAddTest {
         // given
         when(prescriptionRepository.findById(999L)).thenReturn(Optional.empty());
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
-                "199500096", "타이레놀정 500mg", null, null);
+                "199500096", "타이레놀정 500mg", null, null, null);
 
         // when & then
         assertThatThrownBy(() -> prescriptionService.addManualMedicine(100L, 999L, request))

--- a/src/test/java/com/ppiyaki/prescription/service/PrescriptionServicePermissionTest.java
+++ b/src/test/java/com/ppiyaki/prescription/service/PrescriptionServicePermissionTest.java
@@ -181,7 +181,7 @@ class PrescriptionServicePermissionTest {
     }
 
     private PrescriptionMedicineAddRequest validRequest() {
-        return new PrescriptionMedicineAddRequest("199500096", "타이레놀정 500mg", null, null);
+        return new PrescriptionMedicineAddRequest("199500096", "타이레놀정 500mg", null, null, null);
     }
 
     private Prescription givenPrescription(final LocalDateTime createdAt) throws Exception {


### PR DESCRIPTION
## 요약
PR #320(엔티티 컬럼 Phase A)의 후속. spec `docs/features/dosage-quantity-unit-split.md` 결정사항을 모두 같은 release 사이클에 묶어 cut-over하는 통합 PR. 원래 PR 2(AI schema) + PR 3(DTO/Service/fallback 제거) 두 PR로 분할 계획이었으나, spec Q4 "즉시 cut-over" 결정에 따라 분할 의의 작아져 통합.

## 신규 도메인 enum: `DosageUnit`
`TABLET`(정/알) / `CAPSULE`(캡슐) / `PACKET`(포) / `DROP`(방울) / `MG`(mg/밀리그람) / `MCG`(mcg) / `G`(g) / `ML`(ml) / `IU` / `PRN` / `OTHER`(매칭 실패 흡수)

- 입력: String 자유 입력 → `DosageUnit.fromInput`으로 정규화 (`mg`/`밀리그람` → `MG`)
- 저장: enum.name() (`@Enumerated(EnumType.STRING)`)
- 응답: enum.displayValue() String (예: `"mg"`, `"정"`) — **프론트 변경 0**

## 주요 변경
### 엔티티
- `MedicationSchedule.dosageUnit`: String → `DosageUnit`
- `PrescriptionMedicineCandidate.extractedDosageUnit`: String → `DosageUnit`
- 옛 `dosage` String 컬럼은 호환성 합성으로 채움 (PR 4에서 drop 예정)

### AI schema cut-over (Q4)
- 시스템 프롬프트: `dosageQuantity`(number) + `dosageUnit`(string) 강제. 한국어 수량(`한`/`두`) 숫자 변환, 분수(`반정`→0.5), PRN/필요시 → `quantity=null`
- `ExtractedMedicine.dosage` 제거 + `dosageQuantity`/`dosageUnit` 추가
- 옛 schema 호환 없음 (PR 단독 머지 시 신규 candidate `extractedDosage` null → schedule 미생성, release 묶음 필수)

### DTO
- `CandidateDecisionRequest`: PR #318 추가했던 `dosage` String 즉시 제거 (Q5)
- `PrescriptionMedicineAddRequest`/`ScheduleCreateRequest`/`ScheduleUpdateRequest`: dosage(String) → dosageQuantity(BigDecimal) + dosageUnit(String)
- 응답 DTO: BigDecimal `stripTrailingZeros()` (직렬화 일관), unit은 `displayValue()`

### Service
- `PrescriptionService` confirm/updateCandidateDecision/addManualMedicine/OCR loop
- **`MedicationLogService.upsert`: fallback 1 차감 제거** (Q7) → null이면 차감 skip, 분수면 ceiling
- `MedicationLogService.verifyPillCount`: `DosageParser.parsePillCount` → `schedule.dosageQuantity`
- `DashboardService.computeRemainingDays`: 동일
- **`MedicationSchedule.parseDosageInt` + `DOSAGE_INT_PATTERN` 완전 제거**

## 테스트
- 25개 파일 갱신 (도메인 + Service + Controller E2E)
- "반정 fallback 1 차감" 테스트는 새 정책("quantity null이면 skip")으로 정정
- 전체 313 테스트 통과

## ⚠️ Cut-over 주의
- 옛 schedule들(이미 prod에 confirm됨)은 `dosage_quantity = NULL` 상태로 남음 → 잔여량 차감 멈춤. caregiver 보강 API 신설은 Q7 결정에 따라 spec 범위 외 (운영 데이터 영향 작음)
- 옛 `dosage` String 컬럼은 **PR 4(다음 release)에서 drop**

## Notion API 명세
- ✅ PATCH `/api/v1/prescriptions/{id}/medicines/{candidateId}` 갱신 (페이지 `35255690-fbc7-8107-935f-fdb9967b9462`)
- ⏳ POST /confirm, GET /prescriptions/{id}, schedule CRUD 응답 dosage 노출 변경 — 별도 follow-up (사이즈 큼)

## 관련 이슈
- refs #319 (PR 1 #320으로 닫힘. 이 PR은 같은 spec의 PR 2+3 통합)
- Feature Spec: `docs/features/dosage-quantity-unit-split.md` (status=ready-for-impl)

## 라벨 부여 확인
- [x] `type:feat`
- [x] `scope:prescription`
- [x] `ai-generated`
- [ ] `needs-human-review` — 해당 없음 (DB 스키마 변경은 PR #320에서 완료, 이 PR은 코드/AI prompt만)

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` 313 tests pass

## DDD/OOP
- [x] DosageUnit 도메인 enum 신설 (정규화 책임)
- [x] 계층 침범 없음

## 보안/민감정보
- [x] 시크릿 없음
- [x] 의료정보 노출 없음

## AI 작업 기록
- AI가 직접 수정한 파일/범위: 25개 (commit message 참조)
- 사람이 수동 검증: 6개 spec 오픈 질문 합의 + DosageUnit enum 도입 결정 + displayValue 절충안
- 잔여 리스크/추가 follow-up:
  - 옛 prod schedule 차감 멈춤 (사용자 합의로 그대로 두기)
  - Notion API 명세 일부 갱신 (별도 follow-up)
  - PR 4 (옛 dosage 컬럼 drop) 다음 release

</details>