### PR TITLE
fix(medication): 대시보드 모든 슬롯 NOT_SCHEDULED 일자 dayStatus 통일

### DIFF
--- a/docs/features/caregiver-dashboard.md
+++ b/docs/features/caregiver-dashboard.md
@@ -93,15 +93,16 @@ last_reviewed: 2026-05-08
 일자 안의 모든 슬롯을 보고 1개 status로 축약:
 | 값 | 룰 |
 |---|---|
-| `PERFECT` | 모든 schedule된 슬롯이 PERFECT |
+| `PERFECT` | 1개 이상 schedule된 슬롯이 있고 모두 PERFECT |
 | `DELAYED` | DELAYED 슬롯 1개 이상, MISSED 0 |
 | `MISSED` | MISSED 슬롯 1개 이상 (자정 경과 후만 발생) |
 | `PENDING` | PENDING 슬롯 1개 이상, MISSED 0, DELAYED 0 (오늘 진행 중) |
 | `FUTURE` | date > today |
+| `NOT_SCHEDULED` | 가입 이전 날짜(#326) **또는** 모든 슬롯이 `NOT_SCHEDULED`인 일자(#340) |
 
 비고:
 - "오늘"의 status는 frontend isToday 플래그로 추가 강조 (디자인 image2의 25일). backend는 룰 그대로.
-- 시니어 mealTimes가 null이라 모든 슬롯이 `NOT_SCHEDULED`인 일자는 `PERFECT`로 간주(분모 0). 또는 별도 `EMPTY` 추가 — TBD(§8 Q1).
+- 모든 슬롯이 `NOT_SCHEDULED`(mealTimes null 또는 schedule 없음)인 일자는 `NOT_SCHEDULED`로 표시 — 슬롯/일자 의미가 일관되도록 §8 Q1 (c) 채택 (#340, 2026-05-13).
 
 ### 5-3) API 엔드포인트
 
@@ -238,7 +239,7 @@ weekly/monthly는 4~6 단계를 기간으로 확장, status만 도출.
 ## 8) 오픈 질문
 | # | 질문 | 선택지 | 담당/기한 |
 |---|---|---|---|
-| Q1 | 시니어 mealTimes 미설정 일자(모든 슬롯 NOT_SCHEDULED)의 dayStatus | (a) PERFECT (분모 0이라 완벽 간주) / (b) 별도 `EMPTY` enum 추가 / (c) `NOT_SCHEDULED` 그대로 사용 | @goohong / 구현 시 |
+| ~~Q1~~ | ~~시니어 mealTimes 미설정 일자(모든 슬롯 NOT_SCHEDULED)의 dayStatus~~ | **해소 — (c) `NOT_SCHEDULED` 채택 (#340, 2026-05-13). 가입 전 #326 처리와 일관된 의미.** ✅ |
 | Q2 | dosage 파싱 — "반정"(0.5정) / "2정 반"(2.5정) 같은 소수 표기 | (a) 정수만 — 비정수면 0으로 (단순) / (b) BigDecimal로 정밀 / (c) 파싱 실패 시 fallback dailyConsumption=1 | @goohong / 구현 시 |
 | Q3 | weekly의 weekStart 요일 | (a) 일요일 (한국 캘린더 기본) / (b) 월요일 (ISO 8601) — 디자인 image2 "일/월/화/수…" 순이라 (a)로 보임 | 디자인 측 / 구현 시 |
 | Q4 | monthly 응답에 통합 status 외 추가 정보(예: 슬롯별 마커) | (a) 통합 status enum만(권장) / (b) 슬롯별 마커도 — 응답 크기 증가 | @frontend / 구현 시 |
@@ -254,3 +255,4 @@ weekly/monthly는 4~6 단계를 기간으로 확장, status만 도출.
 - 2026-05-08: MISSED 자동 전환 cron은 본 spec scope 외 — dashboard 응답 시 동적 계산.
 - 2026-05-10 (#294): **Q5 해소** — DELAYED 임계 = 보호자별 `notification_settings.medication_delay_threshold_minutes` 참조. `DashboardService.DELAY_THRESHOLD_MINUTES = 60` 하드코딩 제거 → caller 보호자의 settings 조회. 시니어 본인 caller(userId == seniorId)일 때는 default 60 fallback. medication-notification.md PR 7과 동시 머지.
 - 2026-05-08: 통합 endpoint 신규(daily/weekly/monthly) — 기존 logs/medicines/schedules 합성보다 N+1 호출 부담 감소 + status 룰 일관성.
+- 2026-05-13 (#340): **Q1 해소** — 모든 슬롯이 NOT_SCHEDULED인 일자의 dayStatus를 PERFECT가 아닌 NOT_SCHEDULED로 통일. 기존 #326의 가입 전 처리와 의미적 일관성 확보. `DashboardService.deriveDayStatus(FromMarkers)` 빈 `present` 분기 PERFECT → NOT_SCHEDULED.

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -291,7 +291,7 @@ public class DashboardService {
             }
         }
         if (present.isEmpty()) {
-            return DayStatus.PERFECT;
+            return DayStatus.NOT_SCHEDULED;
         }
         if (present.contains(SlotStatus.MISSED)) {
             return DayStatus.MISSED;
@@ -375,7 +375,7 @@ public class DashboardService {
             }
         }
         if (present.isEmpty()) {
-            return DayStatus.PERFECT;
+            return DayStatus.NOT_SCHEDULED;
         }
         if (present.contains(SlotStatus.MISSED)) {
             return DayStatus.MISSED;

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardDailyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardDailyE2ETest.java
@@ -53,7 +53,7 @@ class DashboardDailyE2ETest {
     }
 
     @Test
-    @DisplayName("시니어 본인 호출 — schedule 없으면 dayStatus=PERFECT, header 채워짐")
+    @DisplayName("시니어 본인 호출 — schedule 없으면 dayStatus=NOT_SCHEDULED, header 채워짐")
     void daily_seniorSelf_emptySchedules() {
         final SignupResult senior = signup("일간시니어");
         setMealTimes(senior.userId(), LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
@@ -67,7 +67,7 @@ class DashboardDailyE2ETest {
                 .statusCode(200)
                 .body("seniorId", is(senior.userId().intValue()))
                 .body("date", is(today.toString()))
-                .body("dayStatus", is("PERFECT"))
+                .body("dayStatus", is("NOT_SCHEDULED"))
                 .body("header.seniorName", is("일간시니어"))
                 .body("header.caregiverName", is("일간시니어"))
                 .body("slots", notNullValue())

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
@@ -46,10 +46,10 @@ class DashboardMonthlyE2ETest {
     }
 
     @Test
-    @DisplayName("시니어 본인 호출 — 현재 월 schedule 없으면 가입일 이후 PERFECT, 가입 이전 NOT_SCHEDULED (issue #326)")
+    @DisplayName("시니어 본인 호출 — 현재 월 schedule 없으면 모든 일자 NOT_SCHEDULED (issue #340)")
     void monthly_seniorSelf_emptySchedules() {
         final SignupResult senior = signup("월간시니어");
-        // 현재 월로 조회 — 가입 후 days는 PERFECT, 가입 전 days는 NOT_SCHEDULED
+        // 현재 월로 조회 — 가입 후/전 모두 schedule이 없으므로 NOT_SCHEDULED. 미래 일자만 FUTURE
         final YearMonth ym = YearMonth.now();
         final int today = LocalDate.now().getDayOfMonth();
 
@@ -62,10 +62,8 @@ class DashboardMonthlyE2ETest {
                 .body("seniorId", is(senior.userId().intValue()))
                 .body("yearMonth", is(ym.toString()))
                 .body("days.size()", is(ym.lengthOfMonth()))
-                // today는 가입일과 동일 → PERFECT (schedule 없음 + 가입 이후)
-                .body("days[" + (today - 1) + "].dayStatus", is("PERFECT"))
-                // 1일은 today보다 이르면 NOT_SCHEDULED, 같으면 PERFECT
-                .body("days[0].dayStatus", is(today > 1 ? "NOT_SCHEDULED" : "PERFECT"));
+                .body("days[" + (today - 1) + "].dayStatus", is("NOT_SCHEDULED"))
+                .body("days[0].dayStatus", is("NOT_SCHEDULED"));
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
@@ -54,7 +54,7 @@ class DashboardWeeklyE2ETest {
     }
 
     @Test
-    @DisplayName("시니어 본인 호출 — 가입 후 날짜 schedule 없으면 PERTECT, 가입 이전은 NOT_SCHEDULED (issue #326)")
+    @DisplayName("시니어 본인 호출 — 스케줄 없는 날짜는 dayStatus=NOT_SCHEDULED (issue #340)")
     void weekly_seniorSelf_emptySchedules() {
         final SignupResult senior = signup("주간시니어");
         setMealTimes(senior.userId(), LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
@@ -72,7 +72,7 @@ class DashboardWeeklyE2ETest {
                 .body("weekEnd", is(weekStart.plusDays(6).toString()))
                 .body("adherenceRate", is(nullValue()))
                 .body("days.size()", is(7))
-                .body("days[0].dayStatus", is("PERFECT"))
+                .body("days[0].dayStatus", is("NOT_SCHEDULED"))
                 .body("days[0].slots", notNullValue())
                 .body("days[0].slots[0].status", is("NOT_SCHEDULED"));
     }

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -71,7 +71,7 @@ class DashboardServiceTest {
         final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
 
         assertThat(resp.seniorId()).isEqualTo(SENIOR_ID);
-        assertThat(resp.dayStatus()).isEqualTo(DayStatus.PERFECT);
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.NOT_SCHEDULED);
     }
 
     @Test
@@ -238,7 +238,7 @@ class DashboardServiceTest {
     }
 
     @Test
-    @DisplayName("weekly — 모든 일자 schedule 없음 → adherenceRate=null, days[7] 모두 PERFECT/NOT_SCHEDULED")
+    @DisplayName("weekly — 모든 일자 schedule 없음 → adherenceRate=null, days[7] 모두 NOT_SCHEDULED")
     void weekly_emptySchedules() throws Exception {
         givenSeniorAndCaregiver();
         givenSeniorMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
@@ -254,7 +254,7 @@ class DashboardServiceTest {
         org.assertj.core.api.Assertions.assertThat(resp.adherenceRate()).isNull();
         org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(7);
         org.assertj.core.api.Assertions.assertThat(resp.days()).allMatch(d -> d.dayStatus()
-                == com.ppiyaki.medication.DayStatus.PERFECT
+                == com.ppiyaki.medication.DayStatus.NOT_SCHEDULED
                 && d.slots().stream().allMatch(s -> s.status() == SlotStatus.NOT_SCHEDULED));
     }
 
@@ -289,7 +289,7 @@ class DashboardServiceTest {
     }
 
     @Test
-    @DisplayName("monthly — schedule 없으면 days 모두 PERFECT (분모 0 케이스)")
+    @DisplayName("monthly — schedule 없으면 days 모두 NOT_SCHEDULED")
     void monthly_emptySchedules() throws Exception {
         givenSeniorAndCaregiver();
         givenSeniorMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
@@ -303,7 +303,7 @@ class DashboardServiceTest {
         org.assertj.core.api.Assertions.assertThat(resp.yearMonth()).isEqualTo(ym);
         org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(31);
         org.assertj.core.api.Assertions.assertThat(resp.days())
-                .allMatch(d -> d.dayStatus() == com.ppiyaki.medication.DayStatus.PERFECT);
+                .allMatch(d -> d.dayStatus() == com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
     }
 
     @Test
@@ -323,7 +323,7 @@ class DashboardServiceTest {
         // when
         final var resp = dashboardService.getWeekly(SENIOR_ID, SENIOR_ID, weekStart);
 
-        // then — 처음 3일(weekStart, +1, +2)는 NOT_SCHEDULED, 나머지 4일은 PERFECT(스케줄 없음)
+        // then — 처음 3일(weekStart, +1, +2)는 가입 전 shortcut으로 NOT_SCHEDULED, 나머지 4일은 schedule 없음으로 NOT_SCHEDULED
         org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(7);
         for (int i = 0; i < 3; i++) {
             org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
@@ -333,7 +333,7 @@ class DashboardServiceTest {
         }
         for (int i = 3; i < 7; i++) {
             org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
-                    .isEqualTo(com.ppiyaki.medication.DayStatus.PERFECT);
+                    .isEqualTo(com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
         }
     }
 
@@ -352,14 +352,14 @@ class DashboardServiceTest {
         final java.time.YearMonth ym = java.time.YearMonth.of(2026, 1);
         final var resp = dashboardService.getMonthly(SENIOR_ID, SENIOR_ID, ym);
 
-        // then — 1~14일은 NOT_SCHEDULED, 15일부터 PERFECT
+        // then — 1~14일은 가입 전 shortcut, 15일부터 schedule 없음. 둘 다 NOT_SCHEDULED
         org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(31);
         for (int i = 0; i < 14; i++) {
             org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
                     .isEqualTo(com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
         }
         org.assertj.core.api.Assertions.assertThat(resp.days().get(14).dayStatus())
-                .isEqualTo(com.ppiyaki.medication.DayStatus.PERFECT);
+                .isEqualTo(com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
     }
 
     @Test


### PR DESCRIPTION
## AS-IS
가입 이후이지만 해당 일자에 schedule이 없는 경우, 슬롯은 전부 `NOT_SCHEDULED`인데 `dayStatus`만 `PERFECT`로 반환됨 (운영 보고).

```
{ "date": "2026-05-13", "dayStatus": "PERFECT",
  "slots": [
    { "slot": "BREAKFAST", "status": "NOT_SCHEDULED" },
    { "slot": "LUNCH",     "status": "NOT_SCHEDULED" },
    { "slot": "DINNER",    "status": "NOT_SCHEDULED" } ] }
```

원인: `DashboardService.deriveDayStatus(FromMarkers)` — present(SlotStatus.NOT_SCHEDULED 제외) set이 비면 PERFECT 반환.

## TO-BE
모든 슬롯이 `NOT_SCHEDULED`인 일자(가입 이전 #326 / 가입 이후 schedule 부재 둘 다) → `dayStatus = NOT_SCHEDULED`.

- spec §5-2 DayStatus 표에 `NOT_SCHEDULED` 룰 명시
- §8 Q1 해소 — (c) 채택 (#340, 2026-05-13)
- 프론트는 회색/빈 셀 처리 통일 가능

## 관련 이슈
- closes #340

## 리뷰어 참고 포인트
- spec docs/features/caregiver-dashboard.md §5-2, §8, §9 동시 갱신
- 단위 테스트 5건 / E2E 3건의 단정값 일괄 갱신 (PERFECT → NOT_SCHEDULED)
- 가입 전 시간 분기(`weekly_beforeRegistration` / `monthly_beforeRegistration`)는 두 코드 경로(shortcut vs deriveDayStatusFromMarkers)가 동일 결과를 내므로 단정 단순화

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료
- [x] `scope:*` 라벨 1개 부여 완료
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 — 해당 없음

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 변경 범위의 회귀 가능 구간을 확인했다.
- [x] 롤백 절차: 단일 커밋 revert로 충분 (응답 값 변경만, 스키마 변경 없음).

## DDD/OOP 준수 체크
- [x] 도메인 용어가 기존 컨텍스트와 일치한다 (DayStatus enum 변경 없음).
- [x] 계층 침범 없음.
- [x] 객체 역할 변경 없음.

## 보안/민감정보 체크
- [x] 시크릿 하드코딩 없음.
- [x] 의료정보 노출 없음.

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 운영 로그에서 dayStatus=PERFECT인데 slots 전부 NOT_SCHEDULED인 버그 보고. 사용자가 spec Q1 (c) 채택 결정.
- AI가 직접 수정한 파일/범위: DashboardService.java(2개 분기), 단위 테스트(5건), E2E(3건), spec(§5-2/§8/§9)
- 사람이 수동 검증한 항목: spec Q1 결정 채택
- 잔여 리스크: 프론트 측에서 dayStatus=NOT_SCHEDULED인 일자에 대한 렌더링 처리 필요 (#326으로 이미 도입된 enum 값이므로 신규 enum은 아님)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 약물 일정이 할당되지 않은 날의 대시보드 상태 표시 개선: 이제 "완벽함" 대신 "미예약됨"으로 정확하게 표시됩니다.
  * 일일, 주간, 월간 대시보드 보기에서 일정 누락 시 올바른 상태를 반영하도록 수정되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/341)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->