### PR TITLE
refactor(infra): common/mcp을 루트 mcp/로 이주 (#357)

### DIFF
--- a/src/main/java/com/ppiyaki/chat/ChatToolCallbackConfig.java
+++ b/src/main/java/com/ppiyaki/chat/ChatToolCallbackConfig.java
@@ -1,10 +1,10 @@
 package com.ppiyaki.chat;
 
-import com.ppiyaki.common.mcp.DrugInfoMcpTools;
-import com.ppiyaki.common.mcp.DurMcpTools;
-import com.ppiyaki.common.mcp.MedicationMcpTools;
-import com.ppiyaki.common.mcp.MedicineMcpTools;
-import com.ppiyaki.common.mcp.PillIdentificationMcpTools;
+import com.ppiyaki.mcp.DrugInfoMcpTools;
+import com.ppiyaki.mcp.DurMcpTools;
+import com.ppiyaki.mcp.MedicationMcpTools;
+import com.ppiyaki.mcp.MedicineMcpTools;
+import com.ppiyaki.mcp.PillIdentificationMcpTools;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.ai.support.ToolCallbacks;

--- a/src/main/java/com/ppiyaki/mcp/DrugInfoMcpTools.java
+++ b/src/main/java/com/ppiyaki/mcp/DrugInfoMcpTools.java
@@ -1,4 +1,4 @@
-package com.ppiyaki.common.mcp;
+package com.ppiyaki.mcp;
 
 import com.ppiyaki.common.druginfo.DrugInfoClient;
 import com.ppiyaki.common.druginfo.DrugInfoResponse;

--- a/src/main/java/com/ppiyaki/mcp/DurMcpTools.java
+++ b/src/main/java/com/ppiyaki/mcp/DurMcpTools.java
@@ -1,4 +1,4 @@
-package com.ppiyaki.common.mcp;
+package com.ppiyaki.mcp;
 
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;

--- a/src/main/java/com/ppiyaki/mcp/MedicationMcpTools.java
+++ b/src/main/java/com/ppiyaki/mcp/MedicationMcpTools.java
@@ -1,4 +1,4 @@
-package com.ppiyaki.common.mcp;
+package com.ppiyaki.mcp;
 
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;

--- a/src/main/java/com/ppiyaki/mcp/MedicineMcpTools.java
+++ b/src/main/java/com/ppiyaki/mcp/MedicineMcpTools.java
@@ -1,4 +1,4 @@
-package com.ppiyaki.common.mcp;
+package com.ppiyaki.mcp;
 
 import com.ppiyaki.medicine.controller.dto.MedicineCandidate;
 import com.ppiyaki.medicine.service.MatchResult;

--- a/src/main/java/com/ppiyaki/mcp/PillIdentificationMcpTools.java
+++ b/src/main/java/com/ppiyaki/mcp/PillIdentificationMcpTools.java
@@ -1,4 +1,4 @@
-package com.ppiyaki.common.mcp;
+package com.ppiyaki.mcp;
 
 import com.ppiyaki.medicine.PillIdentification;
 import com.ppiyaki.medicine.repository.PillIdentificationRepository;

--- a/src/test/java/com/ppiyaki/mcp/PillIdentificationMcpToolsTest.java
+++ b/src/test/java/com/ppiyaki/mcp/PillIdentificationMcpToolsTest.java
@@ -1,10 +1,10 @@
-package com.ppiyaki.common.mcp;
+package com.ppiyaki.mcp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.ppiyaki.common.mcp.PillIdentificationMcpTools.PillIdentifyResult;
+import com.ppiyaki.mcp.PillIdentificationMcpTools.PillIdentifyResult;
 import com.ppiyaki.medicine.PillIdentification;
 import com.ppiyaki.medicine.repository.PillIdentificationRepository;
 import java.time.LocalDateTime;


### PR DESCRIPTION
## AS-IS

`common/mcp/`에 MCP tool 5개가 위치. 각 tool이 자기 도메인 서비스(MedicationService 등)를 호출 → `common → domain` 역방향 의존.

## TO-BE

`com.ppiyaki.mcp/`로 이주. ADR 0010 §B 결정대로 의존 방향 정상화.

- 6 파일 이동 (5 main + 1 test)
- 패키지 선언/import 일괄 갱신
- 동작 동일

## 관련 이슈
- closes #357
- ADR: docs/decisions/0010-package-structure-standard.md §B

## 리뷰어 참고 포인트
- 단순 이동. import 외 로직 변경 없음.
- 전체 테스트 통과.

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 (`type:refactor`)
- [x] `scope:*` 라벨 1개 (`scope:infra`)
- [x] `ai-generated` 라벨
- [ ] `needs-human-review` — N/A

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성

## 품질 게이트
- [x] `./gradlew checkstyleMain spotlessCheck` 통과
- [x] `./gradlew test` 통과
- [x] 회귀 가능 구간 확인 (단순 이동, import만)
- [x] 롤백: revert로 가능

## DDD/OOP 준수
- [x] 도메인 용어 일치
- [x] 계층 침범 해소 (이 PR의 목적)
- [x] 객체 역할 변경 없음

## 보안/민감정보
- [x] 시크릿/의료정보 노출 없음

## 예외 머지 여부
- [x] 아님

## AI 작업 기록
- 지시: "자동 진행해" — ADR 0010 머지 후 자동 진행
- 수정 파일: 6개 mcp 클래스 + 1개 참조 (ChatToolCallbackConfig)
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)