### PR TITLE
fix(medication): CodeRabbit 코멘트 + NotificationItemResponse.isRead 제거 (release v0.12.0 직전 정리)

### DIFF
--- a/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/common/ai/OpenAiClient.java
@@ -170,9 +170,7 @@ public class OpenAiClient {
 
             final List<ExtractedMedicine> result = new ArrayList<>();
             for (final JsonNode item : medicines) {
-                final BigDecimal dosageQuantity = item.path("dosageQuantity").isNumber()
-                        ? item.path("dosageQuantity").decimalValue()
-                        : null;
+                final BigDecimal dosageQuantity = parseDosageQuantity(item.path("dosageQuantity"));
                 final DosageUnit dosageUnit = DosageUnit.fromInput(item.path("dosageUnit").asText(null))
                         .orElse(null);
                 result.add(new ExtractedMedicine(
@@ -192,6 +190,22 @@ public class OpenAiClient {
         } catch (final Exception e) {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
                     "AI response parse failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * dosageQuantity 노드를 BigDecimal로 파싱. number/string 모두 허용 (LLM 응답 흔들림 흡수).
+     * 빈 문자열·파싱 실패·null/array/object 등은 모두 null.
+     */
+    private static BigDecimal parseDosageQuantity(final JsonNode node) {
+        final String text = node.asText("").trim();
+        if (text.isEmpty()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(text);
+        } catch (final NumberFormatException ignored) {
+            return null;
         }
     }
 

--- a/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
+++ b/src/main/java/com/ppiyaki/medication/MedicationSchedule.java
@@ -86,6 +86,10 @@ public class MedicationSchedule extends CreatedTimeEntity {
             this.dosageQuantity = dosageQuantity;
         }
         if (dosageUnit != null) {
+            // PRN으로 전환 시 quantity는 의미 없음 — null로 정정 (legacy dosage 합성 시 비정상값 회피)
+            if (dosageUnit == DosageUnit.PRN) {
+                this.dosageQuantity = null;
+            }
             this.dosageUnit = dosageUnit;
         }
         if (dosageQuantity != null || dosageUnit != null) {

--- a/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
@@ -11,7 +11,6 @@ public record NotificationItemResponse(
         String title,
         String body,
         String payload,
-        boolean isRead,
         LocalDateTime readAt,
         LocalDateTime takenAt,
         LocalDateTime createdAt
@@ -25,7 +24,6 @@ public record NotificationItemResponse(
                 notification.getTitle(),
                 notification.getBody(),
                 notification.getPayload(),
-                notification.isRead(),
                 notification.getReadAt(),
                 notification.getTakenAt(),
                 notification.getCreatedAt()

--- a/src/test/java/com/ppiyaki/medication/MedicationScheduleTest.java
+++ b/src/test/java/com/ppiyaki/medication/MedicationScheduleTest.java
@@ -42,4 +42,18 @@ class MedicationScheduleTest {
 
         assertThat(schedule.getMealSlot()).isEqualTo(MealSlot.DINNER);
     }
+
+    @Test
+    @DisplayName("update로 PRN 전환 시 dosageQuantity는 null로 강제 — legacy dosage 비정상 합성 회피")
+    void update_toPRN_clearsDosageQuantity() {
+        final MedicationSchedule schedule = new MedicationSchedule(
+                1L, MealSlot.BREAKFAST, BigDecimal.ONE, DosageUnit.TABLET, "DAILY", LocalDate.now(), null);
+
+        schedule.update(null, null, DosageUnit.PRN, null, null, null);
+
+        assertThat(schedule.getDosageQuantity()).isNull();
+        assertThat(schedule.getDosageUnit()).isEqualTo(DosageUnit.PRN);
+        // legacy dosage = "PRN" (quantity 없음)
+        assertThat(schedule.getDosage()).isEqualTo("PRN");
+    }
 }


### PR DESCRIPTION
release PR #331 머지 전 develop에 합쳐 자동 포함되도록 정리하는 fix PR.

## 변경 1: [CodeRabbit Major] `MedicationSchedule.update` PRN 전환 시 quantity null
**문제**: `dosageUnit=PRN`으로 update 시 기존 `dosageQuantity`가 그대로 남아 legacy dosage 합성에서 비정상값(예: "1PRN") 발생 가능.

**수정**: PRN 분기에서 `this.dosageQuantity = null` 강제. 단위 테스트 추가.

## 변경 2: [CodeRabbit Minor] `OpenAiClient.dosageQuantity` 문자열 응답 허용
**문제**: LLM이 `dosageQuantity`를 number가 아닌 문자열("1"/"0.5")로 응답하면 `isNumber()` 분기에서 null로 떨어져 schedule 미생성.

**수정**: `parseDosageQuantity` 헬퍼 신설 — `isNumber` 우선, `isTextual`이면 BigDecimal 파싱 시도, NumberFormatException 시 null.

## 변경 3: [Refactor] `NotificationItemResponse.isRead` 제거
**문제**: `isRead`는 derived field (`readAt != null`) — 중복. `takenAt` 패턴(시점 단독, `isTaken` 없음)과 비대칭.

**수정**: 응답 DTO에서 `isRead` 필드 제거. `readAt`만 노출. `Notification.isRead()` 도메인 메서드는 유지(외부 사용 0이지만 비용 0).

⚠️ **프론트 cut-over**: `notification.isRead` → `!!notification.readAt` 또는 `notification.readAt !== null` 직접 체크로 변경 필요.

## Notion API 명세 갱신
- 알림함 조회 페이지(`35c55690-fbc7-81c4-830a-dab93451a763`) — `isRead` 필드 deprecated 표시 (`~~~~`), JSON 예시에서도 제거

## 관련 이슈
- refs #331 (release v0.12.0 직전 정리)

## 라벨 부여 확인
- [x] `type:fix`
- [x] `scope:medication`
- [x] `ai-generated`
- [ ] `needs-human-review` — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트</summary>

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` 전체 통과 + PRN 단위 테스트 추가

## DDD/OOP
- [x] PRN/quantity 의미 분리 명확화

## 보안/민감정보
- [x] PII/시크릿 없음

## AI 작업 기록
- 사용한 프롬프트/지시 요약: CodeRabbit 인라인 코멘트 반영 + isRead/readAt 공존 검토 후 isRead 제거
- 변경 파일 4건: OpenAiClient, MedicationSchedule, NotificationItemResponse, MedicationScheduleTest
- 사람이 수동 검증: isRead 제거 결정 (사용자 합의), 프론트 cut-over 안내 필요

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 의약품 용량 수량이 숫자 형식뿐만 아니라 문자열 형식으로도 올바르게 처리됩니다.
* PRN(필요시) 의약품으로 설정할 때 불필요한 용량 값이 자동으로 제거됩니다.

## 개선
* 알림의 읽음 상태가 읽음/미읽음 여부에서 정확한 읽음 시간으로 변경되었습니다.

## 테스트
* PRN 의약품 용량 업데이트 기능의 동작을 검증하는 테스트가 추가되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/332)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->