### PR TITLE
release: v0.12.0

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -188,7 +188,9 @@ OCR + LLM 파싱으로 추출된 약물 후보. 처방전 1건당 N행. 보호�
 | prescription_id | bigint | `prescriptions.id` 참조 |
 | ocr_raw_text | varchar nullable | OCR이 인식한 원문 약물 텍스트 |
 | extracted_name | varchar nullable | LLM이 추출한 약물명 |
-| extracted_dosage | varchar nullable | LLM이 추출한 용량 |
+| extracted_dosage | varchar nullable | LLM이 추출한 용량 (raw 문자열, deprecated 예정 — 정수+단위 분리 컬럼으로 점차 이전, spec `dosage-quantity-unit-split.md`) |
+| extracted_dosage_quantity | decimal(5,2) nullable | 1회 복용량의 수치(분수 허용, 예: `1`, `0.5`). PRN 등 정의되지 않은 케이스는 NULL |
+| extracted_dosage_unit | varchar(16) nullable | 단위 문자열(예: `정`, `캡슐`, `ml`, `mg`, `PRN`). 표준화 enum은 별도 follow-up |
 | extracted_schedule | varchar nullable | LLM이 추출한 복약 일정 |
 | matched_item_seq | varchar nullable | 식약처 DB 매칭된 품목 일련번호 |
 | matched_item_name | varchar nullable | 식약처 DB 매칭된 품목명 |
@@ -230,7 +232,9 @@ OCR + LLM 파싱으로 추출된 약물 후보. 처방전 1건당 N행. 보호�
 | id | bigint PK | |
 | medicine_id | bigint | `medicines.id` 참조 |
 | meal_slot | varchar | DB는 varchar, Java는 `MealSlot` enum(`BREAKFAST`/`LUNCH`/`DINNER`). NOT NULL. 실제 시각은 시니어 mealTimes로 동적 계산 |
-| dosage | varchar | 1회 복용량 (예: `1정`) |
+| dosage | varchar | 1회 복용량 raw 문자열 (예: `1정`). **deprecated 예정** — 정수+단위 분리 컬럼으로 점차 이전 (spec `dosage-quantity-unit-split.md`) |
+| dosage_quantity | decimal(5,2) nullable | 1회 복용량의 수치(분수 허용, 예: `1`, `0.5`). PRN 등 정의되지 않은 케이스는 NULL. release 직후 옛 row는 모두 NULL |
+| dosage_unit | varchar(16) nullable | 단위 문자열(예: `정`, `캡슐`, `ml`, `mg`, `PRN`). 표준화 enum은 별도 follow-up |
 | days_of_week | varchar | 요일 패턴 (예: `MON,TUE,WED,THU,FRI` 또는 `DAILY`). 7비트 마스크 대신 가독성 우선 |
 | start_date | date | 복약 시작일 |
 | end_date | date nullable | 복약 종료일. NULL이면 무기한 |
@@ -473,7 +477,9 @@ erDiagram
         bigint prescription_id FK
         varchar ocr_raw_text "nullable"
         varchar extracted_name "nullable"
-        varchar extracted_dosage "nullable"
+        varchar extracted_dosage "nullable, deprecated"
+        decimal extracted_dosage_quantity "nullable"
+        varchar extracted_dosage_unit "nullable"
         varchar extracted_schedule "nullable"
         varchar matched_item_seq "nullable"
         varchar matched_item_name "nullable"
@@ -502,7 +508,9 @@ erDiagram
         bigint id PK
         bigint medicine_id FK
         varchar meal_slot "BREAKFAST/LUNCH/DINNER"
-        varchar dosage
+        varchar dosage "deprecated"
+        decimal dosage_quantity "nullable"
+        varchar dosage_unit "nullable"
         varchar days_of_week
         date start_date
         date end_date

