### PR TITLE
fix(medication): 복약 지연 알림 메시지에 약 이름 + 복용량 포함

### DIFF
--- a/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
@@ -6,6 +6,8 @@ import com.ppiyaki.medication.MedicationLog;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.notification.DeviceToken;
 import com.ppiyaki.notification.Notification;
 import com.ppiyaki.notification.NotificationCategory;
@@ -47,6 +49,7 @@ public class MedicationDelayDispatcher {
     private final CareRelationRepository careRelationRepository;
     private final MedicationScheduleRepository scheduleRepository;
     private final MedicationLogRepository logRepository;
+    private final MedicineRepository medicineRepository;
     private final NotificationSettingsRepository settingsRepository;
     private final NotificationRepository notificationRepository;
     private final DeviceTokenRepository deviceTokenRepository;
@@ -58,6 +61,7 @@ public class MedicationDelayDispatcher {
             final CareRelationRepository careRelationRepository,
             final MedicationScheduleRepository scheduleRepository,
             final MedicationLogRepository logRepository,
+            final MedicineRepository medicineRepository,
             final NotificationSettingsRepository settingsRepository,
             final NotificationRepository notificationRepository,
             final DeviceTokenRepository deviceTokenRepository,
@@ -68,6 +72,7 @@ public class MedicationDelayDispatcher {
         this.careRelationRepository = careRelationRepository;
         this.scheduleRepository = scheduleRepository;
         this.logRepository = logRepository;
+        this.medicineRepository = medicineRepository;
         this.settingsRepository = settingsRepository;
         this.notificationRepository = notificationRepository;
         this.deviceTokenRepository = deviceTokenRepository;
@@ -145,10 +150,11 @@ public class MedicationDelayDispatcher {
     ) {
         final String slotLabel = SLOT_LABELS.getOrDefault(slot, slot.name());
         final String title = "복약 지연 알림";
+        final String seniorName = senior.getNickname() == null ? "" : senior.getNickname();
+        final String medicineLabel = resolveMedicineLabel(schedule);
         final String body = String.format(
-                "%s 어르신이 %s 약 복용 시간을 %d분 넘겼습니다.",
-                senior.getNickname() == null ? "" : senior.getNickname(),
-                slotLabel, thresholdMinutes);
+                "%s 어르신이 %s에 %s을 아직 복용하지 않았어요. (%d분 경과)",
+                seniorName, slotLabel, medicineLabel, thresholdMinutes);
         final Notification saved = notificationRepository.save(
                 Notification.createForMedicationDelay(
                         caregiverId, senior.getId(), title, body, today, slot.name(), schedule.getId()));
@@ -172,5 +178,20 @@ public class MedicationDelayDispatcher {
 
     public Iterable<User> findAllSeniorsWithMealTimes() {
         return userRepository.findAllByRoleWithMealTimesSet(com.ppiyaki.user.UserRole.SENIOR);
+    }
+
+    /**
+     * 알림 메시지에 노출할 schedule 식별 라벨. "{약이름} {복용량}" 형식.
+     * 같은 슬롯에 여러 schedule 알림이 발송될 때 보호자가 어떤 약인지 구분 가능하게 함 (issue #345).
+     */
+    private String resolveMedicineLabel(final MedicationSchedule schedule) {
+        final String dosage = schedule.getDosage();
+        final String medicineName = medicineRepository.findById(schedule.getMedicineId())
+                .map(Medicine::getName)
+                .orElse("약");
+        if (dosage == null || dosage.isBlank()) {
+            return medicineName;
+        }
+        return medicineName + " " + dosage;
     }
 }

--- a/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
@@ -1,0 +1,224 @@
+package com.ppiyaki.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationLogRepository;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.push.PushSender;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.notification.repository.NotificationSettingsRepository;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.lang.reflect.Field;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("MedicationDelayDispatcher 메시지 빌더")
+class MedicationDelayDispatcherTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private CareRelationRepository careRelationRepository;
+    @Mock
+    private MedicationScheduleRepository scheduleRepository;
+    @Mock
+    private MedicationLogRepository logRepository;
+    @Mock
+    private MedicineRepository medicineRepository;
+    @Mock
+    private NotificationSettingsRepository settingsRepository;
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+    @Mock
+    private PushSender pushSender;
+
+    @Spy
+    private Clock clock = Clock.fixed(
+            Instant.parse("2026-05-13T11:00:30Z"), ZoneId.of("UTC"));
+
+    @InjectMocks
+    private MedicationDelayDispatcher dispatcher;
+
+    private static final Long SENIOR_ID = 38L;
+    private static final Long CAREGIVER_ID = 37L;
+    private static final LocalDate TODAY = LocalDate.of(2026, 5, 13);
+
+    @Test
+    @DisplayName("발송 메시지 본문에 약 이름 + 복용량 포함 (issue #345)")
+    void body_includes_medicine_name_and_dosage() throws Exception {
+        givenSenior();
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule schedule = buildSchedule(46L, 100L, "1정");
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
+                .thenReturn(List.of(schedule));
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
+                .thenReturn(List.of());
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
+                .thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
+        when(medicineRepository.findById(100L)).thenReturn(Optional.of(buildMedicine(100L, "록스펜씨알정")));
+        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
+                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
+
+        dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
+        final Notification saved = captor.getValue();
+        assertThat(saved.getBody())
+                .isEqualTo("김철수 어르신이 아침에 록스펜씨알정 1정을 아직 복용하지 않았어요. (60분 경과)");
+    }
+
+    @Test
+    @DisplayName("medicine 조회 실패 시 fallback \"약\"")
+    void body_fallback_when_medicine_not_found() throws Exception {
+        givenSenior();
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule schedule = buildSchedule(46L, 999L, "2캡슐");
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
+                .thenReturn(List.of(schedule));
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
+                .thenReturn(List.of());
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
+                .thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
+        when(medicineRepository.findById(999L)).thenReturn(Optional.empty());
+        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
+                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
+
+        dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getBody())
+                .isEqualTo("김철수 어르신이 아침에 약 2캡슐을 아직 복용하지 않았어요. (60분 경과)");
+    }
+
+    @Test
+    @DisplayName("dosage가 null이면 약 이름만 표시")
+    void body_omits_dosage_when_null() throws Exception {
+        givenSenior();
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule schedule = buildSchedule(46L, 100L, null);
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
+                .thenReturn(List.of(schedule));
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
+                .thenReturn(List.of());
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
+                .thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
+        when(medicineRepository.findById(100L)).thenReturn(Optional.of(buildMedicine(100L, "록스펜씨알정")));
+        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
+                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
+
+        dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getBody())
+                .isEqualTo("김철수 어르신이 아침에 록스펜씨알정을 아직 복용하지 않았어요. (60분 경과)");
+    }
+
+    // --- fixtures ---
+
+    private User seniorUser() {
+        final User mockSenior = mock(User.class);
+        when(mockSenior.getId()).thenReturn(SENIOR_ID);
+        when(mockSenior.getNickname()).thenReturn("김철수");
+        // BREAKFAST만 설정 — LUNCH/DINNER는 null이라 dispatcher가 skip
+        when(mockSenior.getBreakfastTime()).thenReturn(LocalTime.of(10, 0));
+        return mockSenior;
+    }
+
+    private void givenSenior() {
+        // no-op (User mock에서 mealTimes 직접 stub)
+    }
+
+    private void givenCareRelation() {
+        final CareRelation rel = mock(CareRelation.class);
+        when(rel.getCaregiverId()).thenReturn(CAREGIVER_ID);
+        when(careRelationRepository.findBySeniorIdAndDeletedAtIsNull(SENIOR_ID))
+                .thenReturn(List.of(rel));
+    }
+
+    private void givenSettingsDefault() {
+        when(settingsRepository.findByCaregiverIdAndSeniorId(CAREGIVER_ID, SENIOR_ID))
+                .thenReturn(Optional.empty()); // default threshold 60
+    }
+
+    private MedicationSchedule buildSchedule(final Long id, final Long medicineId,
+            final String dosage) throws Exception {
+        final java.lang.reflect.Constructor<MedicationSchedule> ctor = MedicationSchedule.class
+                .getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final MedicationSchedule s = ctor.newInstance();
+        setField(s, "id", id);
+        setField(s, "medicineId", medicineId);
+        setField(s, "mealSlot", MealSlot.BREAKFAST);
+        setField(s, "dosage", dosage);
+        return s;
+    }
+
+    private Medicine buildMedicine(final Long id, final String name) throws Exception {
+        final Medicine m = new Medicine(SENIOR_ID, null, name, 30, 30, "ITEM-" + id, null);
+        setField(m, "id", id);
+        return m;
+    }
+
+    private static void setField(final Object target, final String fieldName, final Object value) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}


