### PR TITLE
fix(medication): 복약 인증 후 MEDICATION_REMINDER 알림 자동 전이 (taken_at)

### DIFF
--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -57,6 +57,7 @@ public class MedicationLogService {
     private final NcpStorageProperties storageProperties;
     private final S3Client s3Client;
     private final ApplicationEventPublisher eventPublisher;
+    private final com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
 
     public MedicationLogService(
             final MedicationLogRepository medicationLogRepository,
@@ -67,7 +68,8 @@ public class MedicationLogService {
             final OpenAiClient openAiClient,
             final NcpStorageProperties storageProperties,
             final S3Client s3Client,
-            final ApplicationEventPublisher eventPublisher
+            final ApplicationEventPublisher eventPublisher,
+            final com.ppiyaki.notification.repository.NotificationRepository notificationRepository
     ) {
         this.medicationLogRepository = medicationLogRepository;
         this.medicationScheduleRepository = medicationScheduleRepository;
@@ -78,6 +80,7 @@ public class MedicationLogService {
         this.storageProperties = storageProperties;
         this.s3Client = s3Client;
         this.eventPublisher = eventPublisher;
+        this.notificationRepository = notificationRepository;
     }
 
     @Transactional
@@ -134,6 +137,10 @@ public class MedicationLogService {
         // 복약 성공 이벤트 발행 (TAKEN→TAKEN 중복 방지)
         if (request.status() == LogStatus.TAKEN && previousStatus != LogStatus.TAKEN) {
             eventPublisher.publishEvent(new MedicationTakenEvent(seniorId, request.targetDate()));
+            // 같은 시니어/날짜/슬롯 MEDICATION_REMINDER 알림 자동 전이 (issue #324).
+            // 시니어 본인 인증/보호자 대리 인증 모두 시니어의 알림이 대상 (userId=seniorId).
+            notificationRepository.markReminderTaken(
+                    seniorId, request.targetDate(), schedule.getMealSlot().name(), takenAt);
         }
 
         // Phase 2: 사진 + status=TAKEN일 때 약 개수 AI 검증 (spec medication-log-phase2 §5-4)

--- a/src/main/java/com/ppiyaki/notification/Notification.java
+++ b/src/main/java/com/ppiyaki/notification/Notification.java
@@ -64,6 +64,9 @@ public class Notification extends BaseTimeEntity {
     @Column(name = "read_at")
     private LocalDateTime readAt;
 
+    @Column(name = "taken_at")
+    private LocalDateTime takenAt;
+
     Notification(
             final Long userId,
             final Long seniorId,
@@ -195,6 +198,20 @@ public class Notification extends BaseTimeEntity {
     public void markAsRead(final LocalDateTime readAt) {
         if (this.readAt == null) {
             this.readAt = Objects.requireNonNull(readAt, "readAt must not be null");
+        }
+    }
+
+    public boolean isTaken() {
+        return this.takenAt != null;
+    }
+
+    /**
+     * MEDICATION_REMINDER 알림이 복약 인증으로 소비됐음을 표시. 멱등 (이미 채워져 있으면 noop).
+     * spec: PATCH/POST 직접 호출이 아니라 MedicationLogService.upsert TAKEN 신규 전환 분기에서 호출.
+     */
+    public void markTaken(final LocalDateTime takenAt) {
+        if (this.takenAt == null) {
+            this.takenAt = Objects.requireNonNull(takenAt, "takenAt must not be null");
         }
     }
 }

--- a/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
@@ -13,6 +13,7 @@ public record NotificationItemResponse(
         String payload,
         boolean isRead,
         LocalDateTime readAt,
+        LocalDateTime takenAt,
         LocalDateTime createdAt
 ) {
 
@@ -26,6 +27,7 @@ public record NotificationItemResponse(
                 notification.getPayload(),
                 notification.isRead(),
                 notification.getReadAt(),
+                notification.getTakenAt(),
                 notification.getCreatedAt()
         );
     }

--- a/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
@@ -34,6 +34,27 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             """)
     int markAllAsRead(@Param("userId") final Long userId, @Param("readAt") final LocalDateTime readAt);
 
+    /**
+     * 시니어가 복약 인증한 시점에 같은 날짜·슬롯의 MEDICATION_REMINDER 알림을 taken 처리.
+     * takenAt IS NULL인 row만 갱신 (멱등).
+     */
+    @Modifying
+    @Query("""
+            UPDATE Notification n
+            SET n.takenAt = :takenAt
+            WHERE n.userId = :userId
+              AND n.category = com.ppiyaki.notification.NotificationCategory.MEDICATION_REMINDER
+              AND n.targetDate = :targetDate
+              AND n.mealSlot = :mealSlot
+              AND n.takenAt IS NULL
+            """)
+    int markReminderTaken(
+            @Param("userId") final Long userId,
+            @Param("targetDate") final java.time.LocalDate targetDate,
+            @Param("mealSlot") final String mealSlot,
+            @Param("takenAt") final LocalDateTime takenAt
+    );
+
     boolean existsByUserIdAndCategoryAndTargetDateAndMealSlot(
             final Long userId,
             final NotificationCategory category,

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -60,6 +60,8 @@ class MedicationLogServicePhase2Test {
     private S3Client s3Client;
     @Mock
     private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
 
     @InjectMocks
     private MedicationLogService service;

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -51,6 +51,8 @@ class MedicationLogServiceTest {
     private PhotoUrlAssembler photoUrlAssembler;
     @Mock
     private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
 
     @InjectMocks
     private MedicationLogService medicationLogService;
@@ -333,6 +335,55 @@ class MedicationLogServiceTest {
     }
 
     @Test
+    @DisplayName("신규 TAKEN 전환 시 같은 시니어/날짜/슬롯 MEDICATION_REMINDER 알림 자동 전이 (issue #324)")
+    void 신규_TAKEN_시_알림_자동_전이() throws Exception {
+        // given
+        givenScheduleAndMedicineReturning(30, 30, "1정");
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then — notificationRepository.markReminderTaken(seniorId, targetDate, "BREAKFAST", takenAt)
+        verify(notificationRepository).markReminderTaken(
+                eq(SENIOR_ID),
+                eq(TARGET_DATE),
+                eq("BREAKFAST"),
+                any(LocalDateTime.class)
+        );
+    }
+
+    @Test
+    @DisplayName("이미 TAKEN인 row 재호출 시 알림 자동 전이도 호출 안 함 — 멱등")
+    void 이미_TAKEN_재호출_시_알림_전이_안함() throws Exception {
+        // given
+        givenScheduleAndMedicineReturning(30, 25);
+        final MedicationLog existing = new MedicationLog(
+                SENIOR_ID, SCHEDULE_ID, TARGET_DATE, LocalDateTime.of(2026, 4, 18, 8, 0),
+                LogStatus.TAKEN, null, false, SENIOR_ID);
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.of(existing));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then
+        verify(notificationRepository, org.mockito.Mockito.never())
+                .markReminderTaken(any(), any(), any(), any());
+    }
+
+    @Test
     @DisplayName("이미 TAKEN인 row 재호출 시 잔여분 중복 차감 없음 — 멱등")
     void 이미_TAKEN인_경우_차감_없음() throws Exception {
         // given
@@ -471,6 +522,7 @@ class MedicationLogServiceTest {
         final MedicationSchedule schedule = ctor.newInstance();
         setField(schedule, "id", SCHEDULE_ID);
         setField(schedule, "medicineId", MEDICINE_ID);
+        setField(schedule, "mealSlot", com.ppiyaki.medication.MealSlot.BREAKFAST);
         // legacy "1정"/"2정"/"반정" raw 입력을 정수+단위로 정규화
         if (dosage != null) {
             setField(schedule, "dosage", dosage);
@@ -497,6 +549,7 @@ class MedicationLogServiceTest {
         final MedicationSchedule schedule = ctor.newInstance();
         setField(schedule, "id", SCHEDULE_ID);
         setField(schedule, "medicineId", MEDICINE_ID);
+        setField(schedule, "mealSlot", com.ppiyaki.medication.MealSlot.BREAKFAST);
         // 기본 dosage = 1정
         setField(schedule, "dosageQuantity", java.math.BigDecimal.ONE);
         setField(schedule, "dosageUnit", com.ppiyaki.medication.DosageUnit.TABLET);


### PR DESCRIPTION
## AS-IS
- 운영 보고(2026-05-12): 시니어가 복약 인증을 해도 알림함 "확인" 버튼이 사라지지 않음
- `MedicationLogService.upsert`에 잔여량 차감 + `MedicationTakenEvent` publish만 있음
- 같은 시니어/날짜/슬롯 `MEDICATION_REMINDER` 알림 상태 전이 로직 부재
- `Notification`에는 `read_at` 컬럼만 있어 알림 "본 시점"과 "약 인증 시점"을 구분 못 함

## TO-BE
- `Notification.taken_at` DATETIME(6) NULL 컬럼 신규 (시점형, boolean보다 정보량 ↑)
- `read_at` 그대로 유지 (**의미 분리**: `read` = 알림함 조회, `taken` = 약 인증 완료)
- `Notification.markTaken` 도메인 메서드 (멱등)
- `NotificationRepository.markReminderTaken`: `@Modifying UPDATE` (userId + category=MEDICATION_REMINDER + targetDate + mealSlot + takenAt IS NULL)
- `MedicationLogService.upsert`: 신규 TAKEN 전환 분기에서 호출. 시니어 본인 인증/보호자 대리 인증 모두 시니어의 알림이 대상
- `NotificationItemResponse`: `takenAt` 필드 추가

## 프론트 분기 가이드
- 알림함 unread 뱃지: `is_read == false` (변경 없음)
- "확인" 버튼: `takenAt == null && type == MEDICATION_REMINDER`일 때만 표시

## 🔧 prod 수동 마이그레이션
```sql
ALTER TABLE notifications ADD COLUMN taken_at DATETIME(6) NULL;
```
- 옛 알림 backfill 안 함 (운영 데이터 영향 작음, 모두 NULL로 시작)

## 작업 범위 외
- 다른 알림 카테고리(DELAY/DUR/FAMILY_SAFETY/COMPLETE)는 takenAt 의미 없음 → REMINDER 전용 정책
- 옛 알림 backfill (별도 follow-up, 운영 데이터 보고 결정)

## 관련 이슈
- closes #324

## 라벨 부여 확인
- [x] `type:fix`
- [x] `scope:medication`
- [x] `ai-generated`
- [x] `needs-human-review` — DB 스키마 변경(taken_at 컬럼) 동반

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` 전체 통과
- [x] 변경 범위 회귀 가능 구간 확인 — MedicationLogService.upsert에 markReminderTaken 호출만 추가, 기존 동작 영향 없음
- [x] 롤백: `ALTER TABLE notifications DROP COLUMN taken_at` + revert 1회

## DDD/OOP
- [x] Notification 도메인 메서드 markTaken 추가
- [x] 계층 침범 없음

## 보안/민감정보
- [x] 시크릿 없음
- [x] 의료정보 노출 없음

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 사용자 운영 보고 — "확인 버튼 안 사라짐"
- 변경 파일: Notification, NotificationRepository, NotificationItemResponse, MedicationLogService, MedicationLogServiceTest, MedicationLogServicePhase2Test
- 사람이 수동 검증: is_taken vs taken_at 네이밍 결정 (시점형 채택), is_read와 의미 분리
- 잔여 리스크: 옛 알림 backfill 안 함 (Q7 패턴), 다른 알림 카테고리는 takenAt 항상 null

</details>