### PR TITLE
 feat(user): 회원 탈퇴 API 구현 (#322)

### DIFF
--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -62,7 +62,10 @@ public enum ErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_001", "Notification not found"),
     NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_002", "Cannot access another user's notification"),
     DEVICE_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_003", "Device token not found"),
-    DEVICE_TOKEN_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_004", "Cannot access another user's device token");
+    DEVICE_TOKEN_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_004", "Cannot access another user's device token"),
+
+    // User Withdraw
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER_003", "User already deleted");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "User not found"),
     MEAL_TIMES_NOT_SET(HttpStatus.BAD_REQUEST, "USER_002", "Meal times are not set for the senior"),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER_003", "User already deleted"),
 
     // Medicine
     MEDICINE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEDICINE_001", "Medicine not found"),
@@ -62,10 +63,7 @@ public enum ErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_001", "Notification not found"),
     NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_002", "Cannot access another user's notification"),
     DEVICE_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_003", "Device token not found"),
-    DEVICE_TOKEN_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_004", "Cannot access another user's device token"),
-
-    // User Withdraw
-    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER_003", "User already deleted");
+    DEVICE_TOKEN_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_004", "Cannot access another user's device token");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -69,6 +69,9 @@ public class User extends BaseTimeEntity {
     @Column(name = "last_active_at")
     private java.time.LocalDateTime lastActiveAt;
 
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deletedAt;
+
     public User(
             final String loginId,
             final String password,
@@ -126,5 +129,13 @@ public class User extends BaseTimeEntity {
 
     public void touchActiveAt(final java.time.LocalDateTime now) {
         this.lastActiveAt = Objects.requireNonNull(now, "now must not be null");
+    }
+
+    public void softDelete(final java.time.LocalDateTime now) {
+        this.deletedAt = Objects.requireNonNull(now, "now must not be null");
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 }

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -13,12 +13,14 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Objects;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "users")
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {
 

--- a/src/main/java/com/ppiyaki/user/controller/UserController.java
+++ b/src/main/java/com/ppiyaki/user/controller/UserController.java
@@ -6,12 +6,15 @@ import com.ppiyaki.user.controller.dto.MealTimesUpdateRequest;
 import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.service.UserService;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -39,5 +42,11 @@ public class UserController {
             @Valid @RequestBody final MealTimesUpdateRequest request
     ) {
         return ResponseEntity.ok(userService.updateMealTimes(userId, request));
+    }
+
+    @DeleteMapping("/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void withdraw(@AuthenticationPrincipal final Long userId) {
+        userService.withdraw(userId);
     }
 }

--- a/src/main/java/com/ppiyaki/user/controller/UserController.java
+++ b/src/main/java/com/ppiyaki/user/controller/UserController.java
@@ -6,7 +6,6 @@ import com.ppiyaki.user.controller.dto.MealTimesUpdateRequest;
 import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.service.UserService;
 import jakarta.validation.Valid;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -45,8 +43,8 @@ public class UserController {
     }
 
     @DeleteMapping("/me")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void withdraw(@AuthenticationPrincipal final Long userId) {
+    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal final Long userId) {
         userService.withdraw(userId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -66,6 +66,10 @@ public class AuthService {
                         .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND)))
                 .orElseGet(() -> createNewUser(payload, providerUserId));
 
+        if (user.isDeleted()) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
+        }
+
         final String roleName = user.getRole() != null ? user.getRole().name() : null;
         final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
         final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
@@ -111,6 +115,10 @@ public class AuthService {
         if (user.getPassword() == null
                 || !passwordEncoder.matches(loginRequest.password(), user.getPassword())) {
             throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        }
+
+        if (user.isDeleted()) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
         }
 
         final String roleName = user.getRole() != null ? user.getRole().name() : null;

--- a/src/main/java/com/ppiyaki/user/service/UserService.java
+++ b/src/main/java/com/ppiyaki/user/service/UserService.java
@@ -3,12 +3,17 @@ package com.ppiyaki.user.service;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.CareModeResponse;
 import com.ppiyaki.user.controller.dto.MealTimesUpdateRequest;
 import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,13 +22,16 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final CareRelationRepository careRelationRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public UserService(
             final UserRepository userRepository,
-            final CareRelationRepository careRelationRepository
+            final CareRelationRepository careRelationRepository,
+            final RefreshTokenRepository refreshTokenRepository
     ) {
         this.userRepository = userRepository;
         this.careRelationRepository = careRelationRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
     }
 
     @Transactional
@@ -49,5 +57,42 @@ public class UserService {
 
         user.updateMealTimes(request.breakfast(), request.lunch(), request.dinner());
         return UserMeResponse.from(user);
+    }
+
+    @Transactional
+    public void withdraw(final Long userId) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.isDeleted()) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
+        }
+
+        final LocalDateTime now = LocalDateTime.now();
+
+        if (user.getRole() == UserRole.CAREGIVER) {
+            withdrawCaregiverWithSeniors(user, now);
+        } else {
+            withdrawSingleUser(user, now);
+        }
+    }
+
+    private void withdrawCaregiverWithSeniors(final User caregiver, final LocalDateTime now) {
+        final List<CareRelation> careRelations = careRelationRepository.findByCaregiverIdAndDeletedAtIsNull(caregiver
+                .getId());
+
+        for (final CareRelation relation : careRelations) {
+            final User senior = userRepository.findById(relation.getSeniorId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+            withdrawSingleUser(senior, now);
+            relation.softDelete(now);
+        }
+
+        withdrawSingleUser(caregiver, now);
+    }
+
+    private void withdrawSingleUser(final User user, final LocalDateTime now) {
+        user.softDelete(now);
+        refreshTokenRepository.deleteByUserId(user.getId());
     }
 }


