### PR TITLE
fix(medication): 사진 인증 AI COUNT_MATCH 시 슬롯 전체 자동 TAKEN 전파

### DIFF
--- a/docs/features/medication-log-phase2.md
+++ b/docs/features/medication-log-phase2.md
@@ -114,7 +114,11 @@ public enum LogAiStatus {
               ├─ actualCount == expectedCount → COUNT_MATCH
               └─ != → COUNT_MISMATCH
        5. medication_log.ai_status 갱신 후 저장
-       6. 응답 200 + aiStatus 포함 (PUT 응답 시간: 평소 + 5~10s)
+       6. ai_status == COUNT_MATCH → 슬롯의 다른 active schedule들도 TAKEN 전파 (issue #343)
+          - 각 peer schedule에 medication_log upsert (이미 TAKEN이면 skip, 멱등)
+          - 새로 TAKEN 전환되는 peer의 medicine.remainingAmount 차감
+          - peer log의 ai_status = COUNT_MATCH (슬롯 전체가 검증된 상태이므로)
+       7. 응답 200 + aiStatus 포함 (PUT 응답 시간: 평소 + 5~10s)
 ```
 
 ### 5-5) DB 마이그레이션
@@ -176,3 +180,4 @@ public enum LogAiStatus {
 - 2026-05-07: v0.9.0 (#225) — 기대 카운트 산출 키를 `scheduledTime` → `mealSlot`으로 전환. schedule 모델 변경에 따른 자연 후속.
 - 2026-04-30: **dosage 파싱 = 정규식 `(\d+)` 첫 매치** — 단순 / 실패 시 `COUNT_UNKNOWN`로 fallback. "반알" 등은 검증 불가로 처리.
 - 2026-04-30: **결과 알림은 Phase 2 범위 외** — `ai_status` 갱신만 하고, FCM 푸시는 별도 spec 의존.
+- 2026-05-13 (#343): **COUNT_MATCH 시 슬롯 전체 인증 전파** — 사용자가 사진 1장으로 슬롯 전체 약을 인증한 의도. 트리거 schedule 외 peer schedule들에도 TAKEN log 생성 + 잔여분 차감. 멱등(이미 TAKEN이면 skip). 미반영 시 보호자에게 미인증 schedule만큼 지연 알림이 발송되어 사용자 인식과 모순(prod 운영 보고).

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -148,9 +148,63 @@ public class MedicationLogService {
                 && request.photoObjectKey() != null && !request.photoObjectKey().isBlank()) {
             final LogAiStatus aiStatus = verifyPillCount(seniorId, schedule, request);
             log.updateAiStatus(aiStatus);
+            // COUNT_MATCH일 때 슬롯의 다른 active schedule도 TAKEN 전파 (issue #343).
+            // 시니어가 슬롯 전체 약을 사진 한 장에 담아 인증한 경우 == 슬롯 전체 인증으로 인정.
+            if (aiStatus == LogAiStatus.COUNT_MATCH) {
+                propagateTakenToSlotSchedules(seniorId, schedule, request, takenAt, isProxy, userId);
+            }
         }
 
         return MedicationLogResponse.from(log, photoUrlAssembler.toFullUrl(log.getPhotoObjectKey()));
+    }
+
+    /**
+     * 동일 슬롯의 다른 active schedule들에 TAKEN log 전파 (issue #343).
+     * spec medication-log-phase2 §5-4: AI COUNT_MATCH 시 슬롯 전체 인증으로 인정.
+     *
+     * <p>이미 TAKEN인 row는 skip (멱등). 새로 TAKEN 전환되는 schedule의 medicine 잔여분도 차감.
+     * propagated log의 aiStatus는 COUNT_MATCH로 마킹 (슬롯 전체가 검증된 상태이므로).
+     */
+    private void propagateTakenToSlotSchedules(
+            final Long seniorId,
+            final MedicationSchedule triggerSchedule,
+            final MedicationLogUpsertRequest request,
+            final LocalDateTime takenAt,
+            final boolean isProxy,
+            final Long recorderId
+    ) {
+        final List<MedicationSchedule> slotSchedules = medicationScheduleRepository
+                .findActiveByOwnerAndMealSlot(
+                        seniorId, request.targetDate(), triggerSchedule.getMealSlot());
+        for (final MedicationSchedule peer : slotSchedules) {
+            if (peer.getId().equals(triggerSchedule.getId())) {
+                continue;
+            }
+            final Optional<MedicationLog> existing = medicationLogRepository
+                    .findByScheduleIdAndTargetDate(peer.getId(), request.targetDate());
+            final LogStatus previousStatus = existing.map(MedicationLog::getStatus).orElse(null);
+            if (previousStatus == LogStatus.TAKEN) {
+                continue;
+            }
+            final MedicationLog peerLog = existing
+                    .map(found -> {
+                        found.updateRecord(takenAt, LogStatus.TAKEN, request.photoObjectKey(), isProxy, recorderId);
+                        return found;
+                    })
+                    .orElseGet(() -> medicationLogRepository.saveAndFlush(new MedicationLog(
+                            seniorId, peer.getId(), request.targetDate(),
+                            takenAt, LogStatus.TAKEN, request.photoObjectKey(), isProxy, recorderId)));
+            peerLog.updateAiStatus(LogAiStatus.COUNT_MATCH);
+
+            final BigDecimal dosageQuantity = peer.getDosageQuantity();
+            if (dosageQuantity != null) {
+                final int dosageCount = dosageQuantity.setScale(0, java.math.RoundingMode.CEILING).intValueExact();
+                if (dosageCount > 0) {
+                    medicineRepository.findById(peer.getMedicineId())
+                            .ifPresent(m -> m.decreaseRemainingAmount(dosageCount));
+                }
+            }
+        }
     }
 
     /**

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -163,6 +163,105 @@ class MedicationLogServicePhase2Test {
     }
 
     @Test
+    @DisplayName("COUNT_MATCH 시 슬롯의 다른 active schedule도 TAKEN 전파 (issue #343)")
+    void count_match_propagates_to_peers() throws Exception {
+        // given: trigger schedule(1정) + peer schedule(2L, 1정), Vision=2 → COUNT_MATCH
+        final Long peerScheduleId = 2L;
+        final Long peerMedicineId = 11L;
+        final MedicationSchedule triggerSchedule = buildSchedule(SCHEDULE_ID, "1정");
+        final MedicationSchedule peerSchedule = buildSchedule(peerScheduleId, "1정");
+        setField(peerSchedule, "medicineId", peerMedicineId);
+
+        when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(triggerSchedule));
+        final Medicine triggerMedicine = new Medicine(SENIOR_ID, null, "트리거약", 30, 30, "ITEM-1", null);
+        setField(triggerMedicine, "id", MEDICINE_ID);
+        when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(triggerMedicine));
+        final Medicine peerMedicine = new Medicine(SENIOR_ID, null, "피어약", 30, 30, "ITEM-2", null);
+        setField(peerMedicine, "id", peerMedicineId);
+        when(medicineRepository.findById(peerMedicineId)).thenReturn(Optional.of(peerMedicine));
+
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(peerScheduleId, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn("https://example.com/" + VALID_OBJECT_KEY);
+        givenSiblingSchedules(List.of(triggerSchedule, peerSchedule));
+        givenS3Returns(new byte[]{1, 2, 3});
+        when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(2));
+
+        // when
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        // then — trigger + peer 모두 TAKEN log 저장 (saveAndFlush 2번)
+        final ArgumentCaptor<MedicationLog> captor = ArgumentCaptor.forClass(MedicationLog.class);
+        verify(medicationLogRepository, org.mockito.Mockito.times(2)).saveAndFlush(captor.capture());
+        final List<MedicationLog> savedLogs = captor.getAllValues();
+        assertThat(savedLogs).hasSize(2);
+        assertThat(savedLogs).allMatch(l -> l.getStatus() == LogStatus.TAKEN);
+        assertThat(savedLogs.stream().map(MedicationLog::getScheduleId))
+                .containsExactlyInAnyOrder(SCHEDULE_ID, peerScheduleId);
+        // peer의 medicine 잔여분도 차감 (30 → 29)
+        assertThat(peerMedicine.getRemainingAmount()).isEqualTo(29);
+    }
+
+    @Test
+    @DisplayName("COUNT_MISMATCH 시 슬롯의 다른 schedule에 전파 안 함")
+    void count_mismatch_no_propagate() throws Exception {
+        givenScheduleAndMedicine();
+        givenUpsertSucceeds();
+        givenSiblingSchedules(List.of(buildSchedule(SCHEDULE_ID, "1정"), buildSchedule(2L, "1정")));
+        givenS3Returns(new byte[]{1});
+        when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(1));
+
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        // saveAndFlush는 trigger schedule 1번만 호출 (peer는 호출 X)
+        verify(medicationLogRepository, org.mockito.Mockito.times(1)).saveAndFlush(any(MedicationLog.class));
+    }
+
+    @Test
+    @DisplayName("COUNT_MATCH지만 peer가 이미 TAKEN이면 skip (멱등)")
+    void count_match_skip_already_taken_peer() throws Exception {
+        // given
+        final Long peerScheduleId = 2L;
+        final Long peerMedicineId = 11L;
+        final MedicationSchedule triggerSchedule = buildSchedule(SCHEDULE_ID, "1정");
+        final MedicationSchedule peerSchedule = buildSchedule(peerScheduleId, "1정");
+        setField(peerSchedule, "medicineId", peerMedicineId);
+
+        when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(triggerSchedule));
+        final Medicine triggerMedicine = new Medicine(SENIOR_ID, null, "트리거약", 30, 30, "ITEM-1", null);
+        setField(triggerMedicine, "id", MEDICINE_ID);
+        when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(triggerMedicine));
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        // peer는 이미 TAKEN log 있음
+        final MedicationLog existingPeerLog = new MedicationLog(
+                SENIOR_ID, peerScheduleId, TARGET_DATE,
+                java.time.LocalDateTime.of(TARGET_DATE, java.time.LocalTime.of(8, 0)),
+                LogStatus.TAKEN, null, false, SENIOR_ID);
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(peerScheduleId, TARGET_DATE))
+                .thenReturn(Optional.of(existingPeerLog));
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn("https://example.com/" + VALID_OBJECT_KEY);
+        givenSiblingSchedules(List.of(triggerSchedule, peerSchedule));
+        givenS3Returns(new byte[]{1, 2, 3});
+        when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(2));
+
+        // when
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        // then — trigger schedule만 save, peer는 이미 TAKEN이라 skip
+        verify(medicationLogRepository, org.mockito.Mockito.times(1)).saveAndFlush(any(MedicationLog.class));
+    }
+
+    @Test
     @DisplayName("png objectKey면 mediaType=image/png 전달")
     void png_media_type() throws Exception {
         givenScheduleAndMedicine();


### PR DESCRIPTION
## AS-IS
시니어가 슬롯의 약 N개를 사진 한 장으로 인증해도 `medication_log`는 `request.scheduleId()` 단일 schedule에만 TAKEN row 생성. 나머지 N-1 schedule은 미인증 상태로 남아 dispatcher가 schedule별로 지연 알림 N-1건 발송.

운영 사례 (prod 데이터):
- 시니어 38, BREAKFAST schedule 4개(43/46/48/50), 사진 인증 10:56:41
- `medication_log`엔 schedule 43만 TAKEN 1건 생성
- 11:00 dispatcher가 46/48/50 미인증으로 판단 → 보호자에게 알림 3건 발송

## TO-BE
`verifyPillCount` 결과가 `LogAiStatus.COUNT_MATCH`일 때 슬롯의 다른 active schedule들도 자동 TAKEN 처리.

- spec `medication-log-phase2.md`의 슬롯 통합 의도와 일치
- 사용자(시니어/보호자) 입장: 한 사진 인증 = 슬롯 전체 인증으로 자연스러움
- 미인증 알림 모순 자동 해소

## 관련 이슈
- closes #343
- 관련 Discord 백로그: 복약 지연 알림 오류, FCM 푸시알림 오지 않음 (둘 다 같은 근본 원인)
- 폐기: #342 (알림 슬롯 통합) — root cause가 알림 측이 아니라 인증 측으로 판명되어 close

## 리뷰어 참고 포인트
- `propagateTakenToSlotSchedules`: COUNT_MATCH 시에만 호출. trigger schedule은 본문 로직에서 이미 처리되므로 skip.
- 멱등성: 이미 TAKEN인 peer는 skip → 같은 요청 재시도 안전
- 잔여분 차감: 새로 TAKEN 전환되는 peer만 (이미 TAKEN이면 차감 X)
- aiStatus: peer log에도 COUNT_MATCH 마킹 (슬롯 전체가 검증된 상태이므로)
- 기존 COUNT_MISMATCH / COUNT_UNKNOWN / COUNT_FAILED 케이스는 동작 변경 없음

## 라벨 부여 확인
- [x] `type:fix` 라벨 부여
- [x] `scope:medication` 라벨 부여
- [x] `ai-generated` 라벨 부여
- [ ] 보호 영역 변경 없음 → `needs-human-review` 불필요

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 변경 범위의 회귀 가능 구간 확인 (`MedicationLogServicePhase2Test` 7건 모두 통과)
- [x] 롤백 절차: 단일 커밋 revert. DB schema 변경 없음, application 레이어 로직만 추가.

## DDD/OOP 준수 체크
- [x] 도메인 용어 유지 (MedicationLog, MedicationSchedule, LogAiStatus)
- [x] 계층 침범 없음 (Service → Repository)
- [x] 객체 역할 변경 없음

## 보안/민감정보 체크
- [x] 시크릿 하드코딩 없음
- [x] 의료정보 노출 없음

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- prod DB 직접 조회로 root cause 확정 (schedule 43만 인증, 46/48/50 미인증)
- 사용자 결정: AI 검증 약 개수 일치 시 슬롯 전체 인정 정책 채택
- AI가 직접 수정한 파일: MedicationLogService(propagate 메서드 추가), Phase2 spec(§5-4 흐름 + §9 결정 로그), 단위 테스트 3건
- 사람이 수동 검증한 항목: 정책 결정, prod 데이터 사실 확인
- 잔여 리스크: peer log의 aiStatus = COUNT_MATCH 마킹이 의미 명확화 필요할 경우 별도 enum 값(COUNT_MATCH_PROPAGATED 등) 추가 검토 가능 (현재는 단순화 위해 동일 값 사용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * AI 약물 개수 확인이 일치할 때, 같은 식사 시간의 관련 활성 약물 일정에 자동으로 복용 상태를 전파하도록 개선되었습니다.

* **Documentation**
  * Phase 2 약물 로그 기능 동작 명세를 업데이트했습니다.

* **Tests**
  * 약물 전파 동작을 검증하는 테스트 케이스 3개를 추가했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/344)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->