### PR TITLE
 refactor(user): 연동 해제 API 코드 리뷰 피드백 반영 (#336)                 

### DIFF
--- a/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
+++ b/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
@@ -62,13 +62,13 @@ public class CareRelationController {
         return ResponseEntity.ok(loginResponse);
     }
 
-    @DeleteMapping("/care-relations/seniors/{seniorId}")
     @PreAuthorize("hasRole('CAREGIVER')")
-    public ResponseEntity<Void> unlinkSenior(
+    @DeleteMapping("/care-relations/seniors/{seniorId}")
+    public ResponseEntity<Void> removeSeniorRelation(
             @AuthenticationPrincipal final Long userId,
             @PathVariable final Long seniorId
     ) {
-        careRelationService.unlinkSenior(userId, seniorId);
+        careRelationService.removeSeniorRelation(userId, seniorId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -70,11 +70,8 @@ public class AuthService {
             throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
         }
 
-        if (user.getRole() == null) {
-            user.assignRole(UserRole.CAREGIVER);
-        }
-
-        final String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());
+        final String roleName = user.getRole() != null ? user.getRole().name() : null;
+        final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
         final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
         saveRefreshToken(user.getId(), refreshTokenValue);
 

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -113,7 +113,7 @@ public class CareRelationService {
     }
 
     @Transactional
-    public void unlinkSenior(final Long caregiverId, final Long seniorId) {
+    public void removeSeniorRelation(final Long caregiverId, final Long seniorId) {
         final CareRelation careRelation = careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
                 caregiverId, seniorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));


### PR DESCRIPTION
                                                 
  ## AS-IS                                                
  - 어노테이션 순서 피라미드 컨벤션 미준수              
  - 메서드명 unlinkSenior가 delete/remove 네이밍 컨벤션과
  불일치                                                  
  - AuthService에 불필요한 role null 방어 코드 잔존       
                                                          
  ## TO-BE                                                
  - `@PreAuthorize` → `@DeleteMapping` 어노테이션 피라미드
   순서 적용                                              
  - `unlinkSenior` → `removeSeniorRelation`으로 메서드명  
  변경 (서비스 + 컨트롤러)                              
  - AuthService role null 방어 코드 제거 (DB 초기화 예정, 
  재발 경로 없음)                                        
                                                          
  ## 관련 이슈    
  - #336                                                  
                  
  ## 라벨 부여 확인                                     
  - [x] `type:refactor` 라벨 1개 부여 완료                
  - [x] `scope:user` 라벨 1개 부여 완료   
  - [x] `ai-generated` 라벨 부여 완료                     
  - [x] (보호 영역 변경 시) `needs-human-review` — 해당   
  없음                                                    
                                                          

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Kakao 로그인 인증 시 권한 정보 처리의 안정성을 개선했습니다.

* **개선사항**
  * 보호자-대상자 간의 관계 제거 기능의 일관성과 신뢰성을 강화했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/338)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->