### PR TITLE
test(medication): MEDICATION_REMINDER 알림 자동 전이 E2E 보강 (#324)

### DIFF
--- a/src/test/java/com/ppiyaki/notification/controller/NotificationAutoTakenE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/NotificationAutoTakenE2ETest.java
@@ -1,0 +1,201 @@
+package com.ppiyaki.notification.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.ppiyaki.common.auth.JwtProvider;
+import com.ppiyaki.medication.DosageUnit;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("PUT /api/v1/medication-logs TAKEN → MEDICATION_REMINDER 알림 takenAt 자동 전이 E2E")
+class NotificationAutoTakenE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private MedicineRepository medicineRepository;
+    @Autowired
+    private MedicationScheduleRepository scheduleRepository;
+    @Autowired
+    private NotificationRepository notificationRepository;
+    @Autowired
+    private JwtProvider jwtProvider;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 800000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("TAKEN upsert 시 같은 날짜·슬롯의 MEDICATION_REMINDER 알림만 takenAt 채워지고 다른 카테고리는 영향 없음")
+    void taken_upsert_marks_reminder_taken_only() {
+        // given — 시니어 + medicine + schedule(BREAKFAST 1정) + 시니어 토큰
+        final Long seniorId = seedSenior();
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+        final Long medicineId = seedMedicine(seniorId);
+        final Long scheduleId = seedSchedule(medicineId, MealSlot.BREAKFAST);
+
+        // 알림 3건 INSERT
+        // (1) MEDICATION_REMINDER, BREAKFAST, today  → 자동 전이 대상
+        // (2) MEDICATION_REMINDER, DINNER, today     → 다른 슬롯, 영향 없음
+        // (3) DUR_WARNING                            → 다른 카테고리, 영향 없음
+        final LocalDate today = LocalDate.now();
+        final Long reminderBreakfastId = seedReminderNotification(seniorId, today, MealSlot.BREAKFAST);
+        final Long reminderDinnerId = seedReminderNotification(seniorId, today, MealSlot.DINNER);
+        final Long durWarningId = seedDurWarningNotification(seniorId);
+
+        // when — 시니어가 BREAKFAST schedule TAKEN 인증
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + seniorToken)
+                .body("""
+                        {
+                            "scheduleId": %d,
+                            "targetDate": "%s",
+                            "status": "TAKEN"
+                        }
+                        """.formatted(scheduleId, today))
+                .when()
+                .put("/api/v1/medication-logs")
+                .then()
+                .statusCode(200);
+
+        // then — DB에서 직접 검증 (응답 DTO 검증은 GET /notifications로 별도 처리)
+        final Notification reminderBreakfast = notificationRepository.findById(reminderBreakfastId).orElseThrow();
+        final Notification reminderDinner = notificationRepository.findById(reminderDinnerId).orElseThrow();
+        final Notification durWarning = notificationRepository.findById(durWarningId).orElseThrow();
+
+        org.assertj.core.api.Assertions.assertThat(reminderBreakfast.getTakenAt()).isNotNull();
+        org.assertj.core.api.Assertions.assertThat(reminderDinner.getTakenAt())
+                .as("다른 슬롯(DINNER) 알림은 영향 없어야 함").isNull();
+        org.assertj.core.api.Assertions.assertThat(durWarning.getTakenAt())
+                .as("다른 카테고리(DUR_WARNING) 알림은 영향 없어야 함").isNull();
+
+        // GET 응답 DTO에 takenAt 노출 검증
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorToken)
+                .when()
+                .get("/api/v1/notifications?category=MEDICATION_REMINDER")
+                .then()
+                .statusCode(200)
+                .body("responses.find { it.id == " + reminderBreakfastId + " }.takenAt", notNullValue())
+                .body("responses.find { it.id == " + reminderDinnerId + " }.takenAt", is(nullValue()));
+    }
+
+    @Test
+    @DisplayName("이미 TAKEN인 row 재호출(MISSED→TAKEN→TAKEN) 시 첫 TAKEN의 takenAt이 보존되고 두 번째 호출이 덮어쓰지 않음 — 멱등")
+    void reminder_takenAt_idempotent() throws InterruptedException {
+        final Long seniorId = seedSenior();
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+        final Long medicineId = seedMedicine(seniorId);
+        final Long scheduleId = seedSchedule(medicineId, MealSlot.LUNCH);
+        final LocalDate today = LocalDate.now();
+        final Long reminderId = seedReminderNotification(seniorId, today, MealSlot.LUNCH);
+
+        // 1차 TAKEN
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + seniorToken)
+                .body("""
+                        {"scheduleId": %d, "targetDate": "%s", "status": "TAKEN"}
+                        """.formatted(scheduleId, today))
+                .when().put("/api/v1/medication-logs").then().statusCode(200);
+
+        final LocalDateTime firstTakenAt = notificationRepository.findById(reminderId).orElseThrow().getTakenAt();
+        org.assertj.core.api.Assertions.assertThat(firstTakenAt).isNotNull();
+
+        // 2차 TAKEN (멱등 호출)
+        Thread.sleep(20);
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + seniorToken)
+                .body("""
+                        {"scheduleId": %d, "targetDate": "%s", "status": "TAKEN"}
+                        """.formatted(scheduleId, today))
+                .when().put("/api/v1/medication-logs").then().statusCode(200);
+
+        final LocalDateTime secondTakenAt = notificationRepository.findById(reminderId).orElseThrow().getTakenAt();
+        org.assertj.core.api.Assertions.assertThat(secondTakenAt)
+                .as("이미 TAKEN인 알림의 takenAt은 덮어쓰지 않아야 함 (markReminderTaken WHERE takenAt IS NULL)")
+                .isEqualTo(firstTakenAt);
+    }
+
+    // --- fixtures ---
+
+    private Long seedSenior() {
+        return transactionTemplate.execute(status -> {
+            final User senior = User.createSenior("E2E시니어" + userSequence++, (LocalDate) null);
+            return userRepository.save(senior).getId();
+        });
+    }
+
+    private Long seedMedicine(final Long seniorId) {
+        return transactionTemplate.execute(status -> {
+            final Medicine medicine = new Medicine(seniorId, null, "테스트약", 30, 30, "ITEM-1", null);
+            return medicineRepository.save(medicine).getId();
+        });
+    }
+
+    private Long seedSchedule(final Long medicineId, final MealSlot slot) {
+        return transactionTemplate.execute(status -> {
+            final MedicationSchedule schedule = new MedicationSchedule(
+                    medicineId, slot, BigDecimal.ONE, DosageUnit.TABLET,
+                    "DAILY", LocalDate.now(), null);
+            return scheduleRepository.save(schedule).getId();
+        });
+    }
+
+    private Long seedReminderNotification(final Long seniorId, final LocalDate targetDate, final MealSlot slot) {
+        return transactionTemplate.execute(status -> {
+            final Notification n = Notification.createForMedicationReminder(
+                    seniorId, "약 드실 시간이에요", "삐~약드실 시간이에요~", targetDate, slot.name());
+            return notificationRepository.save(n).getId();
+        });
+    }
+
+    private Long seedDurWarningNotification(final Long seniorId) {
+        return transactionTemplate.execute(status -> {
+            final Notification n = Notification.createForDurWarning(
+                    seniorId, seniorId, "DUR 경고", "약 충돌 경고", 999L);
+            return notificationRepository.save(n).getId();
+        });
+    }
+}


