### PR TITLE
chore(infra): CI/CD 속도 개선 — workflow concurrency + ubuntu 고정 + Dockerfile 의존성 레이어 분리

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -5,13 +5,20 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+# 동시 배포 직렬화 — 새 push 와도 옛 배포는 끝까지 진행 (cancel-in-progress: false)
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -13,9 +13,14 @@ permissions:
   checks: write
   pull-requests: write
 
+# 같은 PR에 새 push 시 진행 중인 워크플로우 취소 (러너 자원 절약 + 결과 빠르게)
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     services:
       mysql:
@@ -30,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM gradle:9.4-jdk21 AS build
 WORKDIR /app
 
+# 의존성 레이어 분리 — build 파일만 먼저 COPY해서 dependencies 다운로드 결과를
+# Docker 레이어 캐시로 보존. 소스 변경만 있으면 의존성 재다운로드 skip.
 COPY build.gradle settings.gradle /app/
-
-RUN gradle build -x test --no-daemon > /dev/null 2>&1 || true
+RUN gradle dependencies --no-daemon > /dev/null 2>&1 || true
 
 COPY config /app/config
 COPY src /app/src
 
-RUN gradle clean bootJar -x test -x checkstyleMain -x checkstyleTest --no-daemon
+# 위 레이어에서 가져온 의존성/빌드 결과를 보존하도록 clean 제거.
+# 소스가 바뀐 부분만 컴파일.
+RUN gradle bootJar -x test -x checkstyleMain -x checkstyleTest --no-daemon
 
 FROM eclipse-temurin:21-jre
 WORKDIR /app


### PR DESCRIPTION
## 요약
직전 분석에서 추정 1.5-2분 단축으로 제안된 항목 중, **로컬 실측 결과 효과 미미한 Phase 1(gradle.properties + maxParallelForks)은 폐기**. workflow 캐시 효과/concurrency/Docker 레이어 캐시는 CI 환경에서만 측정 가능하므로 선제적으로 적용 후 머지 다음 PR들의 CI 시간으로 검증.

## Phase 1 폐기 — 로컬 실측 데이터

| Run | Baseline (변경 X) | 변경 후 (gradle.properties + maxParallelForks) |
|---|---|---|
| 1 (cold) | **58.3s** | **56.6s** |
| 2 (warm) | 42.4s | **2.5s** ⚠️ |
| 3 (warm) | 39.4s | **1.5s** ⚠️ |

**환경**: M1 Mac, 8 CPU cores, 313 tests, `./gradlew clean test`

**Run 2/3의 1-2초는 함정**: `org.gradle.caching=true` 효과 (입력 동일 시 task cache hit). CI 환경에서는 PR마다 commit이 달라 cache miss → cold 실행만 의미 → **약 3% 단축, 통계적으로 의미 없음**.

추정(15-20%)과 실측 차이 큼. multi-module 가정이거나 CI 머신 차이. M1 + 단일 모듈 환경에선 fork 분리 오버헤드가 이득 상쇄.

## Phase 2 변경 (선제적 적용 — 후속 측정)

### 1. backend-ci.yml
- `runs-on: ubuntu-latest` → **`ubuntu-22.04`** (캐시 hit 향상)
- `actions/checkout` **`fetch-depth: 1`** (얕은 체크아웃)
- **concurrency: ci-${workflow}-${ref} + cancel-in-progress: true** (PR 새 push 시 옛 CI 취소 → 러너 자원 절약)

### 2. backend-cd.yml
- `runs-on: ubuntu-latest` → **`ubuntu-22.04`**
- **concurrency: production-deploy + cancel-in-progress: false** (배포 직렬화 — 새 push 와도 옛 배포 끝까지 진행)

### 3. Dockerfile 의존성 레이어 분리
- `build.gradle/settings.gradle` COPY → `gradle dependencies` (의존성만 캐시)
- 기존 `gradle build -x test` (전체 빌드 후 폐기)는 의미 없어 제거
- 두 번째 RUN에서 `clean` 제거 (첫 레이어 결과물 보존)
- 소스 변경만 있으면 의존성 재다운로드 skip → CD 시간 단축

## 검증 계획 (머지 후 후속 코멘트로 데이터 첨부)
- baseline: 최근 머지된 PR 5-10개 build-and-test 평균 시간
- 변경 후: 다음 머지될 PR N개 build-and-test 평균 시간
- 비교 표 PR 코멘트로 첨부 + 효과 확인 시 close, 미미하면 revert

## 관련 이슈
- closes #333

## 라벨 부여 확인
- [x] `type:chore`
- [x] `scope:infra`
- [x] `ai-generated`
- [x] **`needs-human-review`** — `.github/workflows/**` + `Dockerfile` 보호 영역

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성

## 품질 게이트 체크
- [x] `./gradlew test` 통과 (build.gradle 변경 없음)
- [x] 로컬 빌드/테스트 시간 실측 데이터 첨부

## DDD/OOP
- [x] 인프라 변경, 도메인 영향 없음

## 보안/민감정보
- [x] PII/시크릿 없음

## AI 작업 기록
- 사용한 프롬프트/지시 요약: CI/CD 속도 개선 분석 + 로컬 실험 후 효과 검증
- 변경 파일: backend-ci.yml, backend-cd.yml, Dockerfile
- 사람이 수동 검증: Phase 1 효과 미미 발견 후 폐기 결정 (사용자 합의)
- 잔여 리스크: workflow/Dockerfile 변경 효과는 머지 후에야 측정. 미미하면 revert

</details>