### PR TITLE
fix(medication): DeviceToken 같은 token 다른 user 재등록 시 소유자 이전

### DIFF
--- a/src/main/java/com/ppiyaki/notification/DeviceToken.java
+++ b/src/main/java/com/ppiyaki/notification/DeviceToken.java
@@ -63,6 +63,17 @@ public class DeviceToken extends BaseTimeEntity {
         this.lastSeenAt = Objects.requireNonNull(lastSeenAt, "lastSeenAt must not be null");
     }
 
+    /**
+     * 같은 device가 다른 사용자 계정으로 로그인 후 재등록되는 케이스의 소유자 이전.
+     * issue #329: token UNIQUE 제약 때문에 신규 INSERT 불가 → 같은 row의 owner를 갱신.
+     * lastSeenAt 갱신 + isActive=true.
+     */
+    public void transferTo(final Long newUserId, final LocalDateTime lastSeenAt) {
+        this.userId = Objects.requireNonNull(newUserId, "newUserId must not be null");
+        this.isActive = true;
+        this.lastSeenAt = Objects.requireNonNull(lastSeenAt, "lastSeenAt must not be null");
+    }
+
     public void deactivate() {
         this.isActive = false;
     }

--- a/src/main/java/com/ppiyaki/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/ppiyaki/notification/service/DeviceTokenService.java
@@ -21,9 +21,15 @@ public class DeviceTokenService {
 
     @Transactional
     public DeviceTokenResponse register(final Long userId, final String token, final DevicePlatform platform) {
+        final LocalDateTime now = LocalDateTime.now();
         final DeviceToken saved = deviceTokenRepository.findByToken(token)
                 .map(existing -> {
-                    existing.reactivate(LocalDateTime.now());
+                    if (!existing.getUserId().equals(userId)) {
+                        // 같은 device가 다른 사용자 계정으로 로그인 후 재등록 — 소유자 이전 (issue #329)
+                        existing.transferTo(userId, now);
+                    } else {
+                        existing.reactivate(now);
+                    }
                     return existing;
                 })
                 .orElseGet(() -> deviceTokenRepository.save(DeviceToken.register(userId, token, platform)));

--- a/src/test/java/com/ppiyaki/notification/service/DeviceTokenServiceTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/DeviceTokenServiceTest.java
@@ -2,6 +2,7 @@ package com.ppiyaki.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -48,10 +49,11 @@ class DeviceTokenServiceTest {
     }
 
     @Test
-    @DisplayName("기존 token이면 reactivate 호출 + save 호출 안 함")
-    void register_existing_token_reactivates() {
+    @DisplayName("기존 token + 같은 user면 reactivate 호출 + transferTo는 호출 안 함")
+    void register_existing_token_sameUser_reactivates() {
         // given
         final DeviceToken existing = mock(DeviceToken.class);
+        given(existing.getUserId()).willReturn(7L);
         given(existing.getIsActive()).willReturn(true);
         given(deviceTokenRepository.findByToken("token-123")).willReturn(Optional.of(existing));
 
@@ -60,6 +62,25 @@ class DeviceTokenServiceTest {
 
         // then
         verify(existing).reactivate(any(LocalDateTime.class));
+        verify(existing, never()).transferTo(any(), any(LocalDateTime.class));
+        verify(deviceTokenRepository, never()).save(any(DeviceToken.class));
+    }
+
+    @Test
+    @DisplayName("기존 token + 다른 user면 transferTo 호출 (소유자 이전, issue #329)")
+    void register_existing_token_differentUser_transfers() {
+        // given — 기존 row owner=7L, 신규 등록 요청 owner=30L (다른 user)
+        final DeviceToken existing = mock(DeviceToken.class);
+        given(existing.getUserId()).willReturn(7L);
+        given(existing.getIsActive()).willReturn(true);
+        given(deviceTokenRepository.findByToken("token-123")).willReturn(Optional.of(existing));
+
+        // when
+        deviceTokenService.register(30L, "token-123", DevicePlatform.ANDROID);
+
+        // then — transferTo로 owner 이전, reactivate는 호출 안 함
+        verify(existing).transferTo(eq(30L), any(LocalDateTime.class));
+        verify(existing, never()).reactivate(any(LocalDateTime.class));
         verify(deviceTokenRepository, never()).save(any(DeviceToken.class));
     }
 


### PR DESCRIPTION
## AS-IS
운영 보고: 신규 시니어 access token으로 `POST /api/v1/users/me/devices` 호출 시 **201 응답이 떴으나** prod FCM 알림 0건. prod 진단 결과:
- `device_tokens` row가 옛 사용자(같은 device로 옛날에 등록한 다른 계정)에 그대로 남음
- 신규 시니어 user_id로 row 갱신되지 않음
- `token` 컬럼 UNIQUE 제약 때문에 신규 INSERT도 불가능 → 발견되지 않은 채 잘못 동작
- 결과: dispatch 시점에 `findByUserIdAndIsActiveTrue(신규user)` → 빈 리스트 → for 루프 미실행 → 푸시 0건 (단 알림함 row는 정상 INSERT라 앱 내 알림은 보임)

```java
// 기존 코드
final DeviceToken saved = deviceTokenRepository.findByToken(token)
        .map(existing -> {
            existing.reactivate(LocalDateTime.now());  // ← user_id 갱신 안 함
            return existing;
        })
        .orElseGet(() -> deviceTokenRepository.save(DeviceToken.register(userId, token, platform)));
```

## TO-BE
- `DeviceToken.transferTo(newUserId, lastSeenAt)` 도메인 메서드 신설 (소유자 이전 + reactivate)
- `DeviceTokenService.register`: 기존 row의 `userId != 신규 userId`이면 `transferTo`, 같으면 기존 `reactivate` (의도 분리)
- 응답 DTO 시그니처 변경 없음 — 프론트 영향 없음

## 동작 변화
| 시나리오 | 기존 | 변경 후 |
|---|---|---|
| 신규 token | INSERT (user_id=요청자) | 동일 |
| 기존 token + 같은 user | reactivate (lastSeenAt 갱신) | 동일 |
| **기존 token + 다른 user** | reactivate (user_id 그대로 — **버그**) | **transferTo (user_id 갱신)** |

## 🔧 prod 데이터 정정
PR 머지 후 다음 중 한 가지:

**(A) 자동 정정 (권장)**: 영향받은 시니어가 device를 다음 한 번만 다시 등록하면 자동 `transferTo`로 정정됨. 별도 SQL 불필요.

**(B) 즉시 수동 정정**: prod에서 직접 row의 user_id 갱신
```sql
-- 예: device_tokens.id=N의 row를 신규 시니어 user_id로 이전
UPDATE device_tokens SET user_id = <신규시니어id>, is_active = TRUE, updated_at = NOW(6)
 WHERE id = <대상row id>;
```
영향받은 시니어 1명 한정 즉시 정정 가능.

## 단위 테스트
- 신규 token → save 호출 (기존)
- 기존 token + 같은 user → reactivate, transferTo 호출 안 함
- 기존 token + 다른 user → transferTo, reactivate 호출 안 함

## 관련 이슈
- closes #329
- 운영 보고: PR #325(takenAt 자동 전이) 후속 진단에서 발견. PR #325 자체는 정상 동작 (DB UPDATE 검증됨)

## 라벨 부여 확인
- [x] `type:fix`
- [x] `scope:medication`
- [x] `ai-generated`
- [ ] `needs-human-review` — 해당 없음 (DB 스키마 변경 X, 데이터 정정만)

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` 전체 통과

## DDD/OOP
- [x] `transferTo` 도메인 메서드로 소유자 이전 의도 명시. Service는 분기만

## 보안/민감정보
- [x] PII/시크릿 없음 (이슈 #329 본문 익명화 후 작성)

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 사용자 운영 보고 — 토큰 등록은 됐는데 푸시 안 옴
- 변경 파일: DeviceToken.java, DeviceTokenService.java, DeviceTokenServiceTest.java
- 사람이 수동 검증: prod ssh 진단 (옛 row user_id=16에 정체된 상태 확인), UPDATE vs DELETE+INSERT 옵션 비교 후 UPDATE 결정
- 잔여 follow-up:
  - prod 데이터 정정 (자동 또는 수동, 위 PR description 참조)
  - PR #325 후속 검증: 시니어가 device 재등록 + 다음 알림 시점에 FCM sent 로그 확인

</details>