### PR DESCRIPTION
## AS-IS
PR #325(notification.taken_at 자동 전이) 검증 범위가 `MedicationLogServiceTest`의 Mockito verify 단위 테스트 2건에 한정. 다음이 검증 안 됨:
- `@Modifying UPDATE` JPQL 자체 동작 (컬럼/path 오타 시 런타임 발견)
- DB에 `taken_at`이 실제로 채워지는지 (Hibernate flush, transaction commit 등 실제 흐름)
- 응답 DTO `NotificationItemResponse.takenAt` JSON 직렬화
- 다른 알림 카테고리(DUR/DELAY/COMPLETE/FAMILY_SAFETY)는 영향 없음

## TO-BE
SpringBootTest 기반 E2E 2건 추가 (`NotificationAutoTakenE2ETest`):

### 시나리오 1: 정확성 + 카테고리 필터
- REMINDER(BREAKFAST/today) + REMINDER(DINNER/today) + DUR_WARNING 3건 INSERT
- BREAKFAST schedule TAKEN 인증 (`PUT /api/v1/medication-logs`)
- 검증:
  - BREAKFAST REMINDER: `takenAt != null` ✓
  - DINNER REMINDER: `takenAt == null` (다른 슬롯) ✓
  - DUR_WARNING: `takenAt == null` (다른 카테고리) ✓
- GET `/api/v1/notifications`로 응답 DTO 노출도 함께 검증

### 시나리오 2: 멱등
- 같은 schedule TAKEN을 두 번 연속 호출
- 첫 번째 takenAt이 두 번째 호출에 의해 덮어쓰지 않음 (`WHERE takenAt IS NULL` 정상 동작)

## 부수 결과: prod FCM 운영 진단
PR #325 작업 도중 prod 점검에서 사용자(최진영) 보고 "FCM 알림 0건"의 원인 확인:
- 김순(seniorId=30)은 role=SENIOR + mealTimes 설정 ✓ + 알림 INSERT 정상 (notifications 테이블에 24h 내 2건)
- 그러나 **device_tokens에 user_id=30 row 없음** → `findByUserIdAndIsActiveTrue` 빈 리스트 → for 루프 미실행 → FCM 발송 0건
- 토큰 등록한 계정(test_senior_20260506, user_id=16)은 role=NULL이라 Scheduler가 아예 제외
- **결론: 코드 버그 X, 데이터 상태 문제**. 김순 앱에서 `POST /api/v1/device-tokens` 호출 흐름 점검 필요. 별도 follow-up

## 관련 이슈
- refs #324 (PR #325 후속 검증 보강)

## 라벨 부여 확인
- [x] `type:test`
- [x] `scope:medication`
- [x] `ai-generated`
- [ ] `needs-human-review` — 해당 없음 (테스트 코드만)

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` 전체 통과 (E2E 2건 추가 + 회귀 없음)

## DDD/OOP
- [x] 테스트 코드만 추가, 운영 코드 변경 없음

## 보안/민감정보
- [x] 시크릿/의료정보 없음

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 사용자 요청 — PR #325 검증 보강 + FCM 미발송 원인 분석
- 변경 파일: `NotificationAutoTakenE2ETest.java` 신규
- 사람이 수동 검증: prod ssh 진단 결과 확인 (device_tokens user_id 매핑 누락)
- 잔여 follow-up:
  - 김순(seniorId=30) 디바이스 토큰 등록 흐름 검증 (프론트)
  - test_senior_20260506(user_id=16) role=NULL 정정
  - DeviceToken 등록 API에 role 검증 추가 검토

</details>