### PR TITLE
feat(infra): 구조화 로깅 + MDC requestId/userId 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation 'com.drewnoakes:metadata-extractor:2.19.0'
     implementation 'com.google.firebase:firebase-admin:9.4.3'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     developmentOnly 'me.paulschwarz:springboot3-dotenv:5.1.0'

--- a/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
@@ -35,9 +35,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             final FilterChain filterChain
     ) throws ServletException, IOException {
         final String token = extractToken(request);
-        boolean userIdSet = false;
+        final boolean userIdSet = token != null && jwtProvider.isValid(token);
 
-        if (token != null && jwtProvider.isValid(token)) {
+        if (userIdSet) {
             final Long userId = jwtProvider.extractUserId(token);
             final String role = jwtProvider.extractRole(token);
             final List<GrantedAuthority> authorities = role == null
@@ -47,7 +47,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     null, authorities);
             SecurityContextHolder.getContext().setAuthentication(authentication);
             MDC.put(MDC_USER_ID, userId.toString());
-            userIdSet = true;
         }
 
         try {

--- a/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
+import org.slf4j.MDC;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -19,6 +20,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String ROLE_PREFIX = "ROLE_";
+    private static final String MDC_USER_ID = "userId";
 
     private final JwtProvider jwtProvider;
 
@@ -33,6 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             final FilterChain filterChain
     ) throws ServletException, IOException {
         final String token = extractToken(request);
+        boolean userIdSet = false;
 
         if (token != null && jwtProvider.isValid(token)) {
             final Long userId = jwtProvider.extractUserId(token);
@@ -43,9 +46,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             final UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId,
                     null, authorities);
             SecurityContextHolder.getContext().setAuthentication(authentication);
+            MDC.put(MDC_USER_ID, userId.toString());
+            userIdSet = true;
         }
 
-        filterChain.doFilter(request, response);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            if (userIdSet) {
+                MDC.remove(MDC_USER_ID);
+            }
+        }
     }
 
     private String extractToken(final HttpServletRequest request) {

--- a/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
+++ b/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.ppiyaki.common.auth;
 
+import com.ppiyaki.common.logging.MdcRequestIdFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -16,15 +17,18 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableMethodSecurity
 public class SecurityConfig {
 
+    private final MdcRequestIdFilter mdcRequestIdFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
     private final RestAccessDeniedHandler restAccessDeniedHandler;
 
     public SecurityConfig(
+            final MdcRequestIdFilter mdcRequestIdFilter,
             final JwtAuthenticationFilter jwtAuthenticationFilter,
             final RestAuthenticationEntryPoint restAuthenticationEntryPoint,
             final RestAccessDeniedHandler restAccessDeniedHandler
     ) {
+        this.mdcRequestIdFilter = mdcRequestIdFilter;
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.restAuthenticationEntryPoint = restAuthenticationEntryPoint;
         this.restAccessDeniedHandler = restAccessDeniedHandler;
@@ -54,6 +58,7 @@ public class SecurityConfig {
                         .accessDeniedHandler(restAccessDeniedHandler)
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(mdcRequestIdFilter, JwtAuthenticationFilter.class)
                 .build();
     }
 }

--- a/src/main/java/com/ppiyaki/common/logging/MdcRequestIdFilter.java
+++ b/src/main/java/com/ppiyaki/common/logging/MdcRequestIdFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -16,6 +17,9 @@ public class MdcRequestIdFilter extends OncePerRequestFilter {
     public static final String REQUEST_ID_HEADER = "X-Request-Id";
     public static final String MDC_REQUEST_ID = "requestId";
 
+    // 영숫자 + dash + underscore, 1~128자. CRLF/제어문자/공백 차단해 로그·헤더 인젝션 회피.
+    private static final Pattern ALLOWED_REQUEST_ID = Pattern.compile("^[A-Za-z0-9_-]{1,128}$");
+
     @Override
     protected void doFilterInternal(
             final HttpServletRequest request,
@@ -23,7 +27,7 @@ public class MdcRequestIdFilter extends OncePerRequestFilter {
             final FilterChain filterChain
     ) throws ServletException, IOException {
         final String headerRequestId = request.getHeader(REQUEST_ID_HEADER);
-        final String requestId = headerRequestId != null && !headerRequestId.isBlank()
+        final String requestId = isValidIncomingId(headerRequestId)
                 ? headerRequestId
                 : UUID.randomUUID().toString();
         MDC.put(MDC_REQUEST_ID, requestId);
@@ -33,5 +37,9 @@ public class MdcRequestIdFilter extends OncePerRequestFilter {
         } finally {
             MDC.remove(MDC_REQUEST_ID);
         }
+    }
+
+    private static boolean isValidIncomingId(final String candidate) {
+        return candidate != null && ALLOWED_REQUEST_ID.matcher(candidate).matches();
     }
 }

--- a/src/main/java/com/ppiyaki/common/logging/MdcRequestIdFilter.java
+++ b/src/main/java/com/ppiyaki/common/logging/MdcRequestIdFilter.java
@@ -1,0 +1,37 @@
+package com.ppiyaki.common.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class MdcRequestIdFilter extends OncePerRequestFilter {
+
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String MDC_REQUEST_ID = "requestId";
+
+    @Override
+    protected void doFilterInternal(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final FilterChain filterChain
+    ) throws ServletException, IOException {
+        final String headerRequestId = request.getHeader(REQUEST_ID_HEADER);
+        final String requestId = headerRequestId != null && !headerRequestId.isBlank()
+                ? headerRequestId
+                : UUID.randomUUID().toString();
+        MDC.put(MDC_REQUEST_ID, requestId);
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_REQUEST_ID);
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- 기본 정의 (Spring Boot 기본값을 일부 재사용) -->
+    <conversionRule conversionWord="clr"
+                    class="org.springframework.boot.logging.logback.ColorConverter"/>
+    <conversionRule conversionWord="wEx"
+                    class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter"/>
+
+    <!-- local / default / test: 사람-친화 텍스트 (Spring Boot 기본 패턴 + MDC) -->
+    <springProfile name="!prod">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%clr(%d{HH:mm:ss.SSS}){faint} %clr(%-5level) %clr([%X{requestId:-}]){cyan} %clr([uid=%X{userId:-}]){blue} %clr(%-40.40logger{39}){magenta} : %m%n%wEx</pattern>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <!-- prod: JSON 한 줄/이벤트 (Loki/Grafana/CloudLog 등 어떤 collector에서도 파싱) -->
+    <springProfile name="prod">
+        <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <!-- 표준 필드 외 MDC 전체를 top-level로 평탄화 -->
+                <includeMdcKeyName>requestId</includeMdcKeyName>
+                <includeMdcKeyName>userId</includeMdcKeyName>
+                <!-- 한국 timezone, ISO-8601 -->
+                <timeZone>Asia/Seoul</timeZone>
+                <customFields>{"service":"ppiyaki-backend","env":"prod"}</customFields>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="JSON_CONSOLE"/>
+        </root>
+    </springProfile>
+
+</configuration>

--- a/src/test/java/com/ppiyaki/common/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/ppiyaki/common/auth/JwtAuthenticationFilterTest.java
@@ -3,10 +3,13 @@ package com.ppiyaki.common.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import java.io.IOException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -25,6 +28,7 @@ class JwtAuthenticationFilterTest {
     @AfterEach
     void clearSecurityContext() {
         SecurityContextHolder.clearContext();
+        MDC.clear();
     }
 
     @Test
@@ -91,5 +95,48 @@ class JwtAuthenticationFilterTest {
 
         // then
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("유효 토큰 → 체인 실행 중엔 MDC userId가 채워지고 종료 후엔 비워진다")
+    void valid_token_sets_user_mdc_during_chain_and_clears_after() throws ServletException, IOException {
+        // given
+        final Long userId = 333L;
+        final String token = jwtProvider.createAccessToken(userId, "SENIOR");
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        final UserIdCapturingChain chain = new UserIdCapturingChain();
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+        // then
+        assertThat(chain.userIdInsideChain).isEqualTo("333");
+        assertThat(MDC.get("userId")).isNull();
+    }
+
+    @Test
+    @DisplayName("토큰 없음 → MDC userId가 채워지지 않고 체인 후에도 null")
+    void no_token_leaves_user_mdc_null() throws ServletException, IOException {
+        // given
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final UserIdCapturingChain chain = new UserIdCapturingChain();
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+        // then
+        assertThat(chain.userIdInsideChain).isNull();
+        assertThat(MDC.get("userId")).isNull();
+    }
+
+    private static final class UserIdCapturingChain implements jakarta.servlet.FilterChain {
+
+        private String userIdInsideChain;
+
+        @Override
+        public void doFilter(final ServletRequest request, final ServletResponse response) {
+            userIdInsideChain = MDC.get("userId");
+        }
     }
 }

--- a/src/test/java/com/ppiyaki/common/logging/MdcRequestIdFilterTest.java
+++ b/src/test/java/com/ppiyaki/common/logging/MdcRequestIdFilterTest.java
@@ -61,6 +61,43 @@ class MdcRequestIdFilterTest {
     }
 
     @Test
+    @DisplayName("X-Request-Id 헤더에 제어문자가 있으면 무시하고 UUID로 폴백한다")
+    void rejects_control_characters() throws ServletException, IOException {
+        // given — CRLF 인젝션 시도 헤더
+        final String malicious = "trace-abc\r\nInjected: yes";
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(MdcRequestIdFilter.REQUEST_ID_HEADER, malicious);
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final CapturingFilterChain chain = new CapturingFilterChain();
+
+        // when
+        filter.doFilter(request, response, chain);
+
+        // then — 인입 헤더는 무시되고, 새 UUID가 생성되어야 함
+        assertThat(chain.requestIdSeen).isNotEqualTo(malicious);
+        assertThat(chain.requestIdSeen).matches("^[A-Za-z0-9-]{36}$"); // UUID 형식
+        assertThat(response.getHeader(MdcRequestIdFilter.REQUEST_ID_HEADER))
+                .doesNotContain("\r", "\n");
+    }
+
+    @Test
+    @DisplayName("X-Request-Id 헤더가 128자 초과면 무시하고 UUID로 폴백한다")
+    void rejects_overly_long_header() throws ServletException, IOException {
+        // given
+        final String tooLong = "a".repeat(129);
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(MdcRequestIdFilter.REQUEST_ID_HEADER, tooLong);
+        final CapturingFilterChain chain = new CapturingFilterChain();
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+        // then
+        assertThat(chain.requestIdSeen).isNotEqualTo(tooLong);
+        assertThat(chain.requestIdSeen.length()).isLessThanOrEqualTo(128);
+    }
+
+    @Test
     @DisplayName("필터 종료 후 MDC가 정리되어 다음 요청에 누수되지 않는다")
     void clears_mdc_after_chain() throws ServletException, IOException {
         // given

--- a/src/test/java/com/ppiyaki/common/logging/MdcRequestIdFilterTest.java
+++ b/src/test/java/com/ppiyaki/common/logging/MdcRequestIdFilterTest.java
@@ -1,0 +1,103 @@
+package com.ppiyaki.common.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@DisplayName("MdcRequestIdFilter")
+class MdcRequestIdFilterTest {
+
+    private final MdcRequestIdFilter filter = new MdcRequestIdFilter();
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
+    @Test
+    @DisplayName("X-Request-Id 헤더가 없으면 UUID를 생성해 MDC와 응답 헤더에 넣는다")
+    void generates_uuid_when_header_missing() throws ServletException, IOException {
+        // given
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final CapturingFilterChain chain = new CapturingFilterChain();
+
+        // when
+        filter.doFilter(request, response, chain);
+
+        // then
+        assertThat(chain.requestIdSeen).isNotBlank();
+        assertThat(response.getHeader(MdcRequestIdFilter.REQUEST_ID_HEADER))
+                .isEqualTo(chain.requestIdSeen);
+    }
+
+    @Test
+    @DisplayName("X-Request-Id 헤더가 있으면 그 값을 MDC와 응답 헤더에 그대로 사용한다")
+    void honors_incoming_header() throws ServletException, IOException {
+        // given
+        final String inbound = "trace-abc-123";
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(MdcRequestIdFilter.REQUEST_ID_HEADER, inbound);
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final CapturingFilterChain chain = new CapturingFilterChain();
+
+        // when
+        filter.doFilter(request, response, chain);
+
+        // then
+        assertThat(chain.requestIdSeen).isEqualTo(inbound);
+        assertThat(response.getHeader(MdcRequestIdFilter.REQUEST_ID_HEADER)).isEqualTo(inbound);
+    }
+
+    @Test
+    @DisplayName("필터 종료 후 MDC가 정리되어 다음 요청에 누수되지 않는다")
+    void clears_mdc_after_chain() throws ServletException, IOException {
+        // given
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+
+        // when
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        // then
+        assertThat(MDC.get(MdcRequestIdFilter.MDC_REQUEST_ID)).isNull();
+    }
+
+    @Test
+    @DisplayName("필터 체인 내부에서 예외가 나도 MDC를 정리한다")
+    void clears_mdc_when_chain_throws() {
+        // given
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final FilterChain throwingChain = (req, res) -> {
+            throw new ServletException("boom");
+        };
+
+        // when / then
+        try {
+            filter.doFilter(request, new MockHttpServletResponse(), throwingChain);
+        } catch (final ServletException | IOException expected) {
+            // pass
+        }
+        assertThat(MDC.get(MdcRequestIdFilter.MDC_REQUEST_ID)).isNull();
+    }
+
+    private static final class CapturingFilterChain implements FilterChain {
+
+        private String requestIdSeen;
+
+        @Override
+        public void doFilter(final ServletRequest request, final ServletResponse response) {
+            requestIdSeen = MDC.get(MdcRequestIdFilter.MDC_REQUEST_ID);
+        }
+    }
+}


### PR DESCRIPTION
## AS-IS

- prod 컨테이너 stdout이 비구조화 텍스트 — 어떤 collector로 보내도 파싱 비용이 큼
- 요청 단위 추적 불가 (HTTP access log 필터 없음, MDC 없음)
- 로그를 봐도 어떤 사용자의 어떤 요청인지 식별 어려움

## TO-BE

- prod 프로필에서 JSON 한 줄/이벤트로 출력 (LogstashEncoder)
- 매 요청마다 `requestId` MDC + 응답 `X-Request-Id` 헤더 (인입 헤더 있으면 그대로 사용 → 분산 추적 호환)
- 인증된 요청은 `userId`도 함께 MDC → 도메인 로그가 자동으로 user 컨텍스트를 가짐
- 로컬은 사람-친화 패턴 유지 — `13:31:43 INFO [3f1a-…] [uid=17] DashboardService : /dashboard/daily seniorId=16 …`

prod 예시 출력:
```json
{"@timestamp":"2026-05-14T13:00:00.000+09:00","level":"INFO","logger_name":"c.p.medication.service.DashboardService","message":"/dashboard/daily seniorId=16 date=2026-05-14","service":"ppiyaki-backend","env":"prod","requestId":"3f1a-…","userId":"17"}
```

## 관련 이슈
- closes #353

## 리뷰어 참고 포인트
- `build.gradle`에 `net.logstash.logback:logstash-logback-encoder:8.0` 1줄 추가 — **AI 보호 영역**이라 `needs-human-review` 라벨 부여
- `JwtAuthenticationFilter`에 try-finally 추가 — 인증 실패 경로에서는 MDC를 건드리지 않도록 boolean flag 사용
- `SecurityConfig.addFilterBefore(mdcRequestIdFilter, JwtAuthenticationFilter.class)` — requestId가 JWT 인증 흐름의 로그도 커버하도록 가장 앞에 등록
- 단위 테스트: 예외 던지는 체인에서도 MDC 정리 확인, 인입 `X-Request-Id` 헤더 보존 확인, 토큰 없을 때 userId MDC 비어있음 확인

## 후속 PR (별도 issue 예정)
- HTTP access log 필터 (method/URI/status/latency 한 줄)
- Sentry 도입 (에러 트래킹)
- Grafana Cloud 또는 NCP CloudLogAnalytics 연동

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료 (`type:feat`)
- [x] `scope:*` 라벨 1개 부여 완료 (`scope:infra`)
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [x] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 (`build.gradle`)

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크
- [x] `./gradlew checkstyleMain spotlessCheck` 통과
- [x] `./gradlew test` 통과 (신규 6 케이스 포함 전체)
- [x] 변경 범위의 회귀 가능 구간을 확인했다 (모든 인증 필터 경로 + 예외 경로 테스트)
- [x] 롤백 절차: 단순 revert로 가능 (스키마/데이터 마이그레이션 없음)

## DDD/OOP 준수 체크
- [x] 도메인 용어가 기존 컨텍스트와 일치한다 (인프라/공통 영역, 도메인 용어 변경 없음)
- [x] 계층 침범 없음 (`common.logging` 신규 패키지, 의존성 한 방향)
- [x] 객체 역할 명확 — 필터 하나의 단일 책임

## 보안/민감정보 체크
- [x] 시크릿 하드코딩 없음
- [x] 의료정보 로그 노출 없음 (logback 패턴이 application 로거만 노출, MDC 필드는 `requestId`/`userId`만)
- [x] Authorization 헤더, 응답 body 로깅 안 함

## 예외 머지 여부
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시: "어떻게 로깅을 하고 대시보드를 무엇으로 하면 좋을지 한번 깊게 고민해볼래?" → 단계적 로드맵 제안 → 사용자 승인 → "구조화 로깅 + MDC 진행해줘"
- AI가 직접 수정한 파일: 위 7개 파일 전체
- 사람이 수동 검증한 항목: PR 머지 전 검토 예정
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 요청 ID 추적 기능 추가 - 각 요청에 고유한 ID를 할당하여 로그에서 추적 가능하게 개선
  * 구조화된 로깅 지원 - 프로덕션 환경에서 JSON 형식의 로그 출력으로 로그 분석 개선

* **테스트**
  * 로깅 기능에 대한 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/354)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->