--- a/docs/features/dosage-quantity-unit-split.md
+++ b/docs/features/dosage-quantity-unit-split.md
@@ -1,0 +1,139 @@
+---
+feature: dosage 컬럼 정수 + 단위 분리
+slug: dosage-quantity-unit-split
+status: ready-for-impl
+owner: @goohong
+scope: prescription
+related_issues: []
+related_prs: [318]
+last_reviewed: 2026-05-12
+---
+
+# dosage 컬럼 정수 + 단위 분리
+
+## 1) 개요 (What / Why)
+- 처방전·복약 도메인의 `dosage`가 현재 자유 입력 String(`"1정"`, `"한 정"`, `"PRN"`, `"30mg"`)이라 정수 추출이 정규식 fallback에 의존한다.
+- AI(OpenAI)가 추출한 raw dosage 텍스트가 `MedicationSchedule.dosage` / `PrescriptionMedicineCandidate.extractedDosage`에 그대로 저장되고, 약 차감/일정 카운트 시점에 `MedicationSchedule.parseDosageInt`로 정수만 추출, 실패 시 fallback 1개 차감.
+- **Primary Why**: (1) 비정수 표현(`한 정`, `PRN`, `30mg`)은 잔여량 차감을 항상 1로 만들어 데이터 정합성 떨어짐. (2) AI 출력 schema가 정밀하지 않아 사람 검수 비용 큼. (3) `parseDosageInt` fallback 제거가 PR #318 머지로 가능해진 후속 정리.
+- **부수 효과**: PRN(필요 시 복용) 같은 케이스를 도메인적으로 명확히 구분할 진입로 마련.
+
+## 2) 사용자 시나리오
+- **AI/시스템**: OCR 마스킹 텍스트에서 약 정보를 추출할 때 `{quantity: 1, unit: "정"}` 형태로 정밀 응답 → 사람 검수 필요 케이스(`한 정`, `PRN`)를 양 통합 필드가 아니라 unit만 받는 형식으로 표현.
+- **보호자**: 처방전 검토 시 OCR 누락분/오류분의 dosage를 정수 + 단위로 입력 (PR #318로 추가된 dosage 필드 갱신).
+- **시스템**: 복약 인증 시 `parseDosageInt` 없이 `schedule.dosageQuantity`로 잔여량 차감. PRN/null 케이스는 차감 자체를 skip하거나 별도 정책으로 처리.
+
+## 3) 요구사항
+
+### 기능 요구사항
+- [ ] `MedicationSchedule`에 `dosage_quantity DECIMAL(5,2) NULL` + `dosage_unit VARCHAR(16) NULL` 컬럼 추가 (Q2 답변: 분수 허용)
+- [ ] `PrescriptionMedicineCandidate`에 동일 두 컬럼 추가
+- [ ] `ExtractedMedicine`(OpenAI 응답 DTO)에 `dosageQuantity: BigDecimal`/`dosageUnit: String` 필드 + 시스템 프롬프트 갱신: **"한 정/한 캡슐"도 quantity=1로 변환, "반정"=0.5, PRN처럼 횟수 정의 안 되는 케이스만 quantity=null** 강제 (Q1 정정)
+- [ ] `CandidateDecisionRequest`(PR #318 결과)에서 `dosage` String 필드 **즉시 제거** + `dosageQuantity`/`dosageUnit` 두 필드 신설 (Q5: 호환 끊음)
+- [ ] `MedicationLogService.java:124-125` fallback 1개 차감 제거 → `schedule.getDosageQuantity()` 직접 사용. `dosageQuantity == null` 케이스는 차감 skip
+- [ ] `MedicationSchedule.parseDosageInt` 메서드 + `DOSAGE_INT_PATTERN` 상수 제거 (호출처 0)
+- [ ] 잔여량 차감/대시보드 카운트 로직을 `BigDecimal` 또는 `double` 기반으로 변경
+- [ ] 응답 DTO(`PrescriptionMedicineCandidateResponse`, schedule 조회/대시보드/medication-log) 모두 분리 구조 노출
+- [ ] **backfill 생략** (Q6 정정): 옛 dosage String → 분리 컬럼 자동 변환 안 함. 모든 옛 row는 `dosage_quantity = NULL` 상태. SQL 정규식이 옛 `parseDosageInt`와 같은 한계 갖는 걸 회피하기 위함
+- [ ] Notion API 명세 다수 갱신 (prescription confirm/detail/PATCH, medication-log upsert/조회, schedule 조회, 대시보드)
+
+### 비기능 요구사항
+- 기존 데이터 무손실 (옛 `dosage` String 컬럼은 일정 기간 공존, 분리 컬럼 backfill 검증 후 drop)
+- AI 출력 schema는 **즉시 새 schema 강제** (Q4: 호환 없음). PR 1(엔티티)+PR 2(AI schema)+PR 3(DTO/Service)을 **같은 release에 묶어 cut-over** 보장 필수
+
+## 4) 범위 / 비범위
+
+### 포함
+- 양 엔티티 컬럼 추가 + AI schema 변경 + DTO 분리 + 호출처 정리 + fallback 제거
+- prod 마이그레이션 SQL 가이드 작성 (수동 ALTER + backfill SQL)
+- Notion API 명세 갱신
+- E2E 회귀 + 신규 케이스(PRN/null/정수 모두) 검증
+
+### 제외 (Out of Scope)
+- 단위 마스터(예: `정`/`캡슐`/`ml`/`mg`/`알`/`포` 표준화 enum) — 우선 자유 입력 String. enum 표준화는 별도 follow-up
+- PRN 처방의 알림/스케줄 정책 변경 — 등록만 허용, 알림 트리거는 기존 방식 유지 (별도 도메인 결정)
+- Medicine 도메인 자체의 단위 표기 (제품 사양) — prescription/schedule 관점만
+- 옛 `dosage` String 컬럼 drop — release 후 안정화 기간(예: 2주) 후 별도 PR로 처리
+- **옛 schedule(이미 confirm된 처방의 schedule) dosage 보강** — Q6/Q7 결정에 따라 자동 backfill도 안 하고 caregiver 보강 API도 신설 안 함. release 직후 기존 schedule들은 `dosage_quantity = NULL`로 잔여량 차감 멈춘 상태로 유지. 운영 데이터 영향이 작아 그대로 두기로 결정. 차후 필요해지면 별도 follow-up
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+- 엔티티 변경: `MedicationSchedule`, `PrescriptionMedicineCandidate`
+- `06-domain-model.md` §5 엔티티 + §6 Mermaid ERD 동시 갱신
+- 유비쿼터스 랭귀지 §4: `Dosage Quantity` / `Dosage Unit` 등재
+
+### 5-2) API 엔드포인트 (변경)
+
+| Method | Path | 변경 내용 |
+|---|---|---|
+| PATCH | /api/v1/prescriptions/{id}/medicines/{candidateId} | `dosage` String → `dosageQuantity` Int + `dosageUnit` String |
+| GET | /api/v1/prescriptions/{id} | candidate 응답에 분리 두 필드 |
+| POST | /api/v1/prescriptions/{id}/confirm | 내부 schedule 생성 시 분리 두 필드 사용 |
+| POST | /api/v1/prescriptions/{id}/medicines | 수동 추가에서도 분리 두 필드 |
+| PUT | /api/v1/medication-logs | 응답에 schedule.dosageQuantity 노출 (필요 시) |
+| GET | /api/v1/seniors/{id}/dashboard/* | 슬롯별 dosage 노출 시 분리 구조 |
+
+### 5-3) 외부 연동 (OpenAI)
+- 시스템 프롬프트 갱신:
+  - "**dosage는 반드시 quantity(숫자) + unit(단위) 두 필드로 분리해서 응답하라**"
+  - "**한국어 수량 표현(`한`/`두`/`세`)도 숫자로 변환하라**" (`한 정` → `{quantity:1, unit:"정"}`)
+  - "**분수 표현(`반`)은 소수로**" (`반정` → `{quantity:0.5, unit:"정"}`)
+  - "**횟수가 정의되지 않은 케이스(`PRN`, `필요 시`)만 quantity=null**" (`PRN` → `{quantity:null, unit:"PRN"}`)
+- 호환성: **즉시 새 schema 강제, 옛 schema 응답 미지원**. 옛 schema 응답 발생 시 candidate 등록 자체 실패 → AI 프롬프트 안정성 검증을 PR 2에서 충분히 수행
+
+### 5-4) 데이터 흐름
+1. OCR → 마스킹 → OpenAI 호출 → `ExtractedMedicine{name, dosageQuantity?, dosageUnit?, ...}` 응답
+2. `PrescriptionMedicineCandidate(extractedDosageQuantity, extractedDosageUnit)` 저장
+3. caregiver PATCH로 보강 (PR #318 dosage String → 분리 두 필드)
+4. confirm 시 `MedicationSchedule(dosageQuantity, dosageUnit)` 생성. **dosageQuantity == null이면 schedule 생성 skip은 유지** (현행 정책)
+5. 복약 인증 시 `medicine.decreaseRemainingAmount(schedule.getDosageQuantity())` — null이면 skip
+
+### 5-5) DB 마이그레이션 (prod 수동)
+```sql
+-- Phase A: 컬럼 추가 (nullable, DECIMAL — 분수 허용)
+ALTER TABLE medication_schedules
+  ADD COLUMN dosage_quantity DECIMAL(5,2) NULL,
+  ADD COLUMN dosage_unit VARCHAR(16) NULL;
+
+ALTER TABLE prescription_medicine_candidates
+  ADD COLUMN extracted_dosage_quantity DECIMAL(5,2) NULL,
+  ADD COLUMN extracted_dosage_unit VARCHAR(16) NULL;
+
+-- Phase B: 자동 backfill 안 함 (Q6 정정 결정).
+-- 옛 dosage String의 정규식 한계가 새 시스템에 침투하는 걸 막기 위해
+-- 옛 row는 모두 NULL 상태로 두고, caregiver/운영자가 별도 보강.
+
+-- Phase C (별도 PR/release): 옛 dosage 컬럼 drop
+-- ALTER TABLE medication_schedules DROP COLUMN dosage;
+```
+
+## 6) 작업 분할 (예상 PR 리스트)
+
+> ⚠️ Q4(즉시 cut-over) 결정에 따라 **PR 1~3을 같은 release 사이클에 묶어 머지**. 분리 머지 시 옛/새 schema가 섞여 candidate 등록 실패 가능.
+
+- [ ] **PR 1 (보호 영역, needs-human-review)**: 양 엔티티에 `dosage_quantity DECIMAL(5,2)` + `dosage_unit VARCHAR(16)` 컬럼 추가 (옛 dosage 컬럼 유지) + JPA 매핑. prod 마이그레이션 가이드(Phase A+B) 첨부. backfill SQL 포함
+- [ ] **PR 2**: AI 프롬프트/응답 schema 갱신 + `ExtractedMedicine` 변경. **옛 schema 응답 미지원, 즉시 새 schema 강제** (Q4). 프롬프트 안정성 검증 테스트
+- [ ] **PR 3**: DTO 분리 + Service 호출처 정리. `CandidateDecisionRequest.dosage` String 필드 **즉시 제거** + `dosageQuantity`/`dosageUnit` 신설 (Q5). `addManualMedicine`, `confirm` 흐름. **MedicationLogService fallback 제거 + `parseDosageInt` 제거 함께 처리** (BigDecimal 차감으로 전환). 응답 DTO 분리 구조 노출. Notion 명세 일괄 갱신
+- [ ] **PR 4 (다음 release 후 별도)**: 옛 `dosage` String 컬럼 drop, 옛 매핑/관련 코드 제거
+
+## 7) 테스트 전략
+- 단위: `MedicationSchedule` 도메인 메서드, `MedicationLogService` 차감 로직 (정수/null 케이스)
+- 통합: AI 응답 mock으로 새 schema → candidate 저장 검증
+- E2E: PR #318 추가 dosage 보강 케이스를 분리 구조로 갱신 + 신규 PRN/한 정 (quantity=null) 케이스
+- AI 프롬프트 검증: 실 OpenAI 호출 테스트 1-2건 (선택, CI 비용 고려)
+
+## 8) 오픈 질문
+
+(현재 미해소 항목 없음 — 모두 §9 결정 로그로 이전)
+
+## 9) 결정 로그
+
+- 2026-05-12: 초안 작성 (status=draft). PR #318 머지 후 follow-up으로 합의.
+- 2026-05-12: 오픈 질문 6건 합의 완료, status=ready-for-impl
+  - **Q1 정정**: AI 프롬프트가 "한 정" 같은 표현도 quantity=1로 변환 강제. 진짜 비정수 케이스(`PRN`/`필요 시`)만 quantity=null
+  - **Q2**: dosage_quantity 컬럼 타입 = `DECIMAL(5,2)`. 분수("반정"=0.5) 허용. 차감 로직 BigDecimal 기반
+  - **Q3**: 단위 표준화(enum)는 별도 follow-up. unit은 String 자유 입력 유지
+  - **Q4**: AI schema 즉시 cut-over (옛 schema 호환 없음). PR 1~3을 같은 release 사이클에 묶음
+  - **Q5**: PR #318의 `CandidateDecisionRequest.dosage` String 필드 즉시 제거 + `dosageQuantity`/`dosageUnit` 두 필드 신설
+  - **Q6 정정**: backfill 자체 생략. 옛 dosage row는 모두 `dosage_quantity = NULL` 상태. SQL 정규식 한계가 새 시스템에 침투하는 걸 막기 위함
+  - **Q7 (Q6 후속)**: release 직후 옛 schedule들의 잔여량 차감 멈추는 문제 — 그대로 두기로 결정. 운영 데이터 영향 작음. 보강 API(예: PATCH /api/v1/medication-schedules/{id}) 신설도 이번 spec 범위 외

--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -170,9 +170,7 @@ public class OpenAiClient {
 
             final List<ExtractedMedicine> result = new ArrayList<>();
             for (final JsonNode item : medicines) {
-                final BigDecimal dosageQuantity = item.path("dosageQuantity").isNumber()
-                        ? item.path("dosageQuantity").decimalValue()
-                        : null;
+                final BigDecimal dosageQuantity = parseDosageQuantity(item.path("dosageQuantity"));
                 final DosageUnit dosageUnit = DosageUnit.fromInput(item.path("dosageUnit").asText(null))
                         .orElse(null);
                 result.add(new ExtractedMedicine(
@@ -192,6 +190,22 @@ public class OpenAiClient {
         } catch (final Exception e) {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
                     "AI response parse failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * dosageQuantity 노드를 BigDecimal로 파싱. number/string 모두 허용 (LLM 응답 흔들림 흡수).
+     * 빈 문자열·파싱 실패·null/array/object 등은 모두 null.
+     */
+    private static BigDecimal parseDosageQuantity(final JsonNode node) {
+        final String text = node.asText("").trim();
+        if (text.isEmpty()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(text);
+        } catch (final NumberFormatException ignored) {
+            return null;
         }
     }
 

--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.medication.DosageUnit;
 import com.ppiyaki.medication.MealSlot;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -99,7 +101,7 @@ public class OpenAiClient {
                     - 약물이 없으면 빈 배열 반환.
 
                     ## 출력 형식
-                    {"medicines": [{"name": "약물명", "manufacturer": "제약사명", "ingredientName": "성분명", "dosage": "용량", "schedule": "복약주기", "mealSlots": ["BREAKFAST","LUNCH","DINNER"]}]}
+                    {"medicines": [{"name": "약물명", "manufacturer": "제약사명", "ingredientName": "성분명", "dosageQuantity": 1, "dosageUnit": "정", "schedule": "복약주기", "mealSlots": ["BREAKFAST","LUNCH","DINNER"]}]}
                     - name: 제품명+제형+용량. 제약사명과 괄호 안 내용은 **제외**.
                       예: "위더스세파클러캡슐250밀리그람" → name: "세파클러캡슐250밀리그람", manufacturer: "위더스"
                       예: "에빅사정(메만틴염산염)_(10mg/1정)" → name: "에빅사정10밀리그램"
@@ -109,7 +111,16 @@ public class OpenAiClient {
                       예: "에빅사정(메만틴염산염)" → ingredientName: "메만틴염산염"
                       예: "타이레놀정500밀리그람" → ingredientName: null (텍스트에 성분명 없음)
                       주의: "(10mg/1정)" 같은 용량 표기는 성분명이 아님. 성분명은 한글 화학명.
-                    - dosage: 1회 투약량 (예: "1정", "0.5정", "2캡슐"). 모르면 null.
+                    - **dosageQuantity (number, nullable)**: 1회 투약 수치. 정수 또는 소수.
+                      * "1정"/"한 정"/"1캡슐" → 1
+                      * "2정"/"두 정" → 2
+                      * "반정"/"0.5정" → 0.5
+                      * 한국어 수량 표현(한/두/세/네/다섯 …)도 반드시 숫자로 변환
+                      * "PRN", "필요시", 횟수가 정의되지 않은 경우 → null
+                    - **dosageUnit (string, nullable)**: 단위 문자열. dosageQuantity 옆에 표기된 단위 그대로.
+                      * "1정" → "정", "2캡슐" → "캡슐", "5ml" → "ml", "30mg" → "mg"
+                      * "PRN"/"필요시" → "PRN" (단위 자리에 표기, dosageQuantity는 null)
+                      * 모르면 null
                     - schedule: 복약주기 (예: "1일 3회 식후 30분"). 모르면 null.
                     - mealSlots: schedule을 식사 슬롯으로 매핑한 배열. 가능한 값은 "BREAKFAST", "LUNCH", "DINNER"만.
                       매핑 규칙:
@@ -159,11 +170,17 @@ public class OpenAiClient {
 
             final List<ExtractedMedicine> result = new ArrayList<>();
             for (final JsonNode item : medicines) {
+                final BigDecimal dosageQuantity = item.path("dosageQuantity").isNumber()
+                        ? item.path("dosageQuantity").decimalValue()
+                        : null;
+                final DosageUnit dosageUnit = DosageUnit.fromInput(item.path("dosageUnit").asText(null))
+                        .orElse(null);
                 result.add(new ExtractedMedicine(
                         item.path("name").asText(null),
                         item.path("manufacturer").asText(null),
                         item.path("ingredientName").asText(null),
-                        item.path("dosage").asText(null),
+                        dosageQuantity,
+                        dosageUnit,
                         item.path("schedule").asText(null),
                         parseMealSlots(item.path("mealSlots"))
                 ));
@@ -289,7 +306,8 @@ public class OpenAiClient {
             String name,
             String manufacturer,
             String ingredientName,
-            String dosage,
+            BigDecimal dosageQuantity,
+            DosageUnit dosageUnit,
             String schedule,
             List<MealSlot> mealSlots
     ) {

--- a/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -16,6 +18,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final String ROLE_PREFIX = "ROLE_";
 
     private final JwtProvider jwtProvider;
 
@@ -33,8 +36,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null && jwtProvider.isValid(token)) {
             final Long userId = jwtProvider.extractUserId(token);
+            final String role = jwtProvider.extractRole(token);
+            final List<GrantedAuthority> authorities = role == null
+                    ? List.of()
+                    : List.of(new SimpleGrantedAuthority(ROLE_PREFIX + role));
             final UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId,
-                    null, List.of());
+                    null, authorities);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
+++ b/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.ppiyaki.common.auth;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -12,6 +13,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_004", "Access denied"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_005", "Resource not found"),
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "COMMON_006", "Too many requests"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_007", "Method not allowed"),
 
     // Auth
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "Invalid token"),

--- a/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,14 @@
 package com.ppiyaki.common.exception;
 
 import jakarta.validation.ConstraintViolationException;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -78,6 +81,20 @@ public class GlobalExceptionHandler {
         final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND,
                 "No endpoint " + exception.getHttpMethod() + " /" + exception.getResourcePath());
         return ResponseEntity.status(ErrorCode.NOT_FOUND.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotSupported(
+            final HttpRequestMethodNotSupportedException exception) {
+        log.debug("Method not allowed: {}", exception.getMessage());
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED,
+                "Method " + exception.getMethod() + " not allowed");
+        final ResponseEntity.BodyBuilder builder = ResponseEntity.status(ErrorCode.METHOD_NOT_ALLOWED.getStatus());
+        final Set<HttpMethod> supportedMethods = exception.getSupportedHttpMethods();
+        if (supportedMethods != null && !supportedMethods.isEmpty()) {
+            builder.allow(supportedMethods.toArray(new HttpMethod[0]));
+        }
+        return builder.body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -81,6 +82,13 @@ public class GlobalExceptionHandler {
         final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND,
                 "No endpoint " + exception.getHttpMethod() + " /" + exception.getResourcePath());
         return ResponseEntity.status(ErrorCode.NOT_FOUND.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(final AccessDeniedException exception) {
+        log.debug("Access denied: {}", exception.getMessage());
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.FORBIDDEN);
+        return ResponseEntity.status(ErrorCode.FORBIDDEN.getStatus()).body(errorResponse);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)

--- a/src/main/java/com/ppiyaki/medication/DayStatus.java
+++ b/src/main/java/com/ppiyaki/medication/DayStatus.java
@@ -9,5 +9,7 @@ public enum DayStatus {
     DELAYED,
     MISSED,
     PENDING,
-    FUTURE
+    FUTURE,
+    /** 시니어 가입 이전 날짜 — 스케줄/로그 자체가 존재할 수 없는 시점. spec issue #326 */
+    NOT_SCHEDULED
 }

--- a/src/main/java/com/ppiyaki/medication/DosageUnit.java
+++ b/src/main/java/com/ppiyaki/medication/DosageUnit.java
@@ -1,0 +1,114 @@
+package com.ppiyaki.medication;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 처방전·복약 일정의 단위 표기 정규화 enum.
+ * spec docs/features/dosage-quantity-unit-split.md.
+ *
+ * 입력 변형(영문 약어/한국어/대소문자 차이)을 fromInput으로 정규화하여 저장한다.
+ * 매칭 안 되는 입력은 OTHER로 흡수 (raw 텍스트 손실, 운영 모니터링으로 enum 추가 검토).
+ */
+public enum DosageUnit {
+
+    /** 정/알 */
+    TABLET("정"),
+    /** 캡슐 */
+    CAPSULE("캡슐"),
+    /** 포 (산제) */
+    PACKET("포"),
+    /** 방울 */
+    DROP("방울"),
+    /** 밀리그램 */
+    MG("mg"),
+    /** 마이크로그램 */
+    MCG("mcg"),
+    /** 그램 */
+    G("g"),
+    /** 밀리리터 */
+    ML("ml"),
+    /** International Unit */
+    IU("IU"),
+    /** PRN — 필요 시 복용 (수량 정의 없음) */
+    PRN("PRN"),
+    /** 매칭 실패한 raw 입력 흡수용. 운영 데이터 보고 enum 추가 검토 */
+    OTHER("");
+
+    private final String displayValue;
+
+    DosageUnit(final String displayValue) {
+        this.displayValue = displayValue;
+    }
+
+    /**
+     * 프론트 응답용 대표 표기. 프론트 변경 없이 그대로 표시 가능.
+     * OTHER는 빈 문자열 (운영 데이터 보고 정책 정정).
+     */
+    public String getDisplayValue() {
+        return displayValue;
+    }
+
+    private static final Map<String, DosageUnit> ALIASES = Map.ofEntries(
+            // TABLET
+            Map.entry("정", TABLET),
+            Map.entry("알", TABLET),
+            Map.entry("tab", TABLET),
+            Map.entry("tablet", TABLET),
+            // CAPSULE
+            Map.entry("캡슐", CAPSULE),
+            Map.entry("cap", CAPSULE),
+            Map.entry("capsule", CAPSULE),
+            // PACKET
+            Map.entry("포", PACKET),
+            Map.entry("pack", PACKET),
+            Map.entry("packet", PACKET),
+            // DROP
+            Map.entry("방울", DROP),
+            Map.entry("drop", DROP),
+            // MG
+            Map.entry("mg", MG),
+            Map.entry("밀리그람", MG),
+            Map.entry("밀리그램", MG),
+            // MCG
+            Map.entry("mcg", MCG),
+            Map.entry("ug", MCG),
+            Map.entry("μg", MCG),
+            Map.entry("마이크로그람", MCG),
+            Map.entry("마이크로그램", MCG),
+            // G
+            Map.entry("g", G),
+            Map.entry("그람", G),
+            Map.entry("그램", G),
+            // ML
+            Map.entry("ml", ML),
+            Map.entry("밀리리터", ML),
+            // IU
+            Map.entry("iu", IU),
+            Map.entry("단위", IU),
+            // PRN
+            Map.entry("prn", PRN),
+            Map.entry("필요시", PRN),
+            Map.entry("필요 시", PRN)
+    );
+
+    /**
+     * 자유 입력 String을 DosageUnit으로 정규화. null/blank → Optional.empty.
+     * 정확 매칭(소문자 비교) → 그 enum, 매칭 실패 → OTHER (raw 입력은 손실).
+     */
+    public static Optional<DosageUnit> fromInput(final String input) {
+        if (input == null || input.isBlank()) {
+            return Optional.empty();
+        }
+        final String key = input.trim().toLowerCase(Locale.ROOT);
+        // 우선 enum.name() 자체 매칭 시도 (이미 정규화된 값 재처리 안전)
+        try {
+            return Optional.of(DosageUnit.valueOf(input.trim().toUpperCase(Locale.ROOT)));
+        } catch (final IllegalArgumentException ignored) {
+            // 별칭 매칭 시도
+        }
+        final DosageUnit matched = ALIASES.get(key);
+        return Optional.of(matched != null ? matched : OTHER);
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
+++ b/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
@@ -86,6 +86,10 @@ public class MedicationSchedule extends CreatedTimeEntity {
             this.dosageQuantity = dosageQuantity;
         }
         if (dosageUnit != null) {
+            // PRN으로 전환 시 quantity는 의미 없음 — null로 정정 (legacy dosage 합성 시 비정상값 회피)
+            if (dosageUnit == DosageUnit.PRN) {
+                this.dosageQuantity = null;
+            }
             this.dosageUnit = dosageUnit;
         }
         if (dosageQuantity != null || dosageUnit != null) {

--- a/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
+++ b/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -38,6 +39,12 @@ public class MedicationSchedule extends CreatedTimeEntity {
 
     @Column(name = "dosage")
     private String dosage;
+
+    @Column(name = "dosage_quantity", precision = 5, scale = 2)
+    private BigDecimal dosageQuantity;
+
+    @Column(name = "dosage_unit", length = 16)
+    private String dosageUnit;
 
     @Column(name = "days_of_week")
     private String daysOfWeek;

--- a/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
+++ b/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
@@ -12,8 +12,6 @@ import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,8 +21,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "medication_schedules")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MedicationSchedule extends CreatedTimeEntity {
-
-    private static final Pattern DOSAGE_INT_PATTERN = Pattern.compile("\\d+");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,8 +39,9 @@ public class MedicationSchedule extends CreatedTimeEntity {
     @Column(name = "dosage_quantity", precision = 5, scale = 2)
     private BigDecimal dosageQuantity;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "dosage_unit", length = 16)
-    private String dosageUnit;
+    private DosageUnit dosageUnit;
 
     @Column(name = "days_of_week")
     private String daysOfWeek;
@@ -58,14 +55,17 @@ public class MedicationSchedule extends CreatedTimeEntity {
     public MedicationSchedule(
             final Long medicineId,
             final MealSlot mealSlot,
-            final String dosage,
+            final BigDecimal dosageQuantity,
+            final DosageUnit dosageUnit,
             final String daysOfWeek,
             final LocalDate startDate,
             final LocalDate endDate
     ) {
         this.medicineId = Objects.requireNonNull(medicineId, "medicineId must not be null");
         this.mealSlot = Objects.requireNonNull(mealSlot, "mealSlot must not be null");
-        this.dosage = Objects.requireNonNull(dosage, "dosage must not be null");
+        this.dosageQuantity = dosageQuantity;
+        this.dosageUnit = dosageUnit;
+        this.dosage = composeLegacyDosage(dosageQuantity, dosageUnit);
         this.daysOfWeek = daysOfWeek;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -73,7 +73,8 @@ public class MedicationSchedule extends CreatedTimeEntity {
 
     public void update(
             final MealSlot mealSlot,
-            final String dosage,
+            final BigDecimal dosageQuantity,
+            final DosageUnit dosageUnit,
             final String daysOfWeek,
             final LocalDate startDate,
             final LocalDate endDate
@@ -81,8 +82,14 @@ public class MedicationSchedule extends CreatedTimeEntity {
         if (mealSlot != null) {
             this.mealSlot = mealSlot;
         }
-        if (dosage != null) {
-            this.dosage = dosage;
+        if (dosageQuantity != null) {
+            this.dosageQuantity = dosageQuantity;
+        }
+        if (dosageUnit != null) {
+            this.dosageUnit = dosageUnit;
+        }
+        if (dosageQuantity != null || dosageUnit != null) {
+            this.dosage = composeLegacyDosage(this.dosageQuantity, this.dosageUnit);
         }
         if (daysOfWeek != null) {
             this.daysOfWeek = daysOfWeek;
@@ -96,21 +103,15 @@ public class MedicationSchedule extends CreatedTimeEntity {
     }
 
     /**
-     * dosage 문자열에서 첫 정수를 추출. 예: "1정" → 1, "2정" → 2, "반정"/null → 0.
-     * spec docs/features/caregiver-dashboard.md §8 Q2 default 룰. 잔여분 차감 / 일일 소요량 계산 공용.
+     * 옛 dosage String 컬럼은 PR 4(다음 release)에서 drop 예정. 그때까지 호환성을 위해
+     * 분리 두 필드로부터 합성. quantity와 unit이 둘 다 null이면 dosage도 null.
      */
-    public static int parseDosageInt(final String dosage) {
-        if (dosage == null) {
-            return 0;
+    private static String composeLegacyDosage(final BigDecimal quantity, final DosageUnit unit) {
+        if (quantity == null && unit == null) {
+            return null;
         }
-        final Matcher matcher = DOSAGE_INT_PATTERN.matcher(dosage);
-        if (matcher.find()) {
-            try {
-                return Integer.parseInt(matcher.group());
-            } catch (final NumberFormatException e) {
-                return 0;
-            }
-        }
-        return 0;
+        final String quantityText = quantity != null ? quantity.stripTrailingZeros().toPlainString() : "";
+        final String unitText = unit != null ? unit.getDisplayValue() : "";
+        return quantityText + unitText;
     }
 }

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleCreateRequest.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleCreateRequest.java
@@ -1,14 +1,15 @@
 package com.ppiyaki.medication.controller.dto;
 
 import com.ppiyaki.medication.MealSlot;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record ScheduleCreateRequest(
         @NotNull MealSlot mealSlot,
-        @NotBlank String dosage,
+        @NotNull BigDecimal dosageQuantity,
+        String dosageUnit,
         @Pattern(
                 regexp = "^(DAILY|(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN))*)$", message = "daysOfWeek must be 'DAILY' or a comma-separated list of MON,TUE,WED,THU,FRI,SAT,SUN"
         ) String daysOfWeek,

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleResponse.java
@@ -3,6 +3,7 @@ package com.ppiyaki.medication.controller.dto;
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.user.User;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -13,6 +14,8 @@ public record ScheduleResponse(
         MealSlot mealSlot,
         LocalTime scheduledTime,
         String dosage,
+        BigDecimal dosageQuantity,
+        String dosageUnit,
         String daysOfWeek,
         LocalDate startDate,
         LocalDate endDate,
@@ -26,6 +29,10 @@ public record ScheduleResponse(
                 schedule.getMealSlot(),
                 schedule.getMealSlot().resolveTime(owner),
                 schedule.getDosage(),
+                schedule.getDosageQuantity() != null
+                        ? schedule.getDosageQuantity().stripTrailingZeros()
+                        : null,
+                schedule.getDosageUnit() != null ? schedule.getDosageUnit().getDisplayValue() : null,
                 schedule.getDaysOfWeek(),
                 schedule.getStartDate(),
                 schedule.getEndDate(),

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleUpdateRequest.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleUpdateRequest.java
@@ -2,11 +2,13 @@ package com.ppiyaki.medication.controller.dto;
 
 import com.ppiyaki.medication.MealSlot;
 import jakarta.validation.constraints.Pattern;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record ScheduleUpdateRequest(
         MealSlot mealSlot,
-        String dosage,
+        BigDecimal dosageQuantity,
+        String dosageUnit,
         @Pattern(
                 regexp = "^(DAILY|(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN))*)$", message = "daysOfWeek must be 'DAILY' or a comma-separated list of MON,TUE,WED,THU,FRI,SAT,SUN"
         ) String daysOfWeek,

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -162,6 +162,7 @@ public class DashboardService {
         }
 
         final LocalDate today = LocalDate.now();
+        final LocalDate seniorRegisteredDate = senior.getCreatedAt().toLocalDate();
         final long delayThresholdMinutes = resolveDelayThresholdMinutes(userId, seniorId);
         final List<DayEntry> dayEntries = new ArrayList<>();
         int adherenceNumerator = 0;
@@ -169,6 +170,14 @@ public class DashboardService {
         for (int i = 0; i < 7; i++) {
             final LocalDate date = weekStart.plusDays(i);
             final List<SlotMarker> slotMarkers = new ArrayList<>();
+            // 시니어 가입 전 날짜는 모든 슬롯 강제 NOT_SCHEDULED + dayStatus NOT_SCHEDULED (issue #326)
+            if (date.isBefore(seniorRegisteredDate)) {
+                for (final MealSlot slot : MealSlot.values()) {
+                    slotMarkers.add(new SlotMarker(slot, SlotStatus.NOT_SCHEDULED));
+                }
+                dayEntries.add(new DayEntry(date, DayStatus.NOT_SCHEDULED, slotMarkers));
+                continue;
+            }
             final Map<Long, MedicationLog> logBySchedule = logsByDateAndSchedule.getOrDefault(date, Map.of());
             for (final MealSlot slot : MealSlot.values()) {
                 final SlotStatus status = deriveSlotStatusForDate(
@@ -216,10 +225,16 @@ public class DashboardService {
         }
 
         final LocalDate today = LocalDate.now();
+        final LocalDate seniorRegisteredDate = senior.getCreatedAt().toLocalDate();
         final long delayThresholdMinutes = resolveDelayThresholdMinutes(userId, seniorId);
         final List<MonthlyDashboardResponse.DayEntry> dayEntries = new ArrayList<>();
         for (int day = 1; day <= yearMonth.lengthOfMonth(); day++) {
             final LocalDate date = yearMonth.atDay(day);
+            // 시니어 가입 전 날짜는 dayStatus 강제 NOT_SCHEDULED (issue #326)
+            if (date.isBefore(seniorRegisteredDate)) {
+                dayEntries.add(new MonthlyDashboardResponse.DayEntry(date, DayStatus.NOT_SCHEDULED));
+                continue;
+            }
             final List<SlotMarker> markers = new ArrayList<>();
             final Map<Long, MedicationLog> logBySchedule = logsByDateAndSchedule.getOrDefault(date, Map.of());
             for (final MealSlot slot : MealSlot.values()) {

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -410,7 +410,10 @@ public class DashboardService {
                     .toList();
             int dailyConsumption = 0;
             for (final MedicationSchedule s : activeSchedules) {
-                dailyConsumption += MedicationSchedule.parseDosageInt(s.getDosage());
+                final java.math.BigDecimal q = s.getDosageQuantity();
+                if (q != null) {
+                    dailyConsumption += q.setScale(0, java.math.RoundingMode.CEILING).intValueExact();
+                }
             }
             if (dailyConsumption == 0) {
                 continue;

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -5,7 +5,6 @@ import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.common.storage.NcpStorageProperties;
 import com.ppiyaki.common.storage.PhotoUrlAssembler;
-import com.ppiyaki.medication.DosageParser;
 import com.ppiyaki.medication.LogAiStatus;
 import com.ppiyaki.medication.LogStatus;
 import com.ppiyaki.medication.MedicationLog;
@@ -19,6 +18,7 @@ import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -119,10 +119,16 @@ public class MedicationLogService {
         }
 
         // 새로 TAKEN으로 전환되는 케이스에만 잔여분 차감 (멱등성: 이미 TAKEN이던 row 재호출 시 중복 차감 방지).
-        // 차감 단위 = schedule.dosage 정수 파싱. 비정수("반정" 등)면 1 fallback (인증했으니 최소 1정 차감).
+        // 차감 단위 = schedule.dosageQuantity (BigDecimal). null이면 차감 skip
+        // (옛 schedule이거나 PRN 같은 정의 안 된 케이스. spec dosage-quantity-unit-split.md Q7 결정).
         if (request.status() == LogStatus.TAKEN && previousStatus != LogStatus.TAKEN) {
-            final int dosageCount = MedicationSchedule.parseDosageInt(schedule.getDosage());
-            medicine.decreaseRemainingAmount(dosageCount > 0 ? dosageCount : 1);
+            final BigDecimal dosageQuantity = schedule.getDosageQuantity();
+            if (dosageQuantity != null) {
+                final int dosageCount = dosageQuantity.setScale(0, java.math.RoundingMode.CEILING).intValueExact();
+                if (dosageCount > 0) {
+                    medicine.decreaseRemainingAmount(dosageCount);
+                }
+            }
         }
 
         // 복약 성공 이벤트 발행 (TAKEN→TAKEN 중복 방지)
@@ -155,11 +161,11 @@ public class MedicationLogService {
 
         int expected = 0;
         for (final MedicationSchedule s : schedules) {
-            final Optional<Integer> parsed = DosageParser.parsePillCount(s.getDosage());
-            if (parsed.isEmpty()) {
+            final BigDecimal quantity = s.getDosageQuantity();
+            if (quantity == null) {
                 return LogAiStatus.COUNT_UNKNOWN;
             }
-            expected += parsed.get();
+            expected += quantity.setScale(0, java.math.RoundingMode.CEILING).intValueExact();
         }
         if (schedules.isEmpty()) {
             return LogAiStatus.COUNT_UNKNOWN;

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -57,6 +57,7 @@ public class MedicationLogService {
     private final NcpStorageProperties storageProperties;
     private final S3Client s3Client;
     private final ApplicationEventPublisher eventPublisher;
+    private final com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
 
     public MedicationLogService(
             final MedicationLogRepository medicationLogRepository,
@@ -67,7 +68,8 @@ public class MedicationLogService {
             final OpenAiClient openAiClient,
             final NcpStorageProperties storageProperties,
             final S3Client s3Client,
-            final ApplicationEventPublisher eventPublisher
+            final ApplicationEventPublisher eventPublisher,
+            final com.ppiyaki.notification.repository.NotificationRepository notificationRepository
     ) {
         this.medicationLogRepository = medicationLogRepository;
         this.medicationScheduleRepository = medicationScheduleRepository;
@@ -78,6 +80,7 @@ public class MedicationLogService {
         this.storageProperties = storageProperties;
         this.s3Client = s3Client;
         this.eventPublisher = eventPublisher;
+        this.notificationRepository = notificationRepository;
     }
 
     @Transactional
@@ -134,6 +137,10 @@ public class MedicationLogService {
         // 복약 성공 이벤트 발행 (TAKEN→TAKEN 중복 방지)
         if (request.status() == LogStatus.TAKEN && previousStatus != LogStatus.TAKEN) {
             eventPublisher.publishEvent(new MedicationTakenEvent(seniorId, request.targetDate()));
+            // 같은 시니어/날짜/슬롯 MEDICATION_REMINDER 알림 자동 전이 (issue #324).
+            // 시니어 본인 인증/보호자 대리 인증 모두 시니어의 알림이 대상 (userId=seniorId).
+            notificationRepository.markReminderTaken(
+                    seniorId, request.targetDate(), schedule.getMealSlot().name(), takenAt);
         }
 
         // Phase 2: 사진 + status=TAKEN일 때 약 개수 AI 검증 (spec medication-log-phase2 §5-4)

--- a/src/main/java/com/ppiyaki/medication/service/MedicationScheduleService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationScheduleService.java
@@ -56,7 +56,8 @@ public class MedicationScheduleService {
         final MedicationSchedule schedule = new MedicationSchedule(
                 medicine.getId(),
                 scheduleCreateRequest.mealSlot(),
-                scheduleCreateRequest.dosage(),
+                scheduleCreateRequest.dosageQuantity(),
+                com.ppiyaki.medication.DosageUnit.fromInput(scheduleCreateRequest.dosageUnit()).orElse(null),
                 daysOfWeek,
                 startDate,
                 scheduleCreateRequest.endDate()
@@ -107,7 +108,8 @@ public class MedicationScheduleService {
 
         schedule.update(
                 scheduleUpdateRequest.mealSlot(),
-                scheduleUpdateRequest.dosage(),
+                scheduleUpdateRequest.dosageQuantity(),
+                com.ppiyaki.medication.DosageUnit.fromInput(scheduleUpdateRequest.dosageUnit()).orElse(null),
                 scheduleUpdateRequest.daysOfWeek(),
                 scheduleUpdateRequest.startDate(),
                 scheduleUpdateRequest.endDate()

--- a/src/main/java/com/ppiyaki/notification/DeviceToken.java
+++ b/src/main/java/com/ppiyaki/notification/DeviceToken.java
@@ -63,6 +63,17 @@ public class DeviceToken extends BaseTimeEntity {
         this.lastSeenAt = Objects.requireNonNull(lastSeenAt, "lastSeenAt must not be null");
     }
 
+    /**
+     * 같은 device가 다른 사용자 계정으로 로그인 후 재등록되는 케이스의 소유자 이전.
+     * issue #329: token UNIQUE 제약 때문에 신규 INSERT 불가 → 같은 row의 owner를 갱신.
+     * lastSeenAt 갱신 + isActive=true.
+     */
+    public void transferTo(final Long newUserId, final LocalDateTime lastSeenAt) {
+        this.userId = Objects.requireNonNull(newUserId, "newUserId must not be null");
+        this.isActive = true;
+        this.lastSeenAt = Objects.requireNonNull(lastSeenAt, "lastSeenAt must not be null");
+    }
+
     public void deactivate() {
         this.isActive = false;
     }

--- a/src/main/java/com/ppiyaki/notification/Notification.java
+++ b/src/main/java/com/ppiyaki/notification/Notification.java
@@ -64,6 +64,9 @@ public class Notification extends BaseTimeEntity {
     @Column(name = "read_at")
     private LocalDateTime readAt;
 
+    @Column(name = "taken_at")
+    private LocalDateTime takenAt;
+
     Notification(
             final Long userId,
             final Long seniorId,
@@ -195,6 +198,20 @@ public class Notification extends BaseTimeEntity {
     public void markAsRead(final LocalDateTime readAt) {
         if (this.readAt == null) {
             this.readAt = Objects.requireNonNull(readAt, "readAt must not be null");
+        }
+    }
+
+    public boolean isTaken() {
+        return this.takenAt != null;
+    }
+
+    /**
+     * MEDICATION_REMINDER 알림이 복약 인증으로 소비됐음을 표시. 멱등 (이미 채워져 있으면 noop).
+     * spec: PATCH/POST 직접 호출이 아니라 MedicationLogService.upsert TAKEN 신규 전환 분기에서 호출.
+     */
+    public void markTaken(final LocalDateTime takenAt) {
+        if (this.takenAt == null) {
+            this.takenAt = Objects.requireNonNull(takenAt, "takenAt must not be null");
         }
     }
 }

--- a/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
@@ -11,7 +11,6 @@ public record NotificationItemResponse(
         String title,
         String body,
         String payload,
-        boolean isRead,
         LocalDateTime readAt,
         LocalDateTime takenAt,
         LocalDateTime createdAt
@@ -25,7 +24,6 @@ public record NotificationItemResponse(
                 notification.getTitle(),
                 notification.getBody(),
                 notification.getPayload(),
-                notification.isRead(),
                 notification.getReadAt(),
                 notification.getTakenAt(),
                 notification.getCreatedAt()

--- a/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
@@ -13,6 +13,7 @@ public record NotificationItemResponse(
         String payload,
         boolean isRead,
         LocalDateTime readAt,
+        LocalDateTime takenAt,
         LocalDateTime createdAt
 ) {
 
@@ -26,6 +27,7 @@ public record NotificationItemResponse(
                 notification.getPayload(),
                 notification.isRead(),
                 notification.getReadAt(),
+                notification.getTakenAt(),
                 notification.getCreatedAt()
         );
     }

--- a/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
@@ -34,6 +34,27 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             """)
     int markAllAsRead(@Param("userId") final Long userId, @Param("readAt") final LocalDateTime readAt);
 
+    /**
+     * 시니어가 복약 인증한 시점에 같은 날짜·슬롯의 MEDICATION_REMINDER 알림을 taken 처리.
+     * takenAt IS NULL인 row만 갱신 (멱등).
+     */
+    @Modifying
+    @Query("""
+            UPDATE Notification n
+            SET n.takenAt = :takenAt
+            WHERE n.userId = :userId
+              AND n.category = com.ppiyaki.notification.NotificationCategory.MEDICATION_REMINDER
+              AND n.targetDate = :targetDate
+              AND n.mealSlot = :mealSlot
+              AND n.takenAt IS NULL
+            """)
+    int markReminderTaken(
+            @Param("userId") final Long userId,
+            @Param("targetDate") final java.time.LocalDate targetDate,
+            @Param("mealSlot") final String mealSlot,
+            @Param("takenAt") final LocalDateTime takenAt
+    );
+
     boolean existsByUserIdAndCategoryAndTargetDateAndMealSlot(
             final Long userId,
             final NotificationCategory category,

--- a/src/main/java/com/ppiyaki/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/ppiyaki/notification/service/DeviceTokenService.java
@@ -21,9 +21,15 @@ public class DeviceTokenService {
 
     @Transactional
     public DeviceTokenResponse register(final Long userId, final String token, final DevicePlatform platform) {
+        final LocalDateTime now = LocalDateTime.now();
         final DeviceToken saved = deviceTokenRepository.findByToken(token)
                 .map(existing -> {
-                    existing.reactivate(LocalDateTime.now());
+                    if (!existing.getUserId().equals(userId)) {
+                        // 같은 device가 다른 사용자 계정으로 로그인 후 재등록 — 소유자 이전 (issue #329)
+                        existing.transferTo(userId, now);
+                    } else {
+                        existing.reactivate(now);
+                    }
                     return existing;
                 })
                 .orElseGet(() -> deviceTokenRepository.save(DeviceToken.register(userId, token, platform)));

--- a/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
+++ b/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.prescription;
 
 import com.ppiyaki.common.entity.CreatedTimeEntity;
+import com.ppiyaki.medication.DosageUnit;
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medicine.service.MatchType;
 import jakarta.persistence.Column;
@@ -44,8 +45,9 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
     @Column(name = "extracted_dosage_quantity", precision = 5, scale = 2)
     private BigDecimal extractedDosageQuantity;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "extracted_dosage_unit", length = 16)
-    private String extractedDosageUnit;
+    private DosageUnit extractedDosageUnit;
 
     @Column(name = "extracted_schedule")
     private String extractedSchedule;
@@ -89,7 +91,8 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
             final Long prescriptionId,
             final String ocrRawText,
             final String extractedName,
-            final String extractedDosage,
+            final BigDecimal extractedDosageQuantity,
+            final DosageUnit extractedDosageUnit,
             final String extractedSchedule,
             final String matchedItemSeq,
             final String matchedItemName,
@@ -100,7 +103,9 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
         this.prescriptionId = Objects.requireNonNull(prescriptionId, "prescriptionId must not be null");
         this.ocrRawText = ocrRawText;
         this.extractedName = extractedName;
-        this.extractedDosage = extractedDosage;
+        this.extractedDosageQuantity = extractedDosageQuantity;
+        this.extractedDosageUnit = extractedDosageUnit;
+        this.extractedDosage = composeLegacyDosage(extractedDosageQuantity, extractedDosageUnit);
         this.extractedSchedule = extractedSchedule;
         this.matchedItemSeq = matchedItemSeq;
         this.matchedItemName = matchedItemName;
@@ -114,7 +119,8 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
             final Long prescriptionId,
             final String itemSeq,
             final String itemName,
-            final String dosage,
+            final BigDecimal dosageQuantity,
+            final DosageUnit dosageUnit,
             final String schedule
     ) {
         Objects.requireNonNull(itemSeq, "itemSeq must not be null");
@@ -123,7 +129,8 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
                 prescriptionId,
                 MANUAL_ADD_RAW_TEXT,
                 itemName,
-                dosage,
+                dosageQuantity,
+                dosageUnit,
                 schedule,
                 itemSeq,
                 itemName,
@@ -135,6 +142,19 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
         candidate.caregiverChosenItemSeq = itemSeq;
         candidate.reviewedAt = LocalDateTime.now();
         return candidate;
+    }
+
+    /**
+     * 옛 extracted_dosage String 컬럼은 PR 4(다음 release)에서 drop 예정. 그때까지 분리
+     * 두 필드로부터 합성하여 쓰기 호환을 유지한다.
+     */
+    private static String composeLegacyDosage(final BigDecimal quantity, final DosageUnit unit) {
+        if (quantity == null && unit == null) {
+            return null;
+        }
+        final String quantityText = quantity != null ? quantity.stripTrailingZeros().toPlainString() : "";
+        final String unitText = unit != null ? unit.getDisplayValue() : "";
+        return quantityText + unitText;
     }
 
     public void accept() {
@@ -161,8 +181,16 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
         this.confirmedMealSlots = MealSlot.toCsv(slots);
     }
 
-    public void updateExtractedDosage(final String dosage) {
-        this.extractedDosage = dosage;
+    public void updateExtractedDosage(final BigDecimal dosageQuantity, final DosageUnit dosageUnit) {
+        if (dosageQuantity != null) {
+            this.extractedDosageQuantity = dosageQuantity;
+        }
+        if (dosageUnit != null) {
+            this.extractedDosageUnit = dosageUnit;
+        }
+        if (dosageQuantity != null || dosageUnit != null) {
+            this.extractedDosage = composeLegacyDosage(this.extractedDosageQuantity, this.extractedDosageUnit);
+        }
     }
 
     public List<MealSlot> getSuggestedMealSlotsList() {

--- a/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
+++ b/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
@@ -154,6 +154,10 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
         this.confirmedMealSlots = MealSlot.toCsv(slots);
     }
 
+    public void updateExtractedDosage(final String dosage) {
+        this.extractedDosage = dosage;
+    }
+
     public List<MealSlot> getSuggestedMealSlotsList() {
         return MealSlot.parseCsv(this.suggestedMealSlots);
     }

--- a/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
+++ b/src/main/java/com/ppiyaki/prescription/PrescriptionMedicineCandidate.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -39,6 +40,12 @@ public class PrescriptionMedicineCandidate extends CreatedTimeEntity {
 
     @Column(name = "extracted_dosage")
     private String extractedDosage;
+
+    @Column(name = "extracted_dosage_quantity", precision = 5, scale = 2)
+    private BigDecimal extractedDosageQuantity;
+
+    @Column(name = "extracted_dosage_unit", length = 16)
+    private String extractedDosageUnit;
 
     @Column(name = "extracted_schedule")
     private String extractedSchedule;

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
@@ -3,12 +3,14 @@ package com.ppiyaki.prescription.controller.dto;
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.prescription.CaregiverDecision;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.List;
 
 public record CandidateDecisionRequest(
         @NotNull CaregiverDecision decision,
         String chosenItemSeq,
         List<MealSlot> confirmedMealSlots,
-        String dosage
+        BigDecimal dosageQuantity,
+        String dosageUnit
 ) {
 }

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/CandidateDecisionRequest.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record CandidateDecisionRequest(
         @NotNull CaregiverDecision decision,
         String chosenItemSeq,
-        List<MealSlot> confirmedMealSlots
+        List<MealSlot> confirmedMealSlots,
+        String dosage
 ) {
 }

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineAddRequest.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineAddRequest.java
@@ -1,11 +1,13 @@
 package com.ppiyaki.prescription.controller.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import java.math.BigDecimal;
 
 public record PrescriptionMedicineAddRequest(
         @NotBlank String itemSeq,
         @NotBlank String itemName,
-        String dosage,
+        BigDecimal dosageQuantity,
+        String dosageUnit,
         String schedule
 ) {
 }

--- a/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineCandidateResponse.java
+++ b/src/main/java/com/ppiyaki/prescription/controller/dto/PrescriptionMedicineCandidateResponse.java
@@ -2,6 +2,7 @@ package com.ppiyaki.prescription.controller.dto;
 
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.prescription.PrescriptionMedicineCandidate;
+import java.math.BigDecimal;
 import java.util.List;
 
 public record PrescriptionMedicineCandidateResponse(
@@ -9,6 +10,8 @@ public record PrescriptionMedicineCandidateResponse(
         String ocrRawText,
         String extractedName,
         String extractedDosage,
+        BigDecimal extractedDosageQuantity,
+        String extractedDosageUnit,
         String extractedSchedule,
         String matchedItemSeq,
         String matchedItemName,
@@ -27,6 +30,11 @@ public record PrescriptionMedicineCandidateResponse(
                 candidate.getOcrRawText(),
                 candidate.getExtractedName(),
                 candidate.getExtractedDosage(),
+                candidate.getExtractedDosageQuantity() != null
+                        ? candidate.getExtractedDosageQuantity().stripTrailingZeros()
+                        : null,
+                candidate.getExtractedDosageUnit() != null ? candidate.getExtractedDosageUnit().getDisplayValue()
+                        : null,
                 candidate.getExtractedSchedule(),
                 candidate.getMatchedItemSeq(),
                 candidate.getMatchedItemName(),

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -228,6 +228,10 @@ public class PrescriptionService {
         if (request.confirmedMealSlots() != null) {
             candidate.updateConfirmedMealSlots(request.confirmedMealSlots());
         }
+
+        if (request.dosage() != null && !request.dosage().isBlank()) {
+            candidate.updateExtractedDosage(request.dosage());
+        }
     }
 
     @Transactional

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -9,6 +9,7 @@ import com.ppiyaki.common.ocr.ClovaOcrClient.OcrResult;
 import com.ppiyaki.common.ocr.ClovaOcrClient.OcrToken;
 import com.ppiyaki.common.storage.NcpStorageProperties;
 import com.ppiyaki.common.storage.PhotoUrlAssembler;
+import com.ppiyaki.medication.DosageUnit;
 import com.ppiyaki.medication.MealSlot;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
@@ -38,6 +39,7 @@ import com.ppiyaki.user.repository.UserRepository;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -143,14 +145,16 @@ public class PrescriptionService {
 
                 final String mfr = med.manufacturer() != null ? med.manufacturer() : "";
                 final String namePrefix = mfr.isEmpty() || med.name().startsWith(mfr) ? "" : mfr;
+                final String dosageDisplay = formatDosageDisplay(med.dosageQuantity(), med.dosageUnit());
                 final String rawText = namePrefix + med.name()
-                        + (med.dosage() != null ? " " + med.dosage() : "");
+                        + (dosageDisplay != null ? " " + dosageDisplay : "");
 
                 candidateRepository.save(new PrescriptionMedicineCandidate(
                         prescription.getId(),
                         rawText,
                         med.name(),
-                        med.dosage(),
+                        med.dosageQuantity(),
+                        med.dosageUnit(),
                         med.schedule(),
                         matched != null ? matched.itemSeq() : null,
                         matched != null ? matched.itemName() : null,
@@ -158,6 +162,7 @@ public class PrescriptionService {
                         matchResult.reason(),
                         med.mealSlots()
                 ));
+                // (note) med.dosageUnit()은 OpenAiClient에서 이미 DosageUnit으로 정규화됨
             }
 
             prescription.complete(maskedObjectKey);
@@ -229,8 +234,9 @@ public class PrescriptionService {
             candidate.updateConfirmedMealSlots(request.confirmedMealSlots());
         }
 
-        if (request.dosage() != null && !request.dosage().isBlank()) {
-            candidate.updateExtractedDosage(request.dosage());
+        final DosageUnit normalizedUnit = DosageUnit.fromInput(request.dosageUnit()).orElse(null);
+        if (request.dosageQuantity() != null || normalizedUnit != null) {
+            candidate.updateExtractedDosage(request.dosageQuantity(), normalizedUnit);
         }
     }
 
@@ -252,7 +258,8 @@ public class PrescriptionService {
                 prescription.getId(),
                 request.itemSeq(),
                 request.itemName(),
-                request.dosage(),
+                request.dosageQuantity(),
+                DosageUnit.fromInput(request.dosageUnit()).orElse(null),
                 request.schedule()
         ));
 
@@ -326,15 +333,16 @@ public class PrescriptionService {
             medicineRepository.save(medicine);
             candidate.linkMedicine(medicine.getId());
 
-            // dosage가 비어있으면 schedule 자동 생성 skip — Medicine만 등록.
+            // dosage_quantity가 비어있으면 schedule 자동 생성 skip — Medicine만 등록.
             // 보호자가 후속으로 schedule CRUD API로 보완 (spec §3 Q2).
-            final String dosage = candidate.getExtractedDosage();
-            if (dosage == null || dosage.isBlank()) {
+            final BigDecimal dosageQuantity = candidate.getExtractedDosageQuantity();
+            final DosageUnit dosageUnit = candidate.getExtractedDosageUnit();
+            if (dosageQuantity == null) {
                 continue;
             }
             for (final MealSlot slot : candidate.getConfirmedMealSlotsList()) {
                 medicationScheduleRepository.save(new MedicationSchedule(
-                        medicine.getId(), slot, dosage, "DAILY", today, null));
+                        medicine.getId(), slot, dosageQuantity, dosageUnit, "DAILY", today, null));
             }
         }
 
@@ -346,6 +354,18 @@ public class PrescriptionService {
     private boolean isAcceptedOrCorrected(final PrescriptionMedicineCandidate candidate) {
         return candidate.getCaregiverDecision() == CaregiverDecision.ACCEPTED
                 || candidate.getCaregiverDecision() == CaregiverDecision.MANUALLY_CORRECTED;
+    }
+
+    /**
+     * candidate raw text 표시용 dosage 합성. 양쪽 다 null이면 null.
+     */
+    private static String formatDosageDisplay(final BigDecimal quantity, final DosageUnit unit) {
+        if (quantity == null && unit == null) {
+            return null;
+        }
+        final String quantityText = quantity != null ? quantity.stripTrailingZeros().toPlainString() : "";
+        final String unitText = unit != null ? unit.getDisplayValue() : "";
+        return quantityText + unitText;
     }
 
     @Transactional

--- a/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
+++ b/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,6 +32,7 @@ public class CareRelationController {
     }
 
     @GetMapping("/care-relations/seniors")
+    @PreAuthorize("hasRole('CAREGIVER')")
     public ResponseEntity<List<SeniorSummaryResponse>> readSeniors(
             @AuthenticationPrincipal final Long userId
     ) {
@@ -39,6 +41,7 @@ public class CareRelationController {
     }
 
     @PostMapping("/care-relations/invite")
+    @PreAuthorize("hasRole('CAREGIVER')")
     public ResponseEntity<InviteCodeResponse> createInviteCode(
             @AuthenticationPrincipal final Long userId,
             @Valid @RequestBody final InviteCodeRequest inviteCodeRequest
@@ -60,6 +63,7 @@ public class CareRelationController {
     }
 
     @DeleteMapping("/seniors/{seniorId}/logout")
+    @PreAuthorize("hasRole('CAREGIVER')")
     public ResponseEntity<Void> forceLogoutSenior(
             @AuthenticationPrincipal final Long userId,
             @PathVariable final Long seniorId

--- a/src/main/java/com/ppiyaki/user/controller/OnboardingController.java
+++ b/src/main/java/com/ppiyaki/user/controller/OnboardingController.java
@@ -6,6 +6,7 @@ import com.ppiyaki.user.service.OnboardingService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +24,7 @@ public class OnboardingController {
     }
 
     @PostMapping("/onboarding")
+    @PreAuthorize("hasRole('CAREGIVER')")
     public ResponseEntity<OnboardingResponse> onboard(
             @AuthenticationPrincipal final Long userId,
             @Valid @RequestBody final OnboardingRequest onboardingRequest

--- a/src/main/java/com/ppiyaki/user/controller/SeniorController.java
+++ b/src/main/java/com/ppiyaki/user/controller/SeniorController.java
@@ -6,6 +6,7 @@ import com.ppiyaki.user.service.SeniorService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +24,7 @@ public class SeniorController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('CAREGIVER')")
     public ResponseEntity<SeniorCreateResponse> createSenior(
             @AuthenticationPrincipal final Long userId,
             @Valid @RequestBody final SeniorCreateRequest seniorCreateRequest

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -8,7 +8,6 @@ import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.InviteCode;
 import com.ppiyaki.user.InviteCode.InviteCodeWithRaw;
 import com.ppiyaki.user.User;
-import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
 import com.ppiyaki.user.controller.dto.SeniorSummaryResponse;
@@ -54,9 +53,6 @@ public class CareRelationService {
 
     @Transactional(readOnly = true)
     public List<SeniorSummaryResponse> readSeniors(final Long caregiverId) {
-        final User caregiver = findUserById(caregiverId);
-        validateRole(caregiver, UserRole.CAREGIVER);
-
         final List<CareRelation> careRelations = careRelationRepository.findByCaregiverIdAndDeletedAtIsNull(
                 caregiverId);
 
@@ -75,9 +71,6 @@ public class CareRelationService {
 
     @Transactional
     public InviteCodeResponse createInviteCode(final Long caregiverId, final Long seniorId) {
-        final User caregiver = findUserById(caregiverId);
-        validateRole(caregiver, UserRole.CAREGIVER);
-
         careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(caregiverId, seniorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
 
@@ -121,9 +114,6 @@ public class CareRelationService {
 
     @Transactional
     public void forceLogoutSenior(final Long caregiverId, final Long seniorId) {
-        final User caregiver = findUserById(caregiverId);
-        validateRole(caregiver, UserRole.CAREGIVER);
-
         careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(caregiverId, seniorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
 
@@ -133,11 +123,5 @@ public class CareRelationService {
     private User findUserById(final Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-    }
-
-    private void validateRole(final User user, final UserRole expectedRole) {
-        if (user.getRole() != expectedRole) {
-            throw new BusinessException(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
-        }
     }
 }

--- a/src/main/java/com/ppiyaki/user/service/OnboardingService.java
+++ b/src/main/java/com/ppiyaki/user/service/OnboardingService.java
@@ -9,7 +9,6 @@ import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.CareMode;
 import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.User;
-import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.OnboardingRequest;
 import com.ppiyaki.user.controller.dto.OnboardingResponse;
 import com.ppiyaki.user.controller.dto.OnboardingResponse.SeniorResult;
@@ -44,10 +43,6 @@ public class OnboardingService {
     public OnboardingResponse onboard(final Long caregiverId, final OnboardingRequest onboardingRequest) {
         final User caregiver = userRepository.findById(caregiverId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
-        if (caregiver.getRole() != UserRole.CAREGIVER) {
-            throw new BusinessException(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
-        }
 
         caregiver.updateNickname(onboardingRequest.nickname());
 

--- a/src/main/java/com/ppiyaki/user/service/SeniorService.java
+++ b/src/main/java/com/ppiyaki/user/service/SeniorService.java
@@ -1,12 +1,9 @@
 package com.ppiyaki.user.service;
 
-import com.ppiyaki.common.exception.BusinessException;
-import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.User;
-import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.SeniorCreateRequest;
 import com.ppiyaki.user.controller.dto.SeniorCreateResponse;
 import com.ppiyaki.user.repository.CareRelationRepository;
@@ -33,13 +30,6 @@ public class SeniorService {
 
     @Transactional
     public SeniorCreateResponse createSenior(final Long caregiverId, final SeniorCreateRequest seniorCreateRequest) {
-        final User caregiver = userRepository.findById(caregiverId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
-        if (caregiver.getRole() != UserRole.CAREGIVER) {
-            throw new BusinessException(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
-        }
-
         final User senior = userRepository.save(
                 User.createSenior(seniorCreateRequest.nickname(), seniorCreateRequest.dob()));
 

--- a/src/test/java/com/ppiyaki/common/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/ppiyaki/common/auth/JwtAuthenticationFilterTest.java
@@ -1,0 +1,95 @@
+package com.ppiyaki.common.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@DisplayName("JwtAuthenticationFilter")
+class JwtAuthenticationFilterTest {
+
+    private static final String TEST_SECRET = "test-secret-key-must-be-at-least-32-bytes-long!!";
+
+    private final JwtProvider jwtProvider = new JwtProvider(
+            new JwtProperties(TEST_SECRET, 1800000L, 1209600000L));
+    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtProvider);
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("role claim이 있는 토큰 → ROLE_<role> 권한이 부착된 Authentication이 생성된다")
+    void token_with_role_attaches_authority() throws ServletException, IOException {
+        // given
+        final Long userId = 100L;
+        final String token = jwtProvider.createAccessToken(userId, "CAREGIVER");
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        // then
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getPrincipal()).isEqualTo(userId);
+        assertThat(authentication.getAuthorities())
+                .extracting(Object::toString)
+                .containsExactly("ROLE_CAREGIVER");
+    }
+
+    @Test
+    @DisplayName("role claim이 없는 deprecated 토큰 → 빈 권한으로 인증되어 하위 호환된다")
+    void token_without_role_keeps_empty_authorities() throws ServletException, IOException {
+        // given
+        @SuppressWarnings("deprecation") final String token = jwtProvider.createAccessToken(200L);
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        // then
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getPrincipal()).isEqualTo(200L);
+        assertThat(authentication.getAuthorities()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더 없음 → SecurityContext가 비어 있다")
+    void no_authorization_header_leaves_context_empty() throws ServletException, IOException {
+        // given
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        // then
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("invalid 토큰 → SecurityContext가 비어 있다")
+    void invalid_token_leaves_context_empty() throws ServletException, IOException {
+        // given
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer invalid.token.value");
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        // then
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+}

--- a/src/test/java/com/ppiyaki/common/auth/RoleAuthorizationE2ETest.java
+++ b/src/test/java/com/ppiyaki/common/auth/RoleAuthorizationE2ETest.java
@@ -1,0 +1,108 @@
+package com.ppiyaki.common.auth;
+
+import static org.hamcrest.Matchers.is;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("CAREGIVER 전용 엔드포인트에 SENIOR 토큰 호출 → 403 FORBIDDEN E2E")
+class RoleAuthorizationE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    private String seniorAccessToken;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        seniorAccessToken = jwtProvider.createAccessToken(999_999L, "SENIOR");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/care-relations/seniors → 403")
+    void readSeniors_with_senior_token_returns_403() {
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorAccessToken)
+                .when()
+                .get("/api/v1/care-relations/seniors")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("COMMON_004"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/care-relations/invite → 403")
+    void createInviteCode_with_senior_token_returns_403() {
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorAccessToken)
+                .contentType(ContentType.JSON)
+                .body("{\"seniorId\": 1}")
+                .when()
+                .post("/api/v1/care-relations/invite")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("COMMON_004"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/seniors/{seniorId}/logout → 403")
+    void forceLogoutSenior_with_senior_token_returns_403() {
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorAccessToken)
+                .when()
+                .delete("/api/v1/seniors/1/logout")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("COMMON_004"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/seniors → 403")
+    void createSenior_with_senior_token_returns_403() {
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorAccessToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "nickname": "할머니"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/seniors")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("COMMON_004"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/onboarding → 403")
+    void onboard_with_senior_token_returns_403() {
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorAccessToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "nickname": "보호자",
+                            "seniors": [
+                                {"nickname": "할머니", "gender": "FEMALE", "careMode": "AUTONOMOUS"}
+                            ]
+                        }
+                        """)
+                .when()
+                .post("/api/v1/onboarding")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("COMMON_004"));
+    }
+}

--- a/src/test/java/com/ppiyaki/common/exception/GlobalExceptionHandlerMethodNotAllowedE2ETest.java
+++ b/src/test/java/com/ppiyaki/common/exception/GlobalExceptionHandlerMethodNotAllowedE2ETest.java
@@ -1,0 +1,77 @@
+package com.ppiyaki.common.exception;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("405 응답 정규화 E2E")
+class GlobalExceptionHandlerMethodNotAllowedE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("permitAll POST-only 경로에 GET 호출 → 405 METHOD_NOT_ALLOWED + Allow 헤더")
+    void wrong_method_on_permitall_path_returns_405() {
+        RestAssured.given()
+                .when()
+                .get("/api/v1/auth/signup")
+                .then()
+                .statusCode(405)
+                .header("Allow", containsString("POST"))
+                .body("error.code", is("COMMON_007"))
+                .body("error.message", containsString("GET"));
+    }
+
+    @Test
+    @DisplayName("인증된 사용자가 GET-only 경로에 POST 호출 → 405 METHOD_NOT_ALLOWED + Allow 헤더")
+    void wrong_method_on_authenticated_path_returns_405() {
+        final String accessToken = signupAndGetToken();
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body("{}")
+                .when()
+                .post("/api/v1/users/me")
+                .then()
+                .statusCode(405)
+                .header("Allow", notNullValue())
+                .body("error.code", is("COMMON_007"))
+                .body("error.message", containsString("POST"));
+    }
+
+    private String signupAndGetToken() {
+        final String loginId = "method405" + System.nanoTime();
+        final String response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "%s",
+                            "password": "password1234!",
+                            "nickname": "테스트"
+                        }
+                        """.formatted(loginId))
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .asString();
+        return io.restassured.path.json.JsonPath.from(response).getString("accessToken");
+    }
+}

--- a/src/test/java/com/ppiyaki/medication/MedicationScheduleTest.java
+++ b/src/test/java/com/ppiyaki/medication/MedicationScheduleTest.java
@@ -3,6 +3,7 @@ package com.ppiyaki.medication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,29 +15,30 @@ class MedicationScheduleTest {
     @DisplayName("mealSlot null이면 NPE")
     void nullMealSlot_throws() {
         assertThatThrownBy(() -> new MedicationSchedule(
-                1L, null, "1정", "DAILY", LocalDate.now(), null))
+                1L, null, BigDecimal.ONE, DosageUnit.TABLET, "DAILY", LocalDate.now(), null))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    @DisplayName("update에 mealSlot null이면 기존 값 유지")
+    @DisplayName("update에 mealSlot null이면 기존 값 유지하고 dosageQuantity는 갱신")
     void update_keepsMealSlotWhenNull() {
         final MedicationSchedule schedule = new MedicationSchedule(
-                1L, MealSlot.BREAKFAST, "1정", "DAILY", LocalDate.now(), null);
+                1L, MealSlot.BREAKFAST, BigDecimal.ONE, DosageUnit.TABLET, "DAILY", LocalDate.now(), null);
 
-        schedule.update(null, "2정", null, null, null);
+        schedule.update(null, new BigDecimal("2"), null, null, null, null);
 
         assertThat(schedule.getMealSlot()).isEqualTo(MealSlot.BREAKFAST);
-        assertThat(schedule.getDosage()).isEqualTo("2정");
+        assertThat(schedule.getDosageQuantity()).isEqualByComparingTo(new BigDecimal("2"));
+        assertThat(schedule.getDosageUnit()).isEqualTo(DosageUnit.TABLET);
     }
 
     @Test
     @DisplayName("update로 슬롯 변경 가능")
     void update_changesMealSlot() {
         final MedicationSchedule schedule = new MedicationSchedule(
-                1L, MealSlot.BREAKFAST, "1정", "DAILY", LocalDate.now(), null);
+                1L, MealSlot.BREAKFAST, BigDecimal.ONE, DosageUnit.TABLET, "DAILY", LocalDate.now(), null);
 
-        schedule.update(MealSlot.DINNER, null, null, null, null);
+        schedule.update(MealSlot.DINNER, null, null, null, null, null);
 
         assertThat(schedule.getMealSlot()).isEqualTo(MealSlot.DINNER);
     }

--- a/src/test/java/com/ppiyaki/medication/MedicationScheduleTest.java
+++ b/src/test/java/com/ppiyaki/medication/MedicationScheduleTest.java
@@ -42,4 +42,18 @@ class MedicationScheduleTest {
 
         assertThat(schedule.getMealSlot()).isEqualTo(MealSlot.DINNER);
     }
+
+    @Test
+    @DisplayName("update로 PRN 전환 시 dosageQuantity는 null로 강제 — legacy dosage 비정상 합성 회피")
+    void update_toPRN_clearsDosageQuantity() {
+        final MedicationSchedule schedule = new MedicationSchedule(
+                1L, MealSlot.BREAKFAST, BigDecimal.ONE, DosageUnit.TABLET, "DAILY", LocalDate.now(), null);
+
+        schedule.update(null, null, DosageUnit.PRN, null, null, null);
+
+        assertThat(schedule.getDosageQuantity()).isNull();
+        assertThat(schedule.getDosageUnit()).isEqualTo(DosageUnit.PRN);
+        // legacy dosage = "PRN" (quantity 없음)
+        assertThat(schedule.getDosage()).isEqualTo("PRN");
+    }
 }

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import com.ppiyaki.user.repository.UserRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.time.LocalDate;
 import java.time.YearMonth;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -45,10 +46,12 @@ class DashboardMonthlyE2ETest {
     }
 
     @Test
-    @DisplayName("시니어 본인 호출 — schedule 없으면 days 모두 PERFECT, 길이는 해당 월 일수")
+    @DisplayName("시니어 본인 호출 — 현재 월 schedule 없으면 가입일 이후 PERFECT, 가입 이전 NOT_SCHEDULED (issue #326)")
     void monthly_seniorSelf_emptySchedules() {
         final SignupResult senior = signup("월간시니어");
-        final YearMonth ym = YearMonth.of(2026, 1);
+        // 현재 월로 조회 — 가입 후 days는 PERFECT, 가입 전 days는 NOT_SCHEDULED
+        final YearMonth ym = YearMonth.now();
+        final int today = LocalDate.now().getDayOfMonth();
 
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
@@ -57,11 +60,12 @@ class DashboardMonthlyE2ETest {
                 .then()
                 .statusCode(200)
                 .body("seniorId", is(senior.userId().intValue()))
-                .body("yearMonth", is("2026-01"))
-                .body("days.size()", is(31))
-                .body("days[0].date", is("2026-01-01"))
-                .body("days[0].dayStatus", is("PERFECT"))
-                .body("days[30].date", is("2026-01-31"));
+                .body("yearMonth", is(ym.toString()))
+                .body("days.size()", is(ym.lengthOfMonth()))
+                // today는 가입일과 동일 → PERFECT (schedule 없음 + 가입 이후)
+                .body("days[" + (today - 1) + "].dayStatus", is("PERFECT"))
+                // 1일은 today보다 이르면 NOT_SCHEDULED, 같으면 PERFECT
+                .body("days[0].dayStatus", is(today > 1 ? "NOT_SCHEDULED" : "PERFECT"));
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
@@ -54,11 +54,12 @@ class DashboardWeeklyE2ETest {
     }
 
     @Test
-    @DisplayName("시니어 본인 호출 — schedule 없으면 days[7] 모두 PERFECT, adherenceRate=null")
+    @DisplayName("시니어 본인 호출 — 가입 후 날짜 schedule 없으면 PERTECT, 가입 이전은 NOT_SCHEDULED (issue #326)")
     void weekly_seniorSelf_emptySchedules() {
         final SignupResult senior = signup("주간시니어");
         setMealTimes(senior.userId(), LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
-        final LocalDate weekStart = LocalDate.now().minusDays(7);
+        // weekStart를 today로 두어 days[0]이 가입 직후(또는 가입일과 동일)가 되도록 함
+        final LocalDate weekStart = LocalDate.now();
 
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationScheduleControllerE2ETest.java
@@ -51,7 +51,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "BREAKFAST",
-                            "dosage": "1정",
+                            "dosageQuantity": 1, "dosageUnit": "정",
                             "daysOfWeek": "DAILY",
                             "startDate": "2026-04-11"
                         }
@@ -64,7 +64,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("medicineId", is(medicineId))
                 .body("mealSlot", is("BREAKFAST"))
                 .body("scheduledTime", is("08:00:00"))
-                .body("dosage", is("1정"))
+                .body("dosageQuantity", is(1)).body("dosageUnit", is("정"))
                 .body("daysOfWeek", is("DAILY"));
     }
 
@@ -82,7 +82,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "LUNCH",
-                            "dosage": "1정"
+                            "dosageQuantity": 1, "dosageUnit": "정"
                         }
                         """)
                 .when()
@@ -107,7 +107,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "MIDNIGHT",
-                            "dosage": "1정"
+                            "dosageQuantity": 1, "dosageUnit": "정"
                         }
                         """)
                 .when()
@@ -175,7 +175,7 @@ class MedicationScheduleControllerE2ETest {
                 .get("/api/v1/medicines/" + medicineId + "/schedules/" + scheduleId)
                 .then()
                 .statusCode(200)
-                .body("dosage", is("2정"))
+                .body("dosageQuantity", is(2)).body("dosageUnit", is("정"))
                 .body("mealSlot", is("LUNCH"))
                 .body("scheduledTime", is("12:30:00"));
     }
@@ -196,7 +196,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "DINNER",
-                            "dosage": "2정"
+                            "dosageQuantity": 2, "dosageUnit": "정"
                         }
                         """)
                 .when()
@@ -205,7 +205,7 @@ class MedicationScheduleControllerE2ETest {
                 .statusCode(200)
                 .body("mealSlot", is("DINNER"))
                 .body("scheduledTime", is("18:30:00"))
-                .body("dosage", is("2정"));
+                .body("dosageQuantity", is(2)).body("dosageUnit", is("정"));
     }
 
     @Test
@@ -247,7 +247,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "BREAKFAST",
-                            "dosage": "1정",
+                            "dosageQuantity": 1, "dosageUnit": "정",
                             "daysOfWeek": "DAILY"
                         }
                         """)
@@ -266,7 +266,7 @@ class MedicationScheduleControllerE2ETest {
                 .get("/api/v1/medicines/" + medicineId + "/schedules/" + scheduleId)
                 .then()
                 .statusCode(200)
-                .body("dosage", is("1정"))
+                .body("dosageQuantity", is(1)).body("dosageUnit", is("정"))
                 .body("scheduledTime", is("08:00:00"));
     }
 
@@ -288,7 +288,7 @@ class MedicationScheduleControllerE2ETest {
                 .body("""
                         {
                             "mealSlot": "BREAKFAST",
-                            "dosage": "1정"
+                            "dosageQuantity": 1, "dosageUnit": "정"
                         }
                         """)
                 .when()
@@ -367,15 +367,28 @@ class MedicationScheduleControllerE2ETest {
             final String mealSlot,
             final String dosage
     ) {
+        // legacy "1정" 등의 raw 입력을 dosageQuantity/dosageUnit으로 분리
+        final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
+                .matcher(dosage);
+        final String quantity;
+        final String unit;
+        if (m.find()) {
+            quantity = m.group(1);
+            unit = m.group(2).trim();
+        } else {
+            quantity = "1";
+            unit = "정";
+        }
         return RestAssured.given()
                 .contentType(ContentType.JSON)
                 .header("Authorization", "Bearer " + token)
                 .body("""
                         {
                             "mealSlot": "%s",
-                            "dosage": "%s"
+                            "dosageQuantity": %s,
+                            "dosageUnit": "%s"
                         }
-                        """.formatted(mealSlot, dosage))
+                        """.formatted(mealSlot, quantity, unit))
                 .when()
                 .post("/api/v1/medicines/" + medicineId + "/schedules")
                 .then()

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -307,6 +307,62 @@ class DashboardServiceTest {
     }
 
     @Test
+    @DisplayName("weekly — 시니어 가입 이전 날짜는 dayStatus NOT_SCHEDULED + 모든 슬롯 NOT_SCHEDULED (issue #326)")
+    void weekly_beforeRegistration_returnsNotScheduled() throws Exception {
+        // given — 시니어 가입일이 weekStart+3 (즉 처음 3일은 가입 전)
+        final User senior = userOf(SENIOR_ID, "김장군");
+        final LocalDate weekStart = TODAY.minusDays(6);
+        final LocalDateTime registeredAt = weekStart.plusDays(3).atStartOfDay();
+        setField(senior, "createdAt", registeredAt);
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(senior));
+
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        // when
+        final var resp = dashboardService.getWeekly(SENIOR_ID, SENIOR_ID, weekStart);
+
+        // then — 처음 3일(weekStart, +1, +2)는 NOT_SCHEDULED, 나머지 4일은 PERFECT(스케줄 없음)
+        org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(7);
+        for (int i = 0; i < 3; i++) {
+            org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
+                    .isEqualTo(com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
+            org.assertj.core.api.Assertions.assertThat(resp.days().get(i).slots())
+                    .allMatch(s -> s.status() == SlotStatus.NOT_SCHEDULED);
+        }
+        for (int i = 3; i < 7; i++) {
+            org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
+                    .isEqualTo(com.ppiyaki.medication.DayStatus.PERFECT);
+        }
+    }
+
+    @Test
+    @DisplayName("monthly — 시니어 가입 이전 날짜는 dayStatus NOT_SCHEDULED (issue #326)")
+    void monthly_beforeRegistration_returnsNotScheduled() throws Exception {
+        // given — 가입일 = 1월 15일, 조회는 1월
+        final User senior = userOf(SENIOR_ID, "김장군");
+        setField(senior, "createdAt", LocalDateTime.of(2026, 1, 15, 0, 0));
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(senior));
+
+        when(scheduleRepository.findActiveByOwnerAndDateRange(eq(SENIOR_ID), any(), any())).thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDateBetweenOrderByTargetDateAscIdAsc(eq(SENIOR_ID), any(), any()))
+                .thenReturn(List.of());
+
+        final java.time.YearMonth ym = java.time.YearMonth.of(2026, 1);
+        final var resp = dashboardService.getMonthly(SENIOR_ID, SENIOR_ID, ym);
+
+        // then — 1~14일은 NOT_SCHEDULED, 15일부터 PERFECT
+        org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(31);
+        for (int i = 0; i < 14; i++) {
+            org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
+                    .isEqualTo(com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
+        }
+        org.assertj.core.api.Assertions.assertThat(resp.days().get(14).dayStatus())
+                .isEqualTo(com.ppiyaki.medication.DayStatus.PERFECT);
+    }
+
+    @Test
     @DisplayName("monthly — 2월(28일)은 days.size=28")
     void monthly_february28() throws Exception {
         givenSeniorAndCaregiver();
@@ -364,6 +420,8 @@ class DashboardServiceTest {
         final User u = ctor.newInstance();
         setField(u, "id", id);
         setField(u, "nickname", nickname);
+        // 기본 createdAt = 1년 전. 가입 이전 날짜 검증 케이스에선 별도 setField로 덮음.
+        setField(u, "createdAt", LocalDateTime.now().minusYears(1));
         return u;
     }
 

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -377,6 +377,15 @@ class DashboardServiceTest {
         setField(s, "medicineId", medicineId);
         setField(s, "mealSlot", slot);
         setField(s, "dosage", dosage);
+        if (dosage != null) {
+            final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
+                    .matcher(dosage);
+            if (m.find()) {
+                setField(s, "dosageQuantity", new java.math.BigDecimal(m.group(1)));
+                setField(s, "dosageUnit",
+                        com.ppiyaki.medication.DosageUnit.fromInput(m.group(2).trim()).orElse(null));
+            }
+        }
         return s;
     }
 

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -60,6 +60,8 @@ class MedicationLogServicePhase2Test {
     private S3Client s3Client;
     @Mock
     private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
 
     @InjectMocks
     private MedicationLogService service;

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -223,6 +223,16 @@ class MedicationLogServicePhase2Test {
         setField(s, "medicineId", MEDICINE_ID);
         setField(s, "dosage", dosage);
         setField(s, "mealSlot", MEAL_SLOT);
+        // legacy raw 입력을 정수+단위로 정규화. 정수 매칭 안 되면 quantity null (PRN/반알 등)
+        if (dosage != null) {
+            final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
+                    .matcher(dosage);
+            if (m.find()) {
+                setField(s, "dosageQuantity", new java.math.BigDecimal(m.group(1)));
+                setField(s, "dosageUnit",
+                        com.ppiyaki.medication.DosageUnit.fromInput(m.group(2).trim()).orElse(null));
+            }
+        }
         return s;
     }
 

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -51,6 +51,8 @@ class MedicationLogServiceTest {
     private PhotoUrlAssembler photoUrlAssembler;
     @Mock
     private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
 
     @InjectMocks
     private MedicationLogService medicationLogService;
@@ -333,6 +335,55 @@ class MedicationLogServiceTest {
     }
 
     @Test
+    @DisplayName("신규 TAKEN 전환 시 같은 시니어/날짜/슬롯 MEDICATION_REMINDER 알림 자동 전이 (issue #324)")
+    void 신규_TAKEN_시_알림_자동_전이() throws Exception {
+        // given
+        givenScheduleAndMedicineReturning(30, 30, "1정");
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then — notificationRepository.markReminderTaken(seniorId, targetDate, "BREAKFAST", takenAt)
+        verify(notificationRepository).markReminderTaken(
+                eq(SENIOR_ID),
+                eq(TARGET_DATE),
+                eq("BREAKFAST"),
+                any(LocalDateTime.class)
+        );
+    }
+
+    @Test
+    @DisplayName("이미 TAKEN인 row 재호출 시 알림 자동 전이도 호출 안 함 — 멱등")
+    void 이미_TAKEN_재호출_시_알림_전이_안함() throws Exception {
+        // given
+        givenScheduleAndMedicineReturning(30, 25);
+        final MedicationLog existing = new MedicationLog(
+                SENIOR_ID, SCHEDULE_ID, TARGET_DATE, LocalDateTime.of(2026, 4, 18, 8, 0),
+                LogStatus.TAKEN, null, false, SENIOR_ID);
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.of(existing));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when
+        medicationLogService.upsert(SENIOR_ID, request);
+
+        // then
+        verify(notificationRepository, org.mockito.Mockito.never())
+                .markReminderTaken(any(), any(), any(), any());
+    }
+
+    @Test
     @DisplayName("이미 TAKEN인 row 재호출 시 잔여분 중복 차감 없음 — 멱등")
     void 이미_TAKEN인_경우_차감_없음() throws Exception {
         // given
@@ -471,6 +522,7 @@ class MedicationLogServiceTest {
         final MedicationSchedule schedule = ctor.newInstance();
         setField(schedule, "id", SCHEDULE_ID);
         setField(schedule, "medicineId", MEDICINE_ID);
+        setField(schedule, "mealSlot", com.ppiyaki.medication.MealSlot.BREAKFAST);
         // legacy "1정"/"2정"/"반정" raw 입력을 정수+단위로 정규화
         if (dosage != null) {
             setField(schedule, "dosage", dosage);
@@ -497,6 +549,7 @@ class MedicationLogServiceTest {
         final MedicationSchedule schedule = ctor.newInstance();
         setField(schedule, "id", SCHEDULE_ID);
         setField(schedule, "medicineId", MEDICINE_ID);
+        setField(schedule, "mealSlot", com.ppiyaki.medication.MealSlot.BREAKFAST);
         // 기본 dosage = 1정
         setField(schedule, "dosageQuantity", java.math.BigDecimal.ONE);
         setField(schedule, "dosageUnit", com.ppiyaki.medication.DosageUnit.TABLET);

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -312,10 +312,10 @@ class MedicationLogServiceTest {
     }
 
     @Test
-    @DisplayName("신규 TAKEN 업서트 시 Medicine.remainingAmount 1 차감")
+    @DisplayName("신규 TAKEN 업서트 시 schedule.dosage_quantity 기준으로 잔여분 차감 (1정 → 1)")
     void 신규_TAKEN_시_잔여분_차감() throws Exception {
-        // given
-        final Medicine medicine = givenScheduleAndMedicineReturning(30, 30);
+        // given — schedule.dosage_quantity=1, unit=TABLET (default)
+        final Medicine medicine = givenScheduleAndMedicineReturning(30, 30, "1정");
         when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
                 .thenReturn(Optional.empty());
         when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
@@ -397,9 +397,9 @@ class MedicationLogServiceTest {
     }
 
     @Test
-    @DisplayName("dosage 정수 추출 불가(\"반정\")이면 1 fallback 차감")
-    void TAKEN_시_dosage_비정수면_1_fallback() throws Exception {
-        // given
+    @DisplayName("schedule.dosage_quantity가 null이면 차감 skip (PRN/옛 schedule 보호) — spec dosage-quantity-unit-split Q7")
+    void TAKEN_시_dosage_quantity_null이면_차감_skip() throws Exception {
+        // given — quantity 추출 실패 케이스 ("반정"은 분수라 정규식에서 quantity null로 둠)
         final Medicine medicine = givenScheduleAndMedicineReturning(30, 30, "반정");
         when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
                 .thenReturn(Optional.empty());
@@ -413,8 +413,8 @@ class MedicationLogServiceTest {
         // when
         medicationLogService.upsert(SENIOR_ID, request);
 
-        // then
-        assertThat(medicine.getRemainingAmount()).isEqualTo(29);
+        // then — 차감 skip
+        assertThat(medicine.getRemainingAmount()).isEqualTo(30);
     }
 
     @Test
@@ -471,8 +471,16 @@ class MedicationLogServiceTest {
         final MedicationSchedule schedule = ctor.newInstance();
         setField(schedule, "id", SCHEDULE_ID);
         setField(schedule, "medicineId", MEDICINE_ID);
+        // legacy "1정"/"2정"/"반정" raw 입력을 정수+단위로 정규화
         if (dosage != null) {
             setField(schedule, "dosage", dosage);
+            final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
+                    .matcher(dosage);
+            if (m.find()) {
+                setField(schedule, "dosageQuantity", new java.math.BigDecimal(m.group(1)));
+                setField(schedule, "dosageUnit",
+                        com.ppiyaki.medication.DosageUnit.fromInput(m.group(2).trim()).orElse(null));
+            }
         }
         when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(schedule));
 
@@ -489,6 +497,9 @@ class MedicationLogServiceTest {
         final MedicationSchedule schedule = ctor.newInstance();
         setField(schedule, "id", SCHEDULE_ID);
         setField(schedule, "medicineId", MEDICINE_ID);
+        // 기본 dosage = 1정
+        setField(schedule, "dosageQuantity", java.math.BigDecimal.ONE);
+        setField(schedule, "dosageUnit", com.ppiyaki.medication.DosageUnit.TABLET);
         when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(schedule));
 
         final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", 30, 30, "ITEM-1", null);

--- a/src/test/java/com/ppiyaki/medicine/controller/MedicineControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medicine/controller/MedicineControllerE2ETest.java
@@ -191,10 +191,12 @@ class MedicineControllerE2ETest {
 
         medicationScheduleRepository.save(
                 new MedicationSchedule(Long.valueOf(medicineId), MealSlot.BREAKFAST,
-                        "1정", "DAILY", LocalDate.now(), null));
+                        java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET,
+                        "DAILY", LocalDate.now(), null));
         medicationScheduleRepository.save(
                 new MedicationSchedule(Long.valueOf(medicineId), MealSlot.DINNER,
-                        "1정", "DAILY", LocalDate.now(), null));
+                        java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET,
+                        "DAILY", LocalDate.now(), null));
 
         // when & then
         RestAssured.given()

--- a/src/test/java/com/ppiyaki/notification/controller/NotificationAutoTakenE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/NotificationAutoTakenE2ETest.java
@@ -1,0 +1,201 @@
+package com.ppiyaki.notification.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.ppiyaki.common.auth.JwtProvider;
+import com.ppiyaki.medication.DosageUnit;
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("PUT /api/v1/medication-logs TAKEN → MEDICATION_REMINDER 알림 takenAt 자동 전이 E2E")
+class NotificationAutoTakenE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private MedicineRepository medicineRepository;
+    @Autowired
+    private MedicationScheduleRepository scheduleRepository;
+    @Autowired
+    private NotificationRepository notificationRepository;
+    @Autowired
+    private JwtProvider jwtProvider;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 800000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("TAKEN upsert 시 같은 날짜·슬롯의 MEDICATION_REMINDER 알림만 takenAt 채워지고 다른 카테고리는 영향 없음")
+    void taken_upsert_marks_reminder_taken_only() {
+        // given — 시니어 + medicine + schedule(BREAKFAST 1정) + 시니어 토큰
+        final Long seniorId = seedSenior();
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+        final Long medicineId = seedMedicine(seniorId);
+        final Long scheduleId = seedSchedule(medicineId, MealSlot.BREAKFAST);
+
+        // 알림 3건 INSERT
+        // (1) MEDICATION_REMINDER, BREAKFAST, today  → 자동 전이 대상
+        // (2) MEDICATION_REMINDER, DINNER, today     → 다른 슬롯, 영향 없음
+        // (3) DUR_WARNING                            → 다른 카테고리, 영향 없음
+        final LocalDate today = LocalDate.now();
+        final Long reminderBreakfastId = seedReminderNotification(seniorId, today, MealSlot.BREAKFAST);
+        final Long reminderDinnerId = seedReminderNotification(seniorId, today, MealSlot.DINNER);
+        final Long durWarningId = seedDurWarningNotification(seniorId);
+
+        // when — 시니어가 BREAKFAST schedule TAKEN 인증
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + seniorToken)
+                .body("""
+                        {
+                            "scheduleId": %d,
+                            "targetDate": "%s",
+                            "status": "TAKEN"
+                        }
+                        """.formatted(scheduleId, today))
+                .when()
+                .put("/api/v1/medication-logs")
+                .then()
+                .statusCode(200);
+
+        // then — DB에서 직접 검증 (응답 DTO 검증은 GET /notifications로 별도 처리)
+        final Notification reminderBreakfast = notificationRepository.findById(reminderBreakfastId).orElseThrow();
+        final Notification reminderDinner = notificationRepository.findById(reminderDinnerId).orElseThrow();
+        final Notification durWarning = notificationRepository.findById(durWarningId).orElseThrow();
+
+        org.assertj.core.api.Assertions.assertThat(reminderBreakfast.getTakenAt()).isNotNull();
+        org.assertj.core.api.Assertions.assertThat(reminderDinner.getTakenAt())
+                .as("다른 슬롯(DINNER) 알림은 영향 없어야 함").isNull();
+        org.assertj.core.api.Assertions.assertThat(durWarning.getTakenAt())
+                .as("다른 카테고리(DUR_WARNING) 알림은 영향 없어야 함").isNull();
+
+        // GET 응답 DTO에 takenAt 노출 검증
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorToken)
+                .when()
+                .get("/api/v1/notifications?category=MEDICATION_REMINDER")
+                .then()
+                .statusCode(200)
+                .body("responses.find { it.id == " + reminderBreakfastId + " }.takenAt", notNullValue())
+                .body("responses.find { it.id == " + reminderDinnerId + " }.takenAt", is(nullValue()));
+    }
+
+    @Test
+    @DisplayName("이미 TAKEN인 row 재호출(MISSED→TAKEN→TAKEN) 시 첫 TAKEN의 takenAt이 보존되고 두 번째 호출이 덮어쓰지 않음 — 멱등")
+    void reminder_takenAt_idempotent() throws InterruptedException {
+        final Long seniorId = seedSenior();
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+        final Long medicineId = seedMedicine(seniorId);
+        final Long scheduleId = seedSchedule(medicineId, MealSlot.LUNCH);
+        final LocalDate today = LocalDate.now();
+        final Long reminderId = seedReminderNotification(seniorId, today, MealSlot.LUNCH);
+
+        // 1차 TAKEN
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + seniorToken)
+                .body("""
+                        {"scheduleId": %d, "targetDate": "%s", "status": "TAKEN"}
+                        """.formatted(scheduleId, today))
+                .when().put("/api/v1/medication-logs").then().statusCode(200);
+
+        final LocalDateTime firstTakenAt = notificationRepository.findById(reminderId).orElseThrow().getTakenAt();
+        org.assertj.core.api.Assertions.assertThat(firstTakenAt).isNotNull();
+
+        // 2차 TAKEN (멱등 호출)
+        Thread.sleep(20);
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + seniorToken)
+                .body("""
+                        {"scheduleId": %d, "targetDate": "%s", "status": "TAKEN"}
+                        """.formatted(scheduleId, today))
+                .when().put("/api/v1/medication-logs").then().statusCode(200);
+
+        final LocalDateTime secondTakenAt = notificationRepository.findById(reminderId).orElseThrow().getTakenAt();
+        org.assertj.core.api.Assertions.assertThat(secondTakenAt)
+                .as("이미 TAKEN인 알림의 takenAt은 덮어쓰지 않아야 함 (markReminderTaken WHERE takenAt IS NULL)")
+                .isEqualTo(firstTakenAt);
+    }
+
+    // --- fixtures ---
+
+    private Long seedSenior() {
+        return transactionTemplate.execute(status -> {
+            final User senior = User.createSenior("E2E시니어" + userSequence++, (LocalDate) null);
+            return userRepository.save(senior).getId();
+        });
+    }
+
+    private Long seedMedicine(final Long seniorId) {
+        return transactionTemplate.execute(status -> {
+            final Medicine medicine = new Medicine(seniorId, null, "테스트약", 30, 30, "ITEM-1", null);
+            return medicineRepository.save(medicine).getId();
+        });
+    }
+
+    private Long seedSchedule(final Long medicineId, final MealSlot slot) {
+        return transactionTemplate.execute(status -> {
+            final MedicationSchedule schedule = new MedicationSchedule(
+                    medicineId, slot, BigDecimal.ONE, DosageUnit.TABLET,
+                    "DAILY", LocalDate.now(), null);
+            return scheduleRepository.save(schedule).getId();
+        });
+    }
+
+    private Long seedReminderNotification(final Long seniorId, final LocalDate targetDate, final MealSlot slot) {
+        return transactionTemplate.execute(status -> {
+            final Notification n = Notification.createForMedicationReminder(
+                    seniorId, "약 드실 시간이에요", "삐~약드실 시간이에요~", targetDate, slot.name());
+            return notificationRepository.save(n).getId();
+        });
+    }
+
+    private Long seedDurWarningNotification(final Long seniorId) {
+        return transactionTemplate.execute(status -> {
+            final Notification n = Notification.createForDurWarning(
+                    seniorId, seniorId, "DUR 경고", "약 충돌 경고", 999L);
+            return notificationRepository.save(n).getId();
+        });
+    }
+}

--- a/src/test/java/com/ppiyaki/notification/service/DeviceTokenServiceTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/DeviceTokenServiceTest.java
@@ -2,6 +2,7 @@ package com.ppiyaki.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -48,10 +49,11 @@ class DeviceTokenServiceTest {
     }
 
     @Test
-    @DisplayName("기존 token이면 reactivate 호출 + save 호출 안 함")
-    void register_existing_token_reactivates() {
+    @DisplayName("기존 token + 같은 user면 reactivate 호출 + transferTo는 호출 안 함")
+    void register_existing_token_sameUser_reactivates() {
         // given
         final DeviceToken existing = mock(DeviceToken.class);
+        given(existing.getUserId()).willReturn(7L);
         given(existing.getIsActive()).willReturn(true);
         given(deviceTokenRepository.findByToken("token-123")).willReturn(Optional.of(existing));
 
@@ -60,6 +62,25 @@ class DeviceTokenServiceTest {
 
         // then
         verify(existing).reactivate(any(LocalDateTime.class));
+        verify(existing, never()).transferTo(any(), any(LocalDateTime.class));
+        verify(deviceTokenRepository, never()).save(any(DeviceToken.class));
+    }
+
+    @Test
+    @DisplayName("기존 token + 다른 user면 transferTo 호출 (소유자 이전, issue #329)")
+    void register_existing_token_differentUser_transfers() {
+        // given — 기존 row owner=7L, 신규 등록 요청 owner=30L (다른 user)
+        final DeviceToken existing = mock(DeviceToken.class);
+        given(existing.getUserId()).willReturn(7L);
+        given(existing.getIsActive()).willReturn(true);
+        given(deviceTokenRepository.findByToken("token-123")).willReturn(Optional.of(existing));
+
+        // when
+        deviceTokenService.register(30L, "token-123", DevicePlatform.ANDROID);
+
+        // then — transferTo로 owner 이전, reactivate는 호출 안 함
+        verify(existing).transferTo(eq(30L), any(LocalDateTime.class));
+        verify(existing, never()).reactivate(any(LocalDateTime.class));
         verify(deviceTokenRepository, never()).save(any(DeviceToken.class));
     }
 

--- a/src/test/java/com/ppiyaki/prescription/PrescriptionMedicineCandidateMealSlotsTest.java
+++ b/src/test/java/com/ppiyaki/prescription/PrescriptionMedicineCandidateMealSlotsTest.java
@@ -15,7 +15,7 @@ class PrescriptionMedicineCandidateMealSlotsTest {
     @DisplayName("생성 시 suggestedMealSlots는 CSV로 직렬화되고, 리스트 게터로 복원된다")
     void constructor_persistsSuggestedSlotsAsCsv() {
         final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                1L, "raw", "타이레놀정", "1정", "1일 3회 식후",
+                1L, "raw", "타이레놀정", java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET, "1일 3회 식후",
                 "ITEM-1", "타이레놀", MatchType.EXACT, "matched",
                 List.of(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER)
         );
@@ -30,7 +30,7 @@ class PrescriptionMedicineCandidateMealSlotsTest {
     @DisplayName("suggestedMealSlots null/empty → CSV는 null, 리스트 게터는 빈 리스트")
     void constructor_emptySuggestedSlots() {
         final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                1L, "raw", "약", "1정", "취침 전",
+                1L, "raw", "약", java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET, "취침 전",
                 null, null, MatchType.NO_MATCH, "no match",
                 List.of()
         );
@@ -43,7 +43,7 @@ class PrescriptionMedicineCandidateMealSlotsTest {
     @DisplayName("updateConfirmedMealSlots: 리스트 → CSV 저장")
     void updateConfirmedMealSlots_persistsCsv() {
         final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                1L, "raw", "약", "1정", "1일 2회",
+                1L, "raw", "약", java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET, "1일 2회",
                 null, null, MatchType.NO_MATCH, null,
                 List.of(MealSlot.BREAKFAST, MealSlot.DINNER)
         );
@@ -59,7 +59,7 @@ class PrescriptionMedicineCandidateMealSlotsTest {
     @DisplayName("updateConfirmedMealSlots: 빈 리스트 → null로 초기화")
     void updateConfirmedMealSlots_emptyClearsField() {
         final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                1L, "raw", "약", "1정", "1일 2회",
+                1L, "raw", "약", java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET, "1일 2회",
                 null, null, MatchType.NO_MATCH, null,
                 List.of(MealSlot.BREAKFAST)
         );
@@ -76,7 +76,7 @@ class PrescriptionMedicineCandidateMealSlotsTest {
     @DisplayName("manualAdd factory: suggestedMealSlots는 비어있음")
     void manualAdd_emptySuggestedSlots() {
         final PrescriptionMedicineCandidate candidate = PrescriptionMedicineCandidate.manualAdd(
-                1L, "ITEM-1", "타이레놀정", "1정", "1일 3회"
+                1L, "ITEM-1", "타이레놀정", java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET, "1일 3회"
         );
 
         assertThat(candidate.getSuggestedMealSlots()).isNull();

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmAutoScheduleE2ETest.java
@@ -107,7 +107,8 @@ class PrescriptionConfirmAutoScheduleE2ETest {
         final List<MedicationSchedule> schedules = medicationScheduleRepository.findByMedicineId(medicineId);
         assertThat(schedules).extracting(MedicationSchedule::getMealSlot)
                 .containsExactlyInAnyOrder(MealSlot.BREAKFAST, MealSlot.LUNCH, MealSlot.DINNER);
-        assertThat(schedules).allMatch(s -> "1정".equals(s.getDosage()));
+        assertThat(schedules).allMatch(s -> java.math.BigDecimal.ONE.compareTo(s.getDosageQuantity()) == 0
+                && com.ppiyaki.medication.DosageUnit.TABLET == s.getDosageUnit());
         assertThat(schedules).allMatch(s -> "DAILY".equals(s.getDaysOfWeek()));
 
         // candidate에 created_medicine_id 채워짐
@@ -297,9 +298,26 @@ class PrescriptionConfirmAutoScheduleE2ETest {
             final String dosage,
             final List<MealSlot> confirmedSlots
     ) {
+        // dosage="1정"/"2정"/null 등 raw 입력을 BigDecimal+DosageUnit으로 정규화
+        final java.math.BigDecimal quantity;
+        final com.ppiyaki.medication.DosageUnit unit;
+        if (dosage == null) {
+            quantity = null;
+            unit = null;
+        } else {
+            final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$").matcher(
+                    dosage);
+            if (m.find()) {
+                quantity = new java.math.BigDecimal(m.group(1));
+                unit = com.ppiyaki.medication.DosageUnit.fromInput(m.group(2).trim()).orElse(null);
+            } else {
+                quantity = null;
+                unit = com.ppiyaki.medication.DosageUnit.fromInput(dosage).orElse(null);
+            }
+        }
         return transactionTemplate.execute(status -> {
             final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                    prescriptionId, "raw", "타이레놀정", dosage, "1일 3회 식후",
+                    prescriptionId, "raw", "타이레놀정", quantity, unit, "1일 3회 식후",
                     "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
                     confirmedSlots
             );

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
@@ -149,6 +149,83 @@ class PrescriptionConfirmedMealSlotsE2ETest {
     }
 
     @Test
+    @DisplayName("PATCH로 dosage 갱신 후 GET 응답에 노출된다")
+    void patch_persists_and_exposes_dosage() {
+        // given — OCR이 dosage 누락한 candidate
+        final SignupResult senior = signup("dosage시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedCandidateWithDosage(prescriptionId, null);
+
+        // when — 보호자가 dosage 보강
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {
+                            "decision": "ACCEPTED",
+                            "dosage": "1정"
+                        }
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // then — GET 응답에 갱신된 dosage 노출
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/prescriptions/" + prescriptionId)
+                .then()
+                .statusCode(200)
+                .body("candidates[0].extractedDosage", is("1정"));
+    }
+
+    @Test
+    @DisplayName("PATCH 본문에 dosage 미포함/공백이면 기존 dosage 유지")
+    void patch_without_dosage_keepsExistingDosage() {
+        // given — 기존 dosage가 있는 candidate
+        final SignupResult senior = signup("dosage유지시니어");
+        setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
+        final Long prescriptionId = seedPrescription(senior.userId());
+        final Long candidateId = seedCandidateWithDosage(prescriptionId, "1정");
+
+        // when — dosage 필드 미포함
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {"decision": "ACCEPTED"}
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // 공백 dosage 도 무시
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .body("""
+                        {"decision": "ACCEPTED", "dosage": "   "}
+                        """)
+                .when()
+                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
+                .then()
+                .statusCode(200);
+
+        // then — 기존 dosage 유지
+        RestAssured.given()
+                .header("Authorization", "Bearer " + senior.accessToken())
+                .when()
+                .get("/api/v1/prescriptions/" + prescriptionId)
+                .then()
+                .statusCode(200)
+                .body("candidates[0].extractedDosage", is("1정"));
+    }
+
+    @Test
     @DisplayName("잘못된 enum 값이면 400")
     void patch_invalidEnum_returns400() {
         final SignupResult senior = signup("잘못된슬롯시니어");
@@ -215,6 +292,20 @@ class PrescriptionConfirmedMealSlotsE2ETest {
                     prescriptionId, "raw", "타이레놀정", "1정", "1일 3회 식후",
                     "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
                     suggestedSlots
+            );
+            return candidateRepository.save(candidate).getId();
+        });
+    }
+
+    private Long seedCandidateWithDosage(
+            final Long prescriptionId,
+            final String dosage
+    ) {
+        return transactionTemplate.execute(status -> {
+            final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
+                    prescriptionId, "raw", "타이레놀정", dosage, "1일 3회 식후",
+                    "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
+                    List.of()
             );
             return candidateRepository.save(candidate).getId();
         });

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionConfirmedMealSlotsE2ETest.java
@@ -149,22 +149,23 @@ class PrescriptionConfirmedMealSlotsE2ETest {
     }
 
     @Test
-    @DisplayName("PATCH로 dosage 갱신 후 GET 응답에 노출된다")
+    @DisplayName("PATCH로 dosage 갱신 후 GET 응답에 노출된다 (정수+단위 분리, unit은 displayValue)")
     void patch_persists_and_exposes_dosage() {
         // given — OCR이 dosage 누락한 candidate
         final SignupResult senior = signup("dosage시니어");
         setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
         final Long prescriptionId = seedPrescription(senior.userId());
-        final Long candidateId = seedCandidateWithDosage(prescriptionId, null);
+        final Long candidateId = seedCandidateWithDosage(prescriptionId, null, null);
 
-        // when — 보호자가 dosage 보강
+        // when — 보호자가 dosage 보강 (입력은 자유 텍스트, 서버에서 enum 정규화)
         RestAssured.given()
                 .contentType(ContentType.JSON)
                 .header("Authorization", "Bearer " + senior.accessToken())
                 .body("""
                         {
                             "decision": "ACCEPTED",
-                            "dosage": "1정"
+                            "dosageQuantity": 1,
+                            "dosageUnit": "정"
                         }
                         """)
                 .when()
@@ -172,24 +173,26 @@ class PrescriptionConfirmedMealSlotsE2ETest {
                 .then()
                 .statusCode(200);
 
-        // then — GET 응답에 갱신된 dosage 노출
+        // then — GET 응답에 분리 두 필드 노출. unit은 enum.name() 대신 displayValue 문자열
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
                 .when()
                 .get("/api/v1/prescriptions/" + prescriptionId)
                 .then()
                 .statusCode(200)
-                .body("candidates[0].extractedDosage", is("1정"));
+                .body("candidates[0].extractedDosageQuantity", is(1))
+                .body("candidates[0].extractedDosageUnit", is("정"));
     }
 
     @Test
-    @DisplayName("PATCH 본문에 dosage 미포함/공백이면 기존 dosage 유지")
+    @DisplayName("PATCH 본문에 dosage 미포함이면 기존 dosage 유지")
     void patch_without_dosage_keepsExistingDosage() {
         // given — 기존 dosage가 있는 candidate
         final SignupResult senior = signup("dosage유지시니어");
         setSeniorMode(senior.userId(), CareMode.AUTONOMOUS);
         final Long prescriptionId = seedPrescription(senior.userId());
-        final Long candidateId = seedCandidateWithDosage(prescriptionId, "1정");
+        final Long candidateId = seedCandidateWithDosage(prescriptionId,
+                java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET);
 
         // when — dosage 필드 미포함
         RestAssured.given()
@@ -203,18 +206,6 @@ class PrescriptionConfirmedMealSlotsE2ETest {
                 .then()
                 .statusCode(200);
 
-        // 공백 dosage 도 무시
-        RestAssured.given()
-                .contentType(ContentType.JSON)
-                .header("Authorization", "Bearer " + senior.accessToken())
-                .body("""
-                        {"decision": "ACCEPTED", "dosage": "   "}
-                        """)
-                .when()
-                .patch("/api/v1/prescriptions/" + prescriptionId + "/medicines/" + candidateId)
-                .then()
-                .statusCode(200);
-
         // then — 기존 dosage 유지
         RestAssured.given()
                 .header("Authorization", "Bearer " + senior.accessToken())
@@ -222,7 +213,8 @@ class PrescriptionConfirmedMealSlotsE2ETest {
                 .get("/api/v1/prescriptions/" + prescriptionId)
                 .then()
                 .statusCode(200)
-                .body("candidates[0].extractedDosage", is("1정"));
+                .body("candidates[0].extractedDosageQuantity", is(1))
+                .body("candidates[0].extractedDosageUnit", is("정"));
     }
 
     @Test
@@ -289,7 +281,9 @@ class PrescriptionConfirmedMealSlotsE2ETest {
     ) {
         return transactionTemplate.execute(status -> {
             final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                    prescriptionId, "raw", "타이레놀정", "1정", "1일 3회 식후",
+                    prescriptionId, "raw", "타이레놀정",
+                    java.math.BigDecimal.ONE, com.ppiyaki.medication.DosageUnit.TABLET,
+                    "1일 3회 식후",
                     "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
                     suggestedSlots
             );
@@ -299,11 +293,14 @@ class PrescriptionConfirmedMealSlotsE2ETest {
 
     private Long seedCandidateWithDosage(
             final Long prescriptionId,
-            final String dosage
+            final java.math.BigDecimal quantity,
+            final com.ppiyaki.medication.DosageUnit unit
     ) {
         return transactionTemplate.execute(status -> {
             final PrescriptionMedicineCandidate candidate = new PrescriptionMedicineCandidate(
-                    prescriptionId, "raw", "타이레놀정", dosage, "1일 3회 식후",
+                    prescriptionId, "raw", "타이레놀정",
+                    quantity, unit,
+                    "1일 3회 식후",
                     "ITEM-1", "타이레놀정", MatchType.EXACT, "matched",
                     List.of()
             );

--- a/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
+++ b/src/test/java/com/ppiyaki/prescription/service/PrescriptionServiceManualAddTest.java
@@ -91,7 +91,9 @@ class PrescriptionServiceManualAddTest {
         when(candidateRepository.findByPrescriptionId(prescriptionId)).thenReturn(List.of());
 
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
-                "199500096", "타이레놀정 500mg", "1정", "1일 3회 식후");
+                "199500096", "타이레놀정 500mg",
+                java.math.BigDecimal.ONE, "정",
+                "1일 3회 식후");
 
         // when
         prescriptionService.addManualMedicine(ownerId, prescriptionId, request);
@@ -126,7 +128,7 @@ class PrescriptionServiceManualAddTest {
         when(candidateRepository.findByPrescriptionId(prescriptionId)).thenReturn(List.of());
 
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
-                "199500096", "타이레놀정 500mg", null, null);
+                "199500096", "타이레놀정 500mg", null, null, null);
 
         // when
         prescriptionService.addManualMedicine(caregiverId, prescriptionId, request);
@@ -148,7 +150,7 @@ class PrescriptionServiceManualAddTest {
                 .thenReturn(Optional.empty());
 
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
-                "199500096", "타이레놀정 500mg", null, null);
+                "199500096", "타이레놀정 500mg", null, null, null);
 
         // when & then
         assertThatThrownBy(() -> prescriptionService.addManualMedicine(otherUserId, prescriptionId, request))
@@ -169,7 +171,7 @@ class PrescriptionServiceManualAddTest {
         when(userRepository.findById(ownerId)).thenReturn(Optional.of(givenSenior(ownerId, CareMode.AUTONOMOUS)));
 
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
-                "199500096", "타이레놀정 500mg", null, null);
+                "199500096", "타이레놀정 500mg", null, null, null);
 
         // when & then
         assertThatThrownBy(() -> prescriptionService.addManualMedicine(ownerId, prescriptionId, request))
@@ -185,7 +187,7 @@ class PrescriptionServiceManualAddTest {
         // given
         when(prescriptionRepository.findById(999L)).thenReturn(Optional.empty());
         final PrescriptionMedicineAddRequest request = new PrescriptionMedicineAddRequest(
-                "199500096", "타이레놀정 500mg", null, null);
+                "199500096", "타이레놀정 500mg", null, null, null);
 
         // when & then
         assertThatThrownBy(() -> prescriptionService.addManualMedicine(100L, 999L, request))

--- a/src/test/java/com/ppiyaki/prescription/service/PrescriptionServicePermissionTest.java
+++ b/src/test/java/com/ppiyaki/prescription/service/PrescriptionServicePermissionTest.java
@@ -181,7 +181,7 @@ class PrescriptionServicePermissionTest {
     }
 
     private PrescriptionMedicineAddRequest validRequest() {
-        return new PrescriptionMedicineAddRequest("199500096", "타이레놀정 500mg", null, null);
+        return new PrescriptionMedicineAddRequest("199500096", "타이레놀정 500mg", null, null, null);
     }
 
     private Prescription givenPrescription(final LocalDateTime createdAt) throws Exception {

--- a/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
@@ -62,9 +62,6 @@ class CareRelationServiceTest {
     @DisplayName("보호자가 시니어의 초대 코드를 발급하면 6자리 코드를 반환한다")
     void createInviteCode_success() {
         // given
-        final User caregiver = mockUser(1L, UserRole.CAREGIVER);
-        given(userRepository.findById(1L)).willReturn(Optional.of(caregiver));
-
         final CareRelation existingRelation = CareRelation.createLinked(2L, 1L);
         given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(1L, 2L))
                 .willReturn(Optional.of(existingRelation));
@@ -83,8 +80,6 @@ class CareRelationServiceTest {
     @DisplayName("연동 관계가 없는 시니어의 코드 발급을 시도하면 CARE_RELATION_NOT_FOUND 에러")
     void createInviteCode_noRelation_throwsNotFound() {
         // given
-        final User caregiver = mockUser(1L, UserRole.CAREGIVER);
-        given(userRepository.findById(1L)).willReturn(Optional.of(caregiver));
         given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(1L, 2L))
                 .willReturn(Optional.empty());
 

--- a/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/OnboardingServiceTest.java
@@ -1,15 +1,12 @@
 package com.ppiyaki.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.ppiyaki.common.exception.BusinessException;
-import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.notification.NotificationSettings;
 import com.ppiyaki.notification.repository.NotificationSettingsRepository;
 import com.ppiyaki.pet.Pet;
@@ -18,7 +15,6 @@ import com.ppiyaki.user.CareMode;
 import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.Gender;
 import com.ppiyaki.user.User;
-import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.OnboardingRequest;
 import com.ppiyaki.user.controller.dto.OnboardingRequest.SeniorEntry;
 import com.ppiyaki.user.controller.dto.OnboardingResponse;
@@ -56,7 +52,6 @@ class OnboardingServiceTest {
     void onboard_success() {
         // given
         final User caregiver = mock(User.class);
-        given(caregiver.getRole()).willReturn(UserRole.CAREGIVER);
         given(caregiver.getNickname()).willReturn("보호자닉네임");
         given(userRepository.findById(1L)).willReturn(Optional.of(caregiver));
 
@@ -100,25 +95,4 @@ class OnboardingServiceTest {
         verify(senior2).changeCareMode(CareMode.MANAGED);
     }
 
-    @Test
-    @DisplayName("시니어가 온보딩을 시도하면 ROLE_MISMATCH 에러가 발생한다")
-    void onboard_bySenior_throwsRoleMismatch() {
-        // given
-        final User senior = mock(User.class);
-        given(senior.getRole()).willReturn(UserRole.SENIOR);
-        given(userRepository.findById(1L)).willReturn(Optional.of(senior));
-
-        final OnboardingRequest onboardingRequest = new OnboardingRequest(
-                "닉네임",
-                List.of(new SeniorEntry("할머니", Gender.FEMALE, CareMode.AUTONOMOUS))
-        );
-
-        // when & then
-        assertThatThrownBy(() -> onboardingService.onboard(1L, onboardingRequest))
-                .isInstanceOf(BusinessException.class)
-                .satisfies(exception -> {
-                    final BusinessException businessException = (BusinessException) exception;
-                    assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
-                });
-    }
 }

--- a/src/test/java/com/ppiyaki/user/service/SeniorServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/SeniorServiceTest.java
@@ -1,25 +1,19 @@
 package com.ppiyaki.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
-import com.ppiyaki.common.exception.BusinessException;
-import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.User;
-import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.SeniorCreateRequest;
 import com.ppiyaki.user.controller.dto.SeniorCreateResponse;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDate;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,10 +40,6 @@ class SeniorServiceTest {
     @DisplayName("보호자가 시니어를 대리 생성하면 시니어 계정, CareRelation, Pet이 함께 생성된다")
     void createSenior_success() {
         // given
-        final User caregiver = mock(User.class);
-        given(caregiver.getRole()).willReturn(UserRole.CAREGIVER);
-        given(userRepository.findById(1L)).willReturn(Optional.of(caregiver));
-
         final User senior = mock(User.class);
         given(senior.getId()).willReturn(2L);
         given(userRepository.save(any(User.class))).willReturn(senior);
@@ -73,22 +63,4 @@ class SeniorServiceTest {
         assertThat(response.petId()).isEqualTo(1L);
     }
 
-    @Test
-    @DisplayName("시니어가 시니어 대리 생성을 시도하면 ROLE_MISMATCH 에러가 발생한다")
-    void createSenior_bySenior_throwsRoleMismatch() {
-        // given
-        final User senior = mock(User.class);
-        lenient().when(senior.getRole()).thenReturn(UserRole.SENIOR);
-        given(userRepository.findById(1L)).willReturn(Optional.of(senior));
-
-        final SeniorCreateRequest request = new SeniorCreateRequest("시니어", null);
-
-        // when & then
-        assertThatThrownBy(() -> seniorService.createSenior(1L, request))
-                .isInstanceOf(BusinessException.class)
-                .satisfies(exception -> {
-                    final BusinessException businessException = (BusinessException) exception;
-                    assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
-                });
-    }
 }


### PR DESCRIPTION
## v0.12.0 — 2026-05-12

### feat
- **(prescription) caregiver가 medicine candidate dosage 직접 수정 가능** (#318) — OCR이 dosage를 누락한 candidate를 caregiver가 PATCH로 보강 가능
- **(medication) dosage_quantity + dosage_unit 컬럼 추가** (#320, Phase A — DECIMAL+VARCHAR 컬럼 신설, 옛 dosage 컬럼 호환 유지)
- **(prescription) dosage 정수+단위 분리 cut-over** (#321) — DosageUnit enum 신설, AI schema 변경, DTO/Service 정리, MedicationLogService fallback 제거

### fix
- **(infra) HTTP 405 글로벌 예외 핸들러 추가** (#312) — 누락된 405 응답 정규화
- **(user) JwtAuthenticationFilter에서 JWT role 클레임 소비** (#314) — PR #227 미완료 분의 consumer 보강
- **(user) JWT role 기반 인가 활성화 + 서비스 단 role 비교 제거** (#316) — `@EnableMethodSecurity` + 5개 controller `@PreAuthorize` + 서비스 단 정리
- **(medication) 복약 인증 후 MEDICATION_REMINDER 알림 자동 전이 (taken_at)** (#325) — 사용자 운영 보고: "확인" 버튼 안 사라짐
- **(medication) 주/월간 대시보드 가입 이전 날짜 dayStatus를 NOT_SCHEDULED로** (#327) — 사용자 운영 보고: 가입 전 PERFECT 표시
- **(medication) DeviceToken 같은 token 다른 user 재등록 시 소유자 이전** (#330) — 사용자 운영 보고: 토큰 등록은 됐는데 푸시 안 옴

### test
- **(medication) MEDICATION_REMINDER 알림 자동 전이 E2E 보강** (#328) — PR #325 후속 검증

## 🔧 prod 수동 마이그레이션 (PR 머지 전에 실행 필수)
ddl-auto=validate라 컬럼 부재 시 부트 fail. release 머지 직전 4건 실행:

```sql
ALTER TABLE medication_schedules
  ADD COLUMN dosage_quantity DECIMAL(5,2) NULL,
  ADD COLUMN dosage_unit VARCHAR(16) NULL;

ALTER TABLE prescription_medicine_candidates
  ADD COLUMN extracted_dosage_quantity DECIMAL(5,2) NULL,
  ADD COLUMN extracted_dosage_unit VARCHAR(16) NULL;

ALTER TABLE notifications ADD COLUMN taken_at DATETIME(6) NULL;
```

## 프론트 cut-over 안내
- **dosage**: PATCH `/prescriptions/{id}/medicines/{candidateId}` body의 `dosage` String 필드 제거 → `dosageQuantity`(number) + `dosageUnit`(string) 두 필드. 응답 unit은 displayValue String (`"정"`, `"mg"`)으로 내려감
- **알림**: `NotificationItemResponse`에 `takenAt` 필드 추가. MEDICATION_REMINDER 알림은 `taken_at == null && type == MEDICATION_REMINDER`일 때만 "확인" 버튼 표시
- **대시보드**: `DayStatus` enum에 `NOT_SCHEDULED` 추가 (가입 이전 날짜)
- **인가**: 시니어가 CAREGIVER 전용 endpoint 호출 시 응답 `error.code` 변경 (`CARE_008` → `COMMON_004`). status code 403 동일

## 작업 범위 외 (다음 release)
- 옛 `dosage` String 컬럼 drop (안정화 2주 후, PR 4)
- 옛 prod schedule(release 전) 차감 멈춤 (Q7 결정대로 그대로 두기, 차후 검토)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 약 투약량을 수량과 단위로 분리하여 더 정확한 약물 관리 지원
  * 약 복용 알림 자동 추적 기능 추가
  * 기기 전환 시 사용자 정보 자동 이전 기능

* **개선사항**
  * 보호자 전용 기능에 역할 기반 접근 제어 강화
  * 가입 전 날짜 상태를 "미예약"으로 구분 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->