### PR DESCRIPTION

  ## AS-IS
  - 회원가입은 있으나 탈퇴 기능 없음
  - 탈퇴한 유저의 로그인을 차단할 방법 없음

  ## TO-BE
  - `DELETE /api/v1/users/me` 엔드포인트 추가 (204 No
  Content)
  - 소프트 딜리트 방식 (User.deletedAt)
  - 시니어 탈퇴: 본인만 soft delete
  - 보호자 탈퇴: 연동된 시니어도 함께 soft delete +
  care_relations soft delete
  - 탈퇴 시 refresh_tokens 삭제
  - 로그인(카카오/로컬) 시 deletedAt 체크하여 탈퇴 유저
  로그인 차단
  - 이미 탈퇴한 유저 재탈퇴 시 400 USER_003

  ## 관련 이슈
  - closes #322

  ## 리뷰어 참고 포인트
  - JwtAuthenticationFilter는 수정하지 않음 — 매 요청 DB
  조회 대신 로그인 시점 체크 + refresh token 삭제 방식
  - access token은 만료(30분)까지 유효하나 refresh 불가로
   자연 차단
  - CareRelation의 기존 softDelete 패턴 재사용

  ## 라벨 부여 확인
  - [x] `type:feat` 라벨 1개 부여 완료
  - [x] `scope:user` 라벨 1개 부여 완료
  - [x] `ai-generated` 라벨 부여 완료
  - [x] (보호 영역 변경 시) `needs-human-review` — 해당
  없음

  <details>
  <summary>AI Agent 전용 체크리스트 (해당 시
  작성)</summary>

  ## AI 작업 여부
  - [x] AI 보조/생성 사용

  ## 품질 게이트 체크 (AI 작성 시)
  - [x] `./gradlew checkstyleMain spotlessCheck`
  - [x] `./gradlew test`
  - [x] 변경 범위의 회귀 가능 구간을 확인했다.
  - [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를
  작성했다. — 소프트 딜리트이므로 deletedAt을 null로
  되돌리면 복구 가능

  ## DDD/OOP 준수 체크 (AI 작성 시)
  - [x] 도메인 용어가 기존 컨텍스트와 일치한다.
  - [x] 계층 침범(Controller -> Repository 직접 호출
  등)이 없다.
  - [x] 객체 역할/책임이 명확하며, 과도한 God Object를
  만들지 않았다.

  ## 보안/민감정보 체크 (AI 작성 시)
  - [x] 시크릿(API 키/토큰/비밀번호) 하드코딩이 없다.
  - [x] 복약 기록/건강 프로필 등 의료정보를
  로그/스크린샷에 노출하지 않았다.
  - [x] 민감정보가 필요한 경우 마스킹 처리했다.

  ## 예외 머지 여부 (AI 작성 시)
  - [x] 예외 머지 아님

  ## AI 작업 기록
  - 사용한 프롬프트/지시 요약: 회원 탈퇴 API를 소프트
  딜리트로 구현. 보호자 탈퇴 시 연동 시니어 연쇄 삭제.
  - AI가 직접 수정한 파일/범위: User(deletedAt 추가),
  ErrorCode(USER_ALREADY_DELETED), UserService(withdraw
  로직), UserController(DELETE /me), AuthService(로그인
  시 deletedAt 체크)
  - 사람이 수동 검증한 항목: 품질 게이트 실행(checkstyle,
   spotless, test)
  - 잔여 리스크/추가 확인 필요사항: access token 만료
  전(최대 30분) 탈퇴 유저 접근 가능. DB 마이그레이션 필요
   (ALTER TABLE users ADD COLUMN deleted_at DATETIME(6)
  NULL)

  </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 계정 탈퇴 기능: DELETE /api/v1/users/me 엔드포인트를 통해 언제든 계정 탈퇴 가능. 탈퇴 시 모든 인증 토큰은 자동 삭제됨
  * 케어기버의 계정 탈퇴 시 연결된 모든 피보호자의 계정도 자동으로 함께 처리
  * 탈퇴한 계정의 재로그인 방지: 카카오 소셜 로그인 및 일반 로그인에서 삭제된 계정 접근 차단

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/323)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->