### PR TITLE
fix(medication): 주/월간 대시보드 가입 이전 날짜 dayStatus를 NOT_SCHEDULED로

### DIFF
--- a/src/main/java/com/ppiyaki/medication/DayStatus.java
+++ b/src/main/java/com/ppiyaki/medication/DayStatus.java
@@ -9,5 +9,7 @@ public enum DayStatus {
     DELAYED,
     MISSED,
     PENDING,
-    FUTURE
+    FUTURE,
+    /** 시니어 가입 이전 날짜 — 스케줄/로그 자체가 존재할 수 없는 시점. spec issue #326 */
+    NOT_SCHEDULED
 }

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -162,6 +162,7 @@ public class DashboardService {
         }
 
         final LocalDate today = LocalDate.now();
+        final LocalDate seniorRegisteredDate = senior.getCreatedAt().toLocalDate();
         final long delayThresholdMinutes = resolveDelayThresholdMinutes(userId, seniorId);
         final List<DayEntry> dayEntries = new ArrayList<>();
         int adherenceNumerator = 0;
@@ -169,6 +170,14 @@ public class DashboardService {
         for (int i = 0; i < 7; i++) {
             final LocalDate date = weekStart.plusDays(i);
             final List<SlotMarker> slotMarkers = new ArrayList<>();
+            // 시니어 가입 전 날짜는 모든 슬롯 강제 NOT_SCHEDULED + dayStatus NOT_SCHEDULED (issue #326)
+            if (date.isBefore(seniorRegisteredDate)) {
+                for (final MealSlot slot : MealSlot.values()) {
+                    slotMarkers.add(new SlotMarker(slot, SlotStatus.NOT_SCHEDULED));
+                }
+                dayEntries.add(new DayEntry(date, DayStatus.NOT_SCHEDULED, slotMarkers));
+                continue;
+            }
             final Map<Long, MedicationLog> logBySchedule = logsByDateAndSchedule.getOrDefault(date, Map.of());
             for (final MealSlot slot : MealSlot.values()) {
                 final SlotStatus status = deriveSlotStatusForDate(
@@ -216,10 +225,16 @@ public class DashboardService {
         }
 
         final LocalDate today = LocalDate.now();
+        final LocalDate seniorRegisteredDate = senior.getCreatedAt().toLocalDate();
         final long delayThresholdMinutes = resolveDelayThresholdMinutes(userId, seniorId);
         final List<MonthlyDashboardResponse.DayEntry> dayEntries = new ArrayList<>();
         for (int day = 1; day <= yearMonth.lengthOfMonth(); day++) {
             final LocalDate date = yearMonth.atDay(day);
+            // 시니어 가입 전 날짜는 dayStatus 강제 NOT_SCHEDULED (issue #326)
+            if (date.isBefore(seniorRegisteredDate)) {
+                dayEntries.add(new MonthlyDashboardResponse.DayEntry(date, DayStatus.NOT_SCHEDULED));
+                continue;
+            }
             final List<SlotMarker> markers = new ArrayList<>();
             final Map<Long, MedicationLog> logBySchedule = logsByDateAndSchedule.getOrDefault(date, Map.of());
             for (final MealSlot slot : MealSlot.values()) {

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import com.ppiyaki.user.repository.UserRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.time.LocalDate;
 import java.time.YearMonth;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -45,10 +46,12 @@ class DashboardMonthlyE2ETest {
     }
 
     @Test
-    @DisplayName("시니어 본인 호출 — schedule 없으면 days 모두 PERFECT, 길이는 해당 월 일수")
+    @DisplayName("시니어 본인 호출 — 현재 월 schedule 없으면 가입일 이후 PERFECT, 가입 이전 NOT_SCHEDULED (issue #326)")
     void monthly_seniorSelf_emptySchedules() {
         final SignupResult senior = signup("월간시니어");
-        final YearMonth ym = YearMonth.of(2026, 1);
+        // 현재 월로 조회 — 가입 후 days는 PERFECT, 가입 전 days는 NOT_SCHEDULED
+        final YearMonth ym = YearMonth.now();
+        final int today = LocalDate.now().getDayOfMonth();
 
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
@@ -57,11 +60,12 @@ class DashboardMonthlyE2ETest {
                 .then()
                 .statusCode(200)
                 .body("seniorId", is(senior.userId().intValue()))
-                .body("yearMonth", is("2026-01"))
-                .body("days.size()", is(31))
-                .body("days[0].date", is("2026-01-01"))
-                .body("days[0].dayStatus", is("PERFECT"))
-                .body("days[30].date", is("2026-01-31"));
+                .body("yearMonth", is(ym.toString()))
+                .body("days.size()", is(ym.lengthOfMonth()))
+                // today는 가입일과 동일 → PERFECT (schedule 없음 + 가입 이후)
+                .body("days[" + (today - 1) + "].dayStatus", is("PERFECT"))
+                // 1일은 today보다 이르면 NOT_SCHEDULED, 같으면 PERFECT
+                .body("days[0].dayStatus", is(today > 1 ? "NOT_SCHEDULED" : "PERFECT"));
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
@@ -54,11 +54,12 @@ class DashboardWeeklyE2ETest {
     }
 
     @Test
-    @DisplayName("시니어 본인 호출 — schedule 없으면 days[7] 모두 PERFECT, adherenceRate=null")
+    @DisplayName("시니어 본인 호출 — 가입 후 날짜 schedule 없으면 PERTECT, 가입 이전은 NOT_SCHEDULED (issue #326)")
     void weekly_seniorSelf_emptySchedules() {
         final SignupResult senior = signup("주간시니어");
         setMealTimes(senior.userId(), LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
-        final LocalDate weekStart = LocalDate.now().minusDays(7);
+        // weekStart를 today로 두어 days[0]이 가입 직후(또는 가입일과 동일)가 되도록 함
+        final LocalDate weekStart = LocalDate.now();
 
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -307,6 +307,62 @@ class DashboardServiceTest {
     }
 
     @Test
+    @DisplayName("weekly — 시니어 가입 이전 날짜는 dayStatus NOT_SCHEDULED + 모든 슬롯 NOT_SCHEDULED (issue #326)")
+    void weekly_beforeRegistration_returnsNotScheduled() throws Exception {
+        // given — 시니어 가입일이 weekStart+3 (즉 처음 3일은 가입 전)
+        final User senior = userOf(SENIOR_ID, "김장군");
+        final LocalDate weekStart = TODAY.minusDays(6);
+        final LocalDateTime registeredAt = weekStart.plusDays(3).atStartOfDay();
+        setField(senior, "createdAt", registeredAt);
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(senior));
+
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        // when
+        final var resp = dashboardService.getWeekly(SENIOR_ID, SENIOR_ID, weekStart);
+
+        // then — 처음 3일(weekStart, +1, +2)는 NOT_SCHEDULED, 나머지 4일은 PERFECT(스케줄 없음)
+        org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(7);
+        for (int i = 0; i < 3; i++) {
+            org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
+                    .isEqualTo(com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
+            org.assertj.core.api.Assertions.assertThat(resp.days().get(i).slots())
+                    .allMatch(s -> s.status() == SlotStatus.NOT_SCHEDULED);
+        }
+        for (int i = 3; i < 7; i++) {
+            org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
+                    .isEqualTo(com.ppiyaki.medication.DayStatus.PERFECT);
+        }
+    }
+
+    @Test
+    @DisplayName("monthly — 시니어 가입 이전 날짜는 dayStatus NOT_SCHEDULED (issue #326)")
+    void monthly_beforeRegistration_returnsNotScheduled() throws Exception {
+        // given — 가입일 = 1월 15일, 조회는 1월
+        final User senior = userOf(SENIOR_ID, "김장군");
+        setField(senior, "createdAt", LocalDateTime.of(2026, 1, 15, 0, 0));
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(senior));
+
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        final java.time.YearMonth ym = java.time.YearMonth.of(2026, 1);
+        final var resp = dashboardService.getMonthly(SENIOR_ID, SENIOR_ID, ym);
+
+        // then — 1~14일은 NOT_SCHEDULED, 15일부터 PERFECT
+        org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(31);
+        for (int i = 0; i < 14; i++) {
+            org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
+                    .isEqualTo(com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
+        }
+        org.assertj.core.api.Assertions.assertThat(resp.days().get(14).dayStatus())
+                .isEqualTo(com.ppiyaki.medication.DayStatus.PERFECT);
+    }
+
+    @Test
     @DisplayName("monthly — 2월(28일)은 days.size=28")
     void monthly_february28() throws Exception {
         givenSeniorAndCaregiver();
@@ -364,6 +420,8 @@ class DashboardServiceTest {
         final User u = ctor.newInstance();
         setField(u, "id", id);
         setField(u, "nickname", nickname);
+        // 기본 createdAt = 1년 전. 가입 이전 날짜 검증 케이스에선 별도 setField로 덮음.
+        setField(u, "createdAt", LocalDateTime.now().minusYears(1));
         return u;
     }
 


### PR DESCRIPTION
## AS-IS
- 운영 보고(2026-05-12): 주간/월간 대시보드에서 senior 가입 이전 날짜의 dayStatus가 모두 PERFECT로 표시
- `DashboardService.deriveDayStatusFromMarkers`의 `present.isEmpty()` 분기가 무조건 PERFECT 반환
- `getWeekly`/`getMonthly`에 `senior.createdAt` 필터 부재
- 결과: 가입 전 날짜 = schedule 없음 = `present.isEmpty() == true` → **PERFECT 오표시**

## TO-BE
- `DashboardService.getWeekly`/`getMonthly` 일자별 status 결정 시:
  - `date.isBefore(senior.createdAt.toLocalDate())`이면 모든 슬롯 NOT_SCHEDULED + dayStatus NOT_SCHEDULED로 강제
  - 가입 후 날짜는 기존 로직 유지
- `DayStatus` enum에 `NOT_SCHEDULED` 추가 (스케줄/로그가 존재할 수 없는 시점)
- 단위 테스트 2건 (weekly/monthly 가입 전 케이스)
- 기존 E2E 테스트 정리:
  - `DashboardWeeklyE2ETest`: weekStart을 today로 변경 (가입 후 기간 검증)
  - `DashboardMonthlyE2ETest`: yearMonth를 현재 월로 + 동적 검증
- `DashboardServiceTest.userOf` helper: createdAt 기본값 1년 전 (모든 기존 테스트 NPE 방지)

## 프론트 영향
- `DayStatus` enum 신규 값 `NOT_SCHEDULED` — 프론트가 알 수 없는 enum 값 처리 방식 확인 필요
- 권장: 가입 전 날짜는 빈 셀 또는 회색 처리

## 관련 이슈
- closes #326

## 라벨 부여 확인
- [x] `type:fix`
- [x] `scope:medication`
- [x] `ai-generated`
- [ ] `needs-human-review` — 해당 없음 (DB 변경 X, enum 추가만)

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` 전체 통과
- [x] 회귀 가능 구간 확인 — 가입 후 날짜 로직 변경 없음
- [x] 롤백: revert 1회 (DayStatus.NOT_SCHEDULED는 enum 추가라 DB drop 불필요)

## DDD/OOP
- [x] DayStatus enum 의미 분리 (PERFECT vs NOT_SCHEDULED)

## 보안/민감정보
- [x] 시크릿/의료정보 없음

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 사용자 운영 보고 — 가입 전 PERFECT 버그
- 변경 파일: DashboardService, DayStatus, DashboardServiceTest, DashboardWeeklyE2ETest, DashboardMonthlyE2ETest
- 사람이 수동 검증: NOT_SCHEDULED enum 재사용 추천 (사용자 합의 옵션 a)
- 잔여 리스크: 프론트가 NOT_SCHEDULED dayStatus 처리 안 하면 표시 비정상 → 프론트 cut-over 필요

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 시니어 가입 이전의 날짜에 대해 대시보드에서 "미예약" 상태를 올바르게 표시하도록 개선했습니다.
  * 등록 전 기간의 약물 기록이 없는 날짜들의 슬롯 상태를 적절히 처리합니다.
  * 주간 및 월간 대시보드 뷰에서 가입 전 데이터 조회 시 발생하던 문제를 해결했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/327)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->