### PR TITLE
release: v0.13.0   

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -5,13 +5,20 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+# 동시 배포 직렬화 — 새 push 와도 옛 배포는 끝까지 진행 (cancel-in-progress: false)
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -13,9 +13,14 @@ permissions:
   checks: write
   pull-requests: write
 
+# 같은 PR에 새 push 시 진행 중인 워크플로우 취소 (러너 자원 절약 + 결과 빠르게)
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     services:
       mysql:
@@ -30,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM gradle:9.4-jdk21 AS build
 WORKDIR /app
 
+# 의존성 레이어 분리 — build 파일만 먼저 COPY해서 dependencies 다운로드 결과를
+# Docker 레이어 캐시로 보존. 소스 변경만 있으면 의존성 재다운로드 skip.
 COPY build.gradle settings.gradle /app/
-
-RUN gradle build -x test --no-daemon > /dev/null 2>&1 || true
+RUN gradle dependencies --no-daemon > /dev/null 2>&1 || true
 
 COPY config /app/config
 COPY src /app/src
 
-RUN gradle clean bootJar -x test -x checkstyleMain -x checkstyleTest --no-daemon
+# 위 레이어에서 가져온 의존성/빌드 결과를 보존하도록 clean 제거.
+# 소스가 바뀐 부분만 컴파일.
+RUN gradle bootJar -x test -x checkstyleMain -x checkstyleTest --no-daemon
 
 FROM eclipse-temurin:21-jre
 WORKDIR /app

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -62,7 +62,10 @@ public enum ErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_001", "Notification not found"),
     NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_002", "Cannot access another user's notification"),
     DEVICE_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_003", "Device token not found"),
-    DEVICE_TOKEN_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_004", "Cannot access another user's device token");
+    DEVICE_TOKEN_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_004", "Cannot access another user's device token"),
+
+    // User Withdraw
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER_003", "User already deleted");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "User not found"),
     MEAL_TIMES_NOT_SET(HttpStatus.BAD_REQUEST, "USER_002", "Meal times are not set for the senior"),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER_003", "User already deleted"),
 
     // Medicine
     MEDICINE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEDICINE_001", "Medicine not found"),
@@ -62,10 +63,7 @@ public enum ErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_001", "Notification not found"),
     NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_002", "Cannot access another user's notification"),
     DEVICE_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_003", "Device token not found"),
-    DEVICE_TOKEN_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_004", "Cannot access another user's device token"),
-
-    // User Withdraw
-    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER_003", "User already deleted");
+    DEVICE_TOKEN_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_004", "Cannot access another user's device token");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -107,6 +107,10 @@ public class User extends BaseTimeEntity {
                 nickname, gender, null, null);
     }
 
