### PR TITLE
release: v0.12.1

### DIFF
--- a/docs/features/caregiver-dashboard.md
+++ b/docs/features/caregiver-dashboard.md
@@ -93,15 +93,16 @@ last_reviewed: 2026-05-08
 일자 안의 모든 슬롯을 보고 1개 status로 축약:
 | 값 | 룰 |
 |---|---|
-| `PERFECT` | 모든 schedule된 슬롯이 PERFECT |
+| `PERFECT` | 1개 이상 schedule된 슬롯이 있고 모두 PERFECT |
 | `DELAYED` | DELAYED 슬롯 1개 이상, MISSED 0 |
 | `MISSED` | MISSED 슬롯 1개 이상 (자정 경과 후만 발생) |
 | `PENDING` | PENDING 슬롯 1개 이상, MISSED 0, DELAYED 0 (오늘 진행 중) |
 | `FUTURE` | date > today |
+| `NOT_SCHEDULED` | 가입 이전 날짜(#326) **또는** 모든 슬롯이 `NOT_SCHEDULED`인 일자(#340) |
 
 비고:
 - "오늘"의 status는 frontend isToday 플래그로 추가 강조 (디자인 image2의 25일). backend는 룰 그대로.
-- 시니어 mealTimes가 null이라 모든 슬롯이 `NOT_SCHEDULED`인 일자는 `PERFECT`로 간주(분모 0). 또는 별도 `EMPTY` 추가 — TBD(§8 Q1).
+- 모든 슬롯이 `NOT_SCHEDULED`(mealTimes null 또는 schedule 없음)인 일자는 `NOT_SCHEDULED`로 표시 — 슬롯/일자 의미가 일관되도록 §8 Q1 (c) 채택 (#340, 2026-05-13).
 
 ### 5-3) API 엔드포인트
 
@@ -238,7 +239,7 @@ weekly/monthly는 4~6 단계를 기간으로 확장, status만 도출.
 ## 8) 오픈 질문
 | # | 질문 | 선택지 | 담당/기한 |
 |---|---|---|---|
-| Q1 | 시니어 mealTimes 미설정 일자(모든 슬롯 NOT_SCHEDULED)의 dayStatus | (a) PERFECT (분모 0이라 완벽 간주) / (b) 별도 `EMPTY` enum 추가 / (c) `NOT_SCHEDULED` 그대로 사용 | @goohong / 구현 시 |
+| ~~Q1~~ | ~~시니어 mealTimes 미설정 일자(모든 슬롯 NOT_SCHEDULED)의 dayStatus~~ | **해소 — (c) `NOT_SCHEDULED` 채택 (#340, 2026-05-13). 가입 전 #326 처리와 일관된 의미.** ✅ |
 | Q2 | dosage 파싱 — "반정"(0.5정) / "2정 반"(2.5정) 같은 소수 표기 | (a) 정수만 — 비정수면 0으로 (단순) / (b) BigDecimal로 정밀 / (c) 파싱 실패 시 fallback dailyConsumption=1 | @goohong / 구현 시 |
 | Q3 | weekly의 weekStart 요일 | (a) 일요일 (한국 캘린더 기본) / (b) 월요일 (ISO 8601) — 디자인 image2 "일/월/화/수…" 순이라 (a)로 보임 | 디자인 측 / 구현 시 |
 | Q4 | monthly 응답에 통합 status 외 추가 정보(예: 슬롯별 마커) | (a) 통합 status enum만(권장) / (b) 슬롯별 마커도 — 응답 크기 증가 | @frontend / 구현 시 |
@@ -254,3 +255,4 @@ weekly/monthly는 4~6 단계를 기간으로 확장, status만 도출.
 - 2026-05-08: MISSED 자동 전환 cron은 본 spec scope 외 — dashboard 응답 시 동적 계산.
 - 2026-05-10 (#294): **Q5 해소** — DELAYED 임계 = 보호자별 `notification_settings.medication_delay_threshold_minutes` 참조. `DashboardService.DELAY_THRESHOLD_MINUTES = 60` 하드코딩 제거 → caller 보호자의 settings 조회. 시니어 본인 caller(userId == seniorId)일 때는 default 60 fallback. medication-notification.md PR 7과 동시 머지.
 - 2026-05-08: 통합 endpoint 신규(daily/weekly/monthly) — 기존 logs/medicines/schedules 합성보다 N+1 호출 부담 감소 + status 룰 일관성.
+- 2026-05-13 (#340): **Q1 해소** — 모든 슬롯이 NOT_SCHEDULED인 일자의 dayStatus를 PERFECT가 아닌 NOT_SCHEDULED로 통일. 기존 #326의 가입 전 처리와 의미적 일관성 확보. `DashboardService.deriveDayStatus(FromMarkers)` 빈 `present` 분기 PERFECT → NOT_SCHEDULED.

--- a/docs/features/medication-log-phase2.md
+++ b/docs/features/medication-log-phase2.md
@@ -114,7 +114,11 @@ public enum LogAiStatus {
               ├─ actualCount == expectedCount → COUNT_MATCH
               └─ != → COUNT_MISMATCH
        5. medication_log.ai_status 갱신 후 저장
-       6. 응답 200 + aiStatus 포함 (PUT 응답 시간: 평소 + 5~10s)
+       6. ai_status == COUNT_MATCH → 슬롯의 다른 active schedule들도 TAKEN 전파 (issue #343)
+          - 각 peer schedule에 medication_log upsert (이미 TAKEN이면 skip, 멱등)
+          - 새로 TAKEN 전환되는 peer의 medicine.remainingAmount 차감
+          - peer log의 ai_status = COUNT_MATCH (슬롯 전체가 검증된 상태이므로)
+       7. 응답 200 + aiStatus 포함 (PUT 응답 시간: 평소 + 5~10s)
 ```
 
 ### 5-5) DB 마이그레이션
@@ -176,3 +180,4 @@ public enum LogAiStatus {
 - 2026-05-07: v0.9.0 (#225) — 기대 카운트 산출 키를 `scheduledTime` → `mealSlot`으로 전환. schedule 모델 변경에 따른 자연 후속.
 - 2026-04-30: **dosage 파싱 = 정규식 `(\d+)` 첫 매치** — 단순 / 실패 시 `COUNT_UNKNOWN`로 fallback. "반알" 등은 검증 불가로 처리.
 - 2026-04-30: **결과 알림은 Phase 2 범위 외** — `ai_status` 갱신만 하고, FCM 푸시는 별도 spec 의존.
+- 2026-05-13 (#343): **COUNT_MATCH 시 슬롯 전체 인증 전파** — 사용자가 사진 1장으로 슬롯 전체 약을 인증한 의도. 트리거 schedule 외 peer schedule들에도 TAKEN log 생성 + 잔여분 차감. 멱등(이미 TAKEN이면 skip). 미반영 시 보호자에게 미인증 schedule만큼 지연 알림이 발송되어 사용자 인식과 모순(prod 운영 보고).

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -291,7 +291,7 @@ public class DashboardService {
             }
         }
         if (present.isEmpty()) {
-            return DayStatus.PERFECT;
+            return DayStatus.NOT_SCHEDULED;
         }
         if (present.contains(SlotStatus.MISSED)) {
             return DayStatus.MISSED;
@@ -375,7 +375,7 @@ public class DashboardService {
             }
         }
         if (present.isEmpty()) {
-            return DayStatus.PERFECT;
+            return DayStatus.NOT_SCHEDULED;
         }
         if (present.contains(SlotStatus.MISSED)) {
             return DayStatus.MISSED;

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -148,9 +148,63 @@ public class MedicationLogService {
                 && request.photoObjectKey() != null && !request.photoObjectKey().isBlank()) {
             final LogAiStatus aiStatus = verifyPillCount(seniorId, schedule, request);
             log.updateAiStatus(aiStatus);
+            // COUNT_MATCH일 때 슬롯의 다른 active schedule도 TAKEN 전파 (issue #343).
+            // 시니어가 슬롯 전체 약을 사진 한 장에 담아 인증한 경우 == 슬롯 전체 인증으로 인정.
+            if (aiStatus == LogAiStatus.COUNT_MATCH) {
+                propagateTakenToSlotSchedules(seniorId, schedule, request, takenAt, isProxy, userId);
+            }
         }
 
         return MedicationLogResponse.from(log, photoUrlAssembler.toFullUrl(log.getPhotoObjectKey()));
+    }
+
+    /**
+     * 동일 슬롯의 다른 active schedule들에 TAKEN log 전파 (issue #343).
+     * spec medication-log-phase2 §5-4: AI COUNT_MATCH 시 슬롯 전체 인증으로 인정.
+     *
+     * <p>이미 TAKEN인 row는 skip (멱등). 새로 TAKEN 전환되는 schedule의 medicine 잔여분도 차감.
+     * propagated log의 aiStatus는 COUNT_MATCH로 마킹 (슬롯 전체가 검증된 상태이므로).
+     */
+    private void propagateTakenToSlotSchedules(
+            final Long seniorId,
+            final MedicationSchedule triggerSchedule,
+            final MedicationLogUpsertRequest request,
+            final LocalDateTime takenAt,
+            final boolean isProxy,
+            final Long recorderId
+    ) {
+        final List<MedicationSchedule> slotSchedules = medicationScheduleRepository
+                .findActiveByOwnerAndMealSlot(
+                        seniorId, request.targetDate(), triggerSchedule.getMealSlot());
+        for (final MedicationSchedule peer : slotSchedules) {
+            if (peer.getId().equals(triggerSchedule.getId())) {
+                continue;
+            }
+            final Optional<MedicationLog> existing = medicationLogRepository
+                    .findByScheduleIdAndTargetDate(peer.getId(), request.targetDate());
+            final LogStatus previousStatus = existing.map(MedicationLog::getStatus).orElse(null);
+            if (previousStatus == LogStatus.TAKEN) {
+                continue;
+            }
+            final MedicationLog peerLog = existing
+                    .map(found -> {
+                        found.updateRecord(takenAt, LogStatus.TAKEN, request.photoObjectKey(), isProxy, recorderId);
+                        return found;
+                    })
+                    .orElseGet(() -> medicationLogRepository.saveAndFlush(new MedicationLog(
+                            seniorId, peer.getId(), request.targetDate(),
+                            takenAt, LogStatus.TAKEN, request.photoObjectKey(), isProxy, recorderId)));
+            peerLog.updateAiStatus(LogAiStatus.COUNT_MATCH);
+
+            final BigDecimal dosageQuantity = peer.getDosageQuantity();
+            if (dosageQuantity != null) {
+                final int dosageCount = dosageQuantity.setScale(0, java.math.RoundingMode.CEILING).intValueExact();
+                if (dosageCount > 0) {
+                    medicineRepository.findById(peer.getMedicineId())
+                            .ifPresent(m -> m.decreaseRemainingAmount(dosageCount));
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
@@ -6,6 +6,8 @@ import com.ppiyaki.medication.MedicationLog;
 import com.ppiyaki.medication.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.notification.DeviceToken;
 import com.ppiyaki.notification.Notification;
 import com.ppiyaki.notification.NotificationCategory;
@@ -47,6 +49,7 @@ public class MedicationDelayDispatcher {
     private final CareRelationRepository careRelationRepository;
     private final MedicationScheduleRepository scheduleRepository;
     private final MedicationLogRepository logRepository;
+    private final MedicineRepository medicineRepository;
     private final NotificationSettingsRepository settingsRepository;
     private final NotificationRepository notificationRepository;
     private final DeviceTokenRepository deviceTokenRepository;
@@ -58,6 +61,7 @@ public class MedicationDelayDispatcher {
             final CareRelationRepository careRelationRepository,
             final MedicationScheduleRepository scheduleRepository,
             final MedicationLogRepository logRepository,
+            final MedicineRepository medicineRepository,
             final NotificationSettingsRepository settingsRepository,
             final NotificationRepository notificationRepository,
             final DeviceTokenRepository deviceTokenRepository,
@@ -68,6 +72,7 @@ public class MedicationDelayDispatcher {
         this.careRelationRepository = careRelationRepository;
         this.scheduleRepository = scheduleRepository;
         this.logRepository = logRepository;
+        this.medicineRepository = medicineRepository;
         this.settingsRepository = settingsRepository;
         this.notificationRepository = notificationRepository;
         this.deviceTokenRepository = deviceTokenRepository;
@@ -145,10 +150,11 @@ public class MedicationDelayDispatcher {
     ) {
         final String slotLabel = SLOT_LABELS.getOrDefault(slot, slot.name());
         final String title = "복약 지연 알림";
+        final String seniorName = senior.getNickname() == null ? "" : senior.getNickname();
+        final String medicineLabel = resolveMedicineLabel(schedule);
         final String body = String.format(
-                "%s 어르신이 %s 약 복용 시간을 %d분 넘겼습니다.",
-                senior.getNickname() == null ? "" : senior.getNickname(),
-                slotLabel, thresholdMinutes);
+                "%s 어르신이 %s에 %s을 아직 복용하지 않았어요. (%d분 경과)",
+                seniorName, slotLabel, medicineLabel, thresholdMinutes);
         final Notification saved = notificationRepository.save(
                 Notification.createForMedicationDelay(
                         caregiverId, senior.getId(), title, body, today, slot.name(), schedule.getId()));
@@ -172,5 +178,20 @@ public class MedicationDelayDispatcher {
 
     public Iterable<User> findAllSeniorsWithMealTimes() {
         return userRepository.findAllByRoleWithMealTimesSet(com.ppiyaki.user.UserRole.SENIOR);
+    }
+
+    /**
+     * 알림 메시지에 노출할 schedule 식별 라벨. "{약이름} {복용량}" 형식.
+     * 같은 슬롯에 여러 schedule 알림이 발송될 때 보호자가 어떤 약인지 구분 가능하게 함 (issue #345).
+     */
+    private String resolveMedicineLabel(final MedicationSchedule schedule) {
+        final String dosage = schedule.getDosage();
+        final String medicineName = medicineRepository.findById(schedule.getMedicineId())
+                .map(Medicine::getName)
+                .orElse("약");
+        if (dosage == null || dosage.isBlank()) {
+            return medicineName;
+        }
+        return medicineName + " " + dosage;
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,6 +4,10 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      # 60s 이상 빌려간 채 반환 안 된 connection의 stack trace 로그 (진단용, issue #346).
+      # 시연 직전 12:14~13:25 pool 고갈 사고 재발 시 leak 위치 즉시 확정 목적.
+      leak-detection-threshold: 60000
   jpa:
     hibernate:
       ddl-auto: ${JPA_DDL_AUTO:validate}

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardDailyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardDailyE2ETest.java
@@ -53,7 +53,7 @@ class DashboardDailyE2ETest {
     }
 
     @Test
-    @DisplayName("시니어 본인 호출 — schedule 없으면 dayStatus=PERFECT, header 채워짐")
+    @DisplayName("시니어 본인 호출 — schedule 없으면 dayStatus=NOT_SCHEDULED, header 채워짐")
     void daily_seniorSelf_emptySchedules() {
         final SignupResult senior = signup("일간시니어");
         setMealTimes(senior.userId(), LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
@@ -67,7 +67,7 @@ class DashboardDailyE2ETest {
                 .statusCode(200)
                 .body("seniorId", is(senior.userId().intValue()))
                 .body("date", is(today.toString()))
-                .body("dayStatus", is("PERFECT"))
+                .body("dayStatus", is("NOT_SCHEDULED"))
                 .body("header.seniorName", is("일간시니어"))
                 .body("header.caregiverName", is("일간시니어"))
                 .body("slots", notNullValue())

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardMonthlyE2ETest.java
@@ -46,10 +46,10 @@ class DashboardMonthlyE2ETest {
     }
 
     @Test
-    @DisplayName("시니어 본인 호출 — 현재 월 schedule 없으면 가입일 이후 PERFECT, 가입 이전 NOT_SCHEDULED (issue #326)")
+    @DisplayName("시니어 본인 호출 — 현재 월 schedule 없으면 모든 일자 NOT_SCHEDULED (issue #340)")
     void monthly_seniorSelf_emptySchedules() {
         final SignupResult senior = signup("월간시니어");
-        // 현재 월로 조회 — 가입 후 days는 PERFECT, 가입 전 days는 NOT_SCHEDULED
+        // 현재 월로 조회 — 가입 후/전 모두 schedule이 없으므로 NOT_SCHEDULED. 미래 일자만 FUTURE
         final YearMonth ym = YearMonth.now();
         final int today = LocalDate.now().getDayOfMonth();
 
@@ -62,10 +62,8 @@ class DashboardMonthlyE2ETest {
                 .body("seniorId", is(senior.userId().intValue()))
                 .body("yearMonth", is(ym.toString()))
                 .body("days.size()", is(ym.lengthOfMonth()))
-                // today는 가입일과 동일 → PERFECT (schedule 없음 + 가입 이후)
-                .body("days[" + (today - 1) + "].dayStatus", is("PERFECT"))
-                // 1일은 today보다 이르면 NOT_SCHEDULED, 같으면 PERFECT
-                .body("days[0].dayStatus", is(today > 1 ? "NOT_SCHEDULED" : "PERFECT"));
+                .body("days[" + (today - 1) + "].dayStatus", is("NOT_SCHEDULED"))
+                .body("days[0].dayStatus", is("NOT_SCHEDULED"));
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/DashboardWeeklyE2ETest.java
@@ -54,7 +54,7 @@ class DashboardWeeklyE2ETest {
     }
 
     @Test
-    @DisplayName("시니어 본인 호출 — 가입 후 날짜 schedule 없으면 PERTECT, 가입 이전은 NOT_SCHEDULED (issue #326)")
+    @DisplayName("시니어 본인 호출 — 스케줄 없는 날짜는 dayStatus=NOT_SCHEDULED (issue #340)")
     void weekly_seniorSelf_emptySchedules() {
         final SignupResult senior = signup("주간시니어");
         setMealTimes(senior.userId(), LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
@@ -72,7 +72,7 @@ class DashboardWeeklyE2ETest {
                 .body("weekEnd", is(weekStart.plusDays(6).toString()))
                 .body("adherenceRate", is(nullValue()))
                 .body("days.size()", is(7))
-                .body("days[0].dayStatus", is("PERFECT"))
+                .body("days[0].dayStatus", is("NOT_SCHEDULED"))
                 .body("days[0].slots", notNullValue())
                 .body("days[0].slots[0].status", is("NOT_SCHEDULED"));
     }

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -71,7 +71,7 @@ class DashboardServiceTest {
         final DailyDashboardResponse resp = dashboardService.getDaily(SENIOR_ID, SENIOR_ID, TODAY);
 
         assertThat(resp.seniorId()).isEqualTo(SENIOR_ID);
-        assertThat(resp.dayStatus()).isEqualTo(DayStatus.PERFECT);
+        assertThat(resp.dayStatus()).isEqualTo(DayStatus.NOT_SCHEDULED);
     }
 
     @Test
@@ -238,7 +238,7 @@ class DashboardServiceTest {
     }
 
     @Test
-    @DisplayName("weekly — 모든 일자 schedule 없음 → adherenceRate=null, days[7] 모두 PERFECT/NOT_SCHEDULED")
+    @DisplayName("weekly — 모든 일자 schedule 없음 → adherenceRate=null, days[7] 모두 NOT_SCHEDULED")
     void weekly_emptySchedules() throws Exception {
         givenSeniorAndCaregiver();
         givenSeniorMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
@@ -254,7 +254,7 @@ class DashboardServiceTest {
         org.assertj.core.api.Assertions.assertThat(resp.adherenceRate()).isNull();
         org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(7);
         org.assertj.core.api.Assertions.assertThat(resp.days()).allMatch(d -> d.dayStatus()
-                == com.ppiyaki.medication.DayStatus.PERFECT
+                == com.ppiyaki.medication.DayStatus.NOT_SCHEDULED
                 && d.slots().stream().allMatch(s -> s.status() == SlotStatus.NOT_SCHEDULED));
     }
 
@@ -289,7 +289,7 @@ class DashboardServiceTest {
     }
 
     @Test
-    @DisplayName("monthly — schedule 없으면 days 모두 PERFECT (분모 0 케이스)")
+    @DisplayName("monthly — schedule 없으면 days 모두 NOT_SCHEDULED")
     void monthly_emptySchedules() throws Exception {
         givenSeniorAndCaregiver();
         givenSeniorMealTimes(LocalTime.of(8, 0), LocalTime.of(12, 30), LocalTime.of(18, 30));
@@ -303,7 +303,7 @@ class DashboardServiceTest {
         org.assertj.core.api.Assertions.assertThat(resp.yearMonth()).isEqualTo(ym);
         org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(31);
         org.assertj.core.api.Assertions.assertThat(resp.days())
-                .allMatch(d -> d.dayStatus() == com.ppiyaki.medication.DayStatus.PERFECT);
+                .allMatch(d -> d.dayStatus() == com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
     }
 
     @Test
@@ -323,7 +323,7 @@ class DashboardServiceTest {
         // when
         final var resp = dashboardService.getWeekly(SENIOR_ID, SENIOR_ID, weekStart);
 
-        // then — 처음 3일(weekStart, +1, +2)는 NOT_SCHEDULED, 나머지 4일은 PERFECT(스케줄 없음)
+        // then — 처음 3일(weekStart, +1, +2)는 가입 전 shortcut으로 NOT_SCHEDULED, 나머지 4일은 schedule 없음으로 NOT_SCHEDULED
         org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(7);
         for (int i = 0; i < 3; i++) {
             org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
@@ -333,7 +333,7 @@ class DashboardServiceTest {
         }
         for (int i = 3; i < 7; i++) {
             org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
-                    .isEqualTo(com.ppiyaki.medication.DayStatus.PERFECT);
+                    .isEqualTo(com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
         }
     }
 
@@ -352,14 +352,14 @@ class DashboardServiceTest {
         final java.time.YearMonth ym = java.time.YearMonth.of(2026, 1);
         final var resp = dashboardService.getMonthly(SENIOR_ID, SENIOR_ID, ym);
 
-        // then — 1~14일은 NOT_SCHEDULED, 15일부터 PERFECT
+        // then — 1~14일은 가입 전 shortcut, 15일부터 schedule 없음. 둘 다 NOT_SCHEDULED
         org.assertj.core.api.Assertions.assertThat(resp.days()).hasSize(31);
         for (int i = 0; i < 14; i++) {
             org.assertj.core.api.Assertions.assertThat(resp.days().get(i).dayStatus())
                     .isEqualTo(com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
         }
         org.assertj.core.api.Assertions.assertThat(resp.days().get(14).dayStatus())
-                .isEqualTo(com.ppiyaki.medication.DayStatus.PERFECT);
+                .isEqualTo(com.ppiyaki.medication.DayStatus.NOT_SCHEDULED);
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -163,6 +163,105 @@ class MedicationLogServicePhase2Test {
     }
 
     @Test
+    @DisplayName("COUNT_MATCH 시 슬롯의 다른 active schedule도 TAKEN 전파 (issue #343)")
+    void count_match_propagates_to_peers() throws Exception {
+        // given: trigger schedule(1정) + peer schedule(2L, 1정), Vision=2 → COUNT_MATCH
+        final Long peerScheduleId = 2L;
+        final Long peerMedicineId = 11L;
+        final MedicationSchedule triggerSchedule = buildSchedule(SCHEDULE_ID, "1정");
+        final MedicationSchedule peerSchedule = buildSchedule(peerScheduleId, "1정");
+        setField(peerSchedule, "medicineId", peerMedicineId);
+
+        when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(triggerSchedule));
+        final Medicine triggerMedicine = new Medicine(SENIOR_ID, null, "트리거약", 30, 30, "ITEM-1", null);
+        setField(triggerMedicine, "id", MEDICINE_ID);
+        when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(triggerMedicine));
+        final Medicine peerMedicine = new Medicine(SENIOR_ID, null, "피어약", 30, 30, "ITEM-2", null);
+        setField(peerMedicine, "id", peerMedicineId);
+        when(medicineRepository.findById(peerMedicineId)).thenReturn(Optional.of(peerMedicine));
+
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(peerScheduleId, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn("https://example.com/" + VALID_OBJECT_KEY);
+        givenSiblingSchedules(List.of(triggerSchedule, peerSchedule));
+        givenS3Returns(new byte[]{1, 2, 3});
+        when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(2));
+
+        // when
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        // then — trigger + peer 모두 TAKEN log 저장 (saveAndFlush 2번)
+        final ArgumentCaptor<MedicationLog> captor = ArgumentCaptor.forClass(MedicationLog.class);
+        verify(medicationLogRepository, org.mockito.Mockito.times(2)).saveAndFlush(captor.capture());
+        final List<MedicationLog> savedLogs = captor.getAllValues();
+        assertThat(savedLogs).hasSize(2);
+        assertThat(savedLogs).allMatch(l -> l.getStatus() == LogStatus.TAKEN);
+        assertThat(savedLogs.stream().map(MedicationLog::getScheduleId))
+                .containsExactlyInAnyOrder(SCHEDULE_ID, peerScheduleId);
+        // peer의 medicine 잔여분도 차감 (30 → 29)
+        assertThat(peerMedicine.getRemainingAmount()).isEqualTo(29);
+    }
+
+    @Test
+    @DisplayName("COUNT_MISMATCH 시 슬롯의 다른 schedule에 전파 안 함")
+    void count_mismatch_no_propagate() throws Exception {
+        givenScheduleAndMedicine();
+        givenUpsertSucceeds();
+        givenSiblingSchedules(List.of(buildSchedule(SCHEDULE_ID, "1정"), buildSchedule(2L, "1정")));
+        givenS3Returns(new byte[]{1});
+        when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(1));
+
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        // saveAndFlush는 trigger schedule 1번만 호출 (peer는 호출 X)
+        verify(medicationLogRepository, org.mockito.Mockito.times(1)).saveAndFlush(any(MedicationLog.class));
+    }
+
+    @Test
+    @DisplayName("COUNT_MATCH지만 peer가 이미 TAKEN이면 skip (멱등)")
+    void count_match_skip_already_taken_peer() throws Exception {
+        // given
+        final Long peerScheduleId = 2L;
+        final Long peerMedicineId = 11L;
+        final MedicationSchedule triggerSchedule = buildSchedule(SCHEDULE_ID, "1정");
+        final MedicationSchedule peerSchedule = buildSchedule(peerScheduleId, "1정");
+        setField(peerSchedule, "medicineId", peerMedicineId);
+
+        when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(triggerSchedule));
+        final Medicine triggerMedicine = new Medicine(SENIOR_ID, null, "트리거약", 30, 30, "ITEM-1", null);
+        setField(triggerMedicine, "id", MEDICINE_ID);
+        when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(triggerMedicine));
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        // peer는 이미 TAKEN log 있음
+        final MedicationLog existingPeerLog = new MedicationLog(
+                SENIOR_ID, peerScheduleId, TARGET_DATE,
+                java.time.LocalDateTime.of(TARGET_DATE, java.time.LocalTime.of(8, 0)),
+                LogStatus.TAKEN, null, false, SENIOR_ID);
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(peerScheduleId, TARGET_DATE))
+                .thenReturn(Optional.of(existingPeerLog));
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn("https://example.com/" + VALID_OBJECT_KEY);
+        givenSiblingSchedules(List.of(triggerSchedule, peerSchedule));
+        givenS3Returns(new byte[]{1, 2, 3});
+        when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(2));
+
+        // when
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        // then — trigger schedule만 save, peer는 이미 TAKEN이라 skip
+        verify(medicationLogRepository, org.mockito.Mockito.times(1)).saveAndFlush(any(MedicationLog.class));
+    }
+
+    @Test
     @DisplayName("png objectKey면 mediaType=image/png 전달")
     void png_media_type() throws Exception {
         givenScheduleAndMedicine();

--- a/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
@@ -1,0 +1,224 @@
+package com.ppiyaki.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ppiyaki.medication.MealSlot;
+import com.ppiyaki.medication.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationLogRepository;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.push.PushSender;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.notification.repository.NotificationSettingsRepository;
+import com.ppiyaki.user.CareRelation;
+import com.ppiyaki.user.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.lang.reflect.Field;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("MedicationDelayDispatcher 메시지 빌더")
+class MedicationDelayDispatcherTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private CareRelationRepository careRelationRepository;
+    @Mock
+    private MedicationScheduleRepository scheduleRepository;
+    @Mock
+    private MedicationLogRepository logRepository;
+    @Mock
+    private MedicineRepository medicineRepository;
+    @Mock
+    private NotificationSettingsRepository settingsRepository;
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+    @Mock
+    private PushSender pushSender;
+
+    @Spy
+    private Clock clock = Clock.fixed(
+            Instant.parse("2026-05-13T11:00:30Z"), ZoneId.of("UTC"));
+
+    @InjectMocks
+    private MedicationDelayDispatcher dispatcher;
+
+    private static final Long SENIOR_ID = 38L;
+    private static final Long CAREGIVER_ID = 37L;
+    private static final LocalDate TODAY = LocalDate.of(2026, 5, 13);
+
+    @Test
+    @DisplayName("발송 메시지 본문에 약 이름 + 복용량 포함 (issue #345)")
+    void body_includes_medicine_name_and_dosage() throws Exception {
+        givenSenior();
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule schedule = buildSchedule(46L, 100L, "1정");
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
+                .thenReturn(List.of(schedule));
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
+                .thenReturn(List.of());
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
+                .thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
+        when(medicineRepository.findById(100L)).thenReturn(Optional.of(buildMedicine(100L, "록스펜씨알정")));
+        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
+                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
+
+        dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
+        final Notification saved = captor.getValue();
+        assertThat(saved.getBody())
+                .isEqualTo("김철수 어르신이 아침에 록스펜씨알정 1정을 아직 복용하지 않았어요. (60분 경과)");
+    }
+
+    @Test
+    @DisplayName("medicine 조회 실패 시 fallback \"약\"")
+    void body_fallback_when_medicine_not_found() throws Exception {
+        givenSenior();
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule schedule = buildSchedule(46L, 999L, "2캡슐");
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
+                .thenReturn(List.of(schedule));
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
+                .thenReturn(List.of());
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
+                .thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
+        when(medicineRepository.findById(999L)).thenReturn(Optional.empty());
+        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
+                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
+
+        dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getBody())
+                .isEqualTo("김철수 어르신이 아침에 약 2캡슐을 아직 복용하지 않았어요. (60분 경과)");
+    }
+
+    @Test
+    @DisplayName("dosage가 null이면 약 이름만 표시")
+    void body_omits_dosage_when_null() throws Exception {
+        givenSenior();
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule schedule = buildSchedule(46L, 100L, null);
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
+                .thenReturn(List.of(schedule));
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
+                .thenReturn(List.of());
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
+                .thenReturn(List.of());
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
+        when(medicineRepository.findById(100L)).thenReturn(Optional.of(buildMedicine(100L, "록스펜씨알정")));
+        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
+                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
+
+        dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getBody())
+                .isEqualTo("김철수 어르신이 아침에 록스펜씨알정을 아직 복용하지 않았어요. (60분 경과)");
+    }
+
+    // --- fixtures ---
+
+    private User seniorUser() {
+        final User mockSenior = mock(User.class);
+        when(mockSenior.getId()).thenReturn(SENIOR_ID);
+        when(mockSenior.getNickname()).thenReturn("김철수");
+        // BREAKFAST만 설정 — LUNCH/DINNER는 null이라 dispatcher가 skip
+        when(mockSenior.getBreakfastTime()).thenReturn(LocalTime.of(10, 0));
+        return mockSenior;
+    }
+
+    private void givenSenior() {
+        // no-op (User mock에서 mealTimes 직접 stub)
+    }
+
+    private void givenCareRelation() {
+        final CareRelation rel = mock(CareRelation.class);
+        when(rel.getCaregiverId()).thenReturn(CAREGIVER_ID);
+        when(careRelationRepository.findBySeniorIdAndDeletedAtIsNull(SENIOR_ID))
+                .thenReturn(List.of(rel));
+    }
+
+    private void givenSettingsDefault() {
+        when(settingsRepository.findByCaregiverIdAndSeniorId(CAREGIVER_ID, SENIOR_ID))
+                .thenReturn(Optional.empty()); // default threshold 60
+    }
+
+    private MedicationSchedule buildSchedule(final Long id, final Long medicineId,
+            final String dosage) throws Exception {
+        final java.lang.reflect.Constructor<MedicationSchedule> ctor = MedicationSchedule.class
+                .getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final MedicationSchedule s = ctor.newInstance();
+        setField(s, "id", id);
+        setField(s, "medicineId", medicineId);
+        setField(s, "mealSlot", MealSlot.BREAKFAST);
+        setField(s, "dosage", dosage);
+        return s;
+    }
+
+    private Medicine buildMedicine(final Long id, final String name) throws Exception {
+        final Medicine m = new Medicine(SENIOR_ID, null, name, 30, 30, "ITEM-" + id, null);
+        setField(m, "id", id);
+        return m;
+    }
+
+    private static void setField(final Object target, final String fieldName, final Object value) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                final Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}


### PR DESCRIPTION
## Changelog

### fix
- **#341** 대시보드 모든 슬롯 NOT_SCHEDULED 일자 dayStatus를 NOT_SCHEDULED로 통일 (`scope:medication`)
- **#344** 사진 인증 AI COUNT_MATCH 시 슬롯의 모든 active schedule 자동 TAKEN 전파 (`scope:medication`) — 운영 보고: 슬롯의 약 4개 중 1개만 TAKEN log 생성되어 미인증 알림 다수 발송되던 문제
- **#348** 복약 지연 알림 메시지에 약 이름 + 복용량 포함 (`scope:medication`) — schedule별 알림 차별화로 중복 착각 방지

### chore
- **#347** prod Hikari `leak-detection-threshold: 60s` 활성화 (`scope:infra`) — 2026-05-13 prod connection pool 고갈 사고(12:14~13:25) 재발 시 leak 위치 stack trace로 즉시 진단 목적

## 운영 메모
- 본 release 후 prod에 `leak-detection-threshold`가 적용되므로, 다음 connection leak 발생 시 WARN 로그에 stack trace가 출력됩니다. 진단 효과 확인 후 root-cause fix는 별도 PR 예정.
- v0.12.0 이후 prod DB 마이그레이션 없음.

## 머지 방식
- **Merge commit** (Squash 금지) — develop 히스토리 main에 보존
- 머지 후 `git tag -a v0.12.1` + `gh release create v0.12.1 --generate-notes`