### PR DESCRIPTION
## AS-IS
schedule 단위로 지연 알림 N건이 발송될 때 모든 메시지가 동일 텍스트:
```
복약 지연 알림
김철수 어르신이 아침 약 복용 시간을 60분 넘겼습니다.
```
→ 보호자에게 "중복 알림이 왔다"는 착각 유발.

## TO-BE
schedule별로 약 이름 + 복용량을 메시지에 포함:
```
복약 지연 알림
김철수 어르신이 아침에 록스펜씨알정 1정을 아직 복용하지 않았어요. (60분 경과)
복약 지연 알림
김철수 어르신이 아침에 칼론정 1정을 아직 복용하지 않았어요. (60분 경과)
```

- medicine 조회 실패 시 fallback "약"
- dosage가 null이면 약 이름만 표시

## 관련 이슈
- closes #345
- 관련 Discord 백로그: "복약 지연 알림 오류"
- PR #344(슬롯 통합 인증)와 보완 관계: #344가 정상 인증 시 알림 발송 자체를 줄이고, 본 PR은 mismatch/의도적 일부 인증 케이스의 메시지 가독성 보강

## 리뷰어 참고 포인트
- `MedicationDelayDispatcher` 의존성에 `MedicineRepository` 추가
- `resolveMedicineLabel(schedule)` private helper 신설
- 멱등성/필터 로직은 그대로 (메시지 문구만 변경)
- 단위 테스트 3건 신규 (`MedicationDelayDispatcherTest`)

## 라벨 부여 확인
- [x] `type:fix` 라벨 부여
- [x] `scope:medication` 라벨 부여
- [x] `ai-generated` 라벨 부여
- [ ] 보호 영역 변경 없음 → `needs-human-review` 불필요

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 회귀 가능 구간 확인 (dispatcher 발송 흐름 그대로, 문구만 변경)
- [x] 롤백 절차: 단일 커밋 revert

## DDD/OOP 준수 체크
- [x] 도메인 용어 유지
- [x] 계층 침범 없음
- [x] 의존성 추가 1개 (MedicineRepository — 같은 도메인 group의 자연 의존)

## 보안/민감정보 체크
- [x] 시크릿 하드코딩 없음
- [x] 의료정보(약 이름)는 알림 본문 노출이 의도된 동작

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용자가 채팅에서 "중복 알림 착각 방지 위해 약 이름/복용량 포함" 요청
- AI가 직접 수정한 파일: MedicationDelayDispatcher(+의존성, +helper, +메시지 문구), 단위 테스트(신규 파일)
- 사람이 수동 검증한 항목: 메시지 포맷 결정