+    public void assignRole(final UserRole role) {
+        this.role = Objects.requireNonNull(role, "role must not be null");
+    }
+
     public void updateNickname(final String nickname) {
         this.nickname = Objects.requireNonNull(nickname, "nickname must not be null");
     }

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -69,6 +69,9 @@ public class User extends BaseTimeEntity {
     @Column(name = "last_active_at")
     private java.time.LocalDateTime lastActiveAt;
 
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deletedAt;
+
     public User(
             final String loginId,
             final String password,
@@ -126,5 +129,13 @@ public class User extends BaseTimeEntity {
 
     public void touchActiveAt(final java.time.LocalDateTime now) {
         this.lastActiveAt = Objects.requireNonNull(now, "now must not be null");
+    }
+
+    public void softDelete(final java.time.LocalDateTime now) {
+        this.deletedAt = Objects.requireNonNull(now, "now must not be null");
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 }

--- a/src/main/java/com/ppiyaki/user/User.java
+++ b/src/main/java/com/ppiyaki/user/User.java
@@ -13,12 +13,14 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Objects;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "users")
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {
 

--- a/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
+++ b/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
@@ -62,6 +62,16 @@ public class CareRelationController {
         return ResponseEntity.ok(loginResponse);
     }
 
+    @DeleteMapping("/care-relations/seniors/{seniorId}")
+    @PreAuthorize("hasRole('CAREGIVER')")
+    public ResponseEntity<Void> unlinkSenior(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long seniorId
+    ) {
+        careRelationService.unlinkSenior(userId, seniorId);
+        return ResponseEntity.noContent().build();
+    }
+
     @DeleteMapping("/seniors/{seniorId}/logout")
     @PreAuthorize("hasRole('CAREGIVER')")
     public ResponseEntity<Void> forceLogoutSenior(

--- a/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
+++ b/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
@@ -62,13 +62,13 @@ public class CareRelationController {
         return ResponseEntity.ok(loginResponse);
     }
 
-    @DeleteMapping("/care-relations/seniors/{seniorId}")
     @PreAuthorize("hasRole('CAREGIVER')")
-    public ResponseEntity<Void> unlinkSenior(
+    @DeleteMapping("/care-relations/seniors/{seniorId}")
+    public ResponseEntity<Void> removeSeniorRelation(
             @AuthenticationPrincipal final Long userId,
             @PathVariable final Long seniorId
     ) {
-        careRelationService.unlinkSenior(userId, seniorId);
+        careRelationService.removeSeniorRelation(userId, seniorId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/ppiyaki/user/controller/UserController.java
+++ b/src/main/java/com/ppiyaki/user/controller/UserController.java
@@ -6,12 +6,15 @@ import com.ppiyaki.user.controller.dto.MealTimesUpdateRequest;
 import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.service.UserService;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -39,5 +42,11 @@ public class UserController {
             @Valid @RequestBody final MealTimesUpdateRequest request
     ) {
         return ResponseEntity.ok(userService.updateMealTimes(userId, request));
+    }
+
+    @DeleteMapping("/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void withdraw(@AuthenticationPrincipal final Long userId) {
+        userService.withdraw(userId);
     }
 }

--- a/src/main/java/com/ppiyaki/user/controller/UserController.java
+++ b/src/main/java/com/ppiyaki/user/controller/UserController.java
@@ -6,7 +6,6 @@ import com.ppiyaki.user.controller.dto.MealTimesUpdateRequest;
 import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.service.UserService;
 import jakarta.validation.Valid;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -45,8 +43,8 @@ public class UserController {
     }
 
     @DeleteMapping("/me")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void withdraw(@AuthenticationPrincipal final Long userId) {
+    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal final Long userId) {
         userService.withdraw(userId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -66,6 +66,10 @@ public class AuthService {
                         .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND)))
                 .orElseGet(() -> createNewUser(payload, providerUserId));
 
+        if (user.isDeleted()) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
+        }
+
         final String roleName = user.getRole() != null ? user.getRole().name() : null;
         final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
         final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
@@ -111,6 +115,10 @@ public class AuthService {
         if (user.getPassword() == null
                 || !passwordEncoder.matches(loginRequest.password(), user.getPassword())) {
             throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        }
+
+        if (user.isDeleted()) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
         }
 
         final String roleName = user.getRole() != null ? user.getRole().name() : null;

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -70,12 +70,15 @@ public class AuthService {
             throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
         }
 
-        final String roleName = user.getRole() != null ? user.getRole().name() : null;
-        final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
+        if (user.getRole() == null) {
+            user.assignRole(UserRole.CAREGIVER);
+        }
+
+        final String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());
         final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
         saveRefreshToken(user.getId(), refreshTokenValue);
 
-        final boolean isOnboarded = user.getRole() != null;
+        final boolean isOnboarded = user.getNickname() != null;
 
         return new LoginResponse(accessToken, refreshTokenValue, isOnboarded);
     }

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -70,11 +70,8 @@ public class AuthService {
             throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
         }
 
-        if (user.getRole() == null) {
-            user.assignRole(UserRole.CAREGIVER);
-        }
-
-        final String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());
+        final String roleName = user.getRole() != null ? user.getRole().name() : null;
+        final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
         final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
         saveRefreshToken(user.getId(), refreshTokenValue);
 

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -113,7 +113,7 @@ public class CareRelationService {
     }
 
     @Transactional
-    public void unlinkSenior(final Long caregiverId, final Long seniorId) {
+    public void removeSeniorRelation(final Long caregiverId, final Long seniorId) {
         final CareRelation careRelation = careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
                 caregiverId, seniorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -113,6 +113,15 @@ public class CareRelationService {
     }
 
     @Transactional
+    public void unlinkSenior(final Long caregiverId, final Long seniorId) {
+        final CareRelation careRelation = careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
+                caregiverId, seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+
+        careRelation.softDelete(LocalDateTime.now());
+    }
+
+    @Transactional
     public void forceLogoutSenior(final Long caregiverId, final Long seniorId) {
         careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(caregiverId, seniorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));

--- a/src/main/java/com/ppiyaki/user/service/UserService.java
+++ b/src/main/java/com/ppiyaki/user/service/UserService.java
@@ -3,12 +3,17 @@ package com.ppiyaki.user.service;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.user.CareMode;
+import com.ppiyaki.user.CareRelation;
 import com.ppiyaki.user.User;
+import com.ppiyaki.user.UserRole;
 import com.ppiyaki.user.controller.dto.CareModeResponse;
 import com.ppiyaki.user.controller.dto.MealTimesUpdateRequest;
 import com.ppiyaki.user.controller.dto.UserMeResponse;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,13 +22,16 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final CareRelationRepository careRelationRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public UserService(
             final UserRepository userRepository,
-            final CareRelationRepository careRelationRepository
+            final CareRelationRepository careRelationRepository,
+            final RefreshTokenRepository refreshTokenRepository
     ) {
         this.userRepository = userRepository;
         this.careRelationRepository = careRelationRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
     }
 
     @Transactional
@@ -49,5 +57,42 @@ public class UserService {
 
         user.updateMealTimes(request.breakfast(), request.lunch(), request.dinner());
         return UserMeResponse.from(user);
+    }
+
+    @Transactional
+    public void withdraw(final Long userId) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.isDeleted()) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
+        }
+
+        final LocalDateTime now = LocalDateTime.now();
+
+        if (user.getRole() == UserRole.CAREGIVER) {
+            withdrawCaregiverWithSeniors(user, now);
+        } else {
+            withdrawSingleUser(user, now);
+        }
+    }
+
+    private void withdrawCaregiverWithSeniors(final User caregiver, final LocalDateTime now) {
+        final List<CareRelation> careRelations = careRelationRepository.findByCaregiverIdAndDeletedAtIsNull(caregiver
+                .getId());
+
+        for (final CareRelation relation : careRelations) {
+            final User senior = userRepository.findById(relation.getSeniorId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+            withdrawSingleUser(senior, now);
+            relation.softDelete(now);
+        }
+
+        withdrawSingleUser(caregiver, now);
+    }
+
+    private void withdrawSingleUser(final User user, final LocalDateTime now) {
+        user.softDelete(now);
+        refreshTokenRepository.deleteByUserId(user.getId());
     }
 }


### PR DESCRIPTION
                 
  ### feat                                                
  - **(user)** 회원 탈퇴 API 구현 — 소프트 딜리트 +
  보호자-시니어 연쇄 삭제 (#322) — `DELETE                
  /api/v1/users/me`, 시니어는 본인만 soft delete, 보호자는
   연동 시니어도 함께 삭제 + refresh token 폐기           
  - **(user)** 보호자-시니어 연동 해제 API 구현 (#336) —  
  `DELETE /api/v1/care-relations/seniors/{seniorId}`,   
  CareRelation soft delete                                
                          
  ### refactor                                            
  - **(user)** User 엔티티에
  `@AllArgsConstructor(PACKAGE)` 추가 (#322) — 코딩     
  가이드라인 준수                                         
  - **(user)** UserController 탈퇴 API 반환 타입
  `ResponseEntity`로 통일 (#322)                          
  - **(user)** 연동 해제 API 어노테이션 피라미드 순서 +
  메서드명 `removeSeniorRelation` 컨벤션 적용 (#336)    
                                                          
  ### chore
  - **(infra)** CI/CD 속도 개선 — workflow concurrency +  
  ubuntu 고정 + Dockerfile 의존성 레이어 분리 (#334)    
                                                          
  ---
                                                          
  ### 🔧 prod 수동 마이그레이션 (PR 머지 전에 실행 필수)
                                                          
  `ddl-auto=validate`라 컬럼 부재 시 부트 fail. release
  머지 직전 실행:                                         
                  
  ```sql                                                  
  ALTER TABLE users ADD COLUMN deleted_at DATETIME(6)
  NULL;                                                 
                                                          
  프론트 cut-over 안내
                                                          
  - 회원 탈퇴: DELETE /api/v1/users/me → 204 No Content.  
  탈퇴 후 로그인 시 400 USER_003                          
  - 연동 해제: DELETE                                     
  /api/v1/care-relations/seniors/{seniorId} → 204 No      
  Content. 보호자 전용                                  
  - 인가: 탈퇴 유저 재로그인 시 USER_003 ("User already   
  deleted") 반환                                          
                                                        
  ---                                                     
  Post-merge Checklist
                                                          
  - prod DB 마이그레이션 SQL 적용 (release 머지 직후)
  - CD 자동 배포 완료 + ppiyaki-server 컨테이너 startup   
  정상 검증                                               
  - git tag -a v0.13.0 -m "release v0.13.0" && git push   
  origin v0.13.0                                          
  - gh release create v0.13.0 --generate-notes          
                                                          
  **라벨:** `type:chore`, `scope:infra`
                                                          
  **머지 방식:** Merge commit (Squash 금지)               
                                                          
  **주의:** `develop` 브랜치 삭제하지 않음      