### PR TITLE
chore(infra): prod Hikari leak-detection-threshold 60s 활성화

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,6 +4,10 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      # 60s 이상 빌려간 채 반환 안 된 connection의 stack trace 로그 (진단용, issue #346).
+      # 시연 직전 12:14~13:25 pool 고갈 사고 재발 시 leak 위치 즉시 확정 목적.
+      leak-detection-threshold: 60000
   jpa:
     hibernate:
       ddl-auto: ${JPA_DDL_AUTO:validate}


### PR DESCRIPTION
## AS-IS
2026-05-13 시연 직전 prod에서 HikariCP pool 고갈 사고:
- 12:14 ~ 13:25 약 70분간 모든 DB connection이 active 상태로 잡혀 timeout
- 첫 SQL 에러 thread = `[undedElastic-13]` (Reactor boundedElastic) — chat stream/MCP tool 흐름 강한 의심
- MySQL processlist는 10개 모두 Sleep + 트랜잭션 X 상태 (= Hikari 측에서만 active로 카운트되는 leak 패턴)
- 컨테이너 재시작으로 회복

**stack trace 없어 어느 라인이 leak했는지 단정 불가**.

## TO-BE
`application-prod.yml`에 `spring.datasource.hikari.leak-detection-threshold: 60000` 1줄 추가. 60초 이상 보유된 connection 발생 시 빌린 thread의 stack trace가 WARN 로그로 출력 → 재발 시 즉시 위치 확정.

진단 도구이며 동작 변경 없음.

## 관련 이슈
- closes #346
- 관련: 2026-05-13 사고 (Discord 백로그 발생은 안 함, prod 사고 → 즉시 컨테이너 재시작)

## 리뷰어 참고 포인트
- `application-prod.yml`만 수정. local/test 환경 영향 없음.
- 60s threshold는 일반적인 short-lived JPA 호출에는 false positive 안 남는 안전한 값
- 로그 양 미증가 — leak 발생 시에만 출력
- Hikari 6.x 공식 권장 진단 옵션

## 라벨 부여 확인
- [x] `type:chore` 라벨 부여
- [x] `scope:infra` 라벨 부여
- [x] `ai-generated` 라벨 부여
- [x] (보호 영역 `application*.yml` 변경) `needs-human-review` 라벨 부여

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] yml 단순 추가 — 신규 테스트 불필요 (build/run 영향 없음)
- [x] 롤백 절차: 단일 커밋 revert. 즉시 안전.

## DDD/OOP 준수 체크
- N/A (yml 설정만)

## 보안/민감정보 체크
- [x] 시크릿 하드코딩 없음
- [x] 민감정보 노출 없음

## 예외 머지 여부
- [x] 예외 머지 아님 — 다만 운영 진단 목적이라 가급적 빠른 머지 권장 (다음 재발 시 진단 가능하려면 prod에 적용되어 있어야 함)

## AI 작업 기록
- prod 컨테이너/MySQL 직접 진단으로 leak 패턴 + 의심 영역 식별
- 정확한 위치 확정 불가 → 진단 도구 활성화 PR
- AI가 직접 수정한 파일: application-prod.yml (1 hunk)
- 사람이 수동 검증한 항목: leak 가설 / 진단 우선 접근 결정
- 잔여 리스크: 60s threshold는 보수적 값. 만약 정상 long-running query가 있으면 false positive 가능 (현재 코드에 그런 패턴 없음 — OpenAI 10s, S3 30s, FCM 미상이나 일반적으로 짧음)