### PR TITLE
docs(infra): ADR 0010 후속 — feature spec stale 패키지 경로 갱신 (#363)

### DIFF
--- a/docs/features/medication-notification.md
+++ b/docs/features/medication-notification.md
@@ -126,7 +126,7 @@ last_reviewed: 2026-05-10
 - Android + iOS(APNs는 FCM 경유) 단일 인터페이스.
 - 인증: Firebase Service Account JSON.
 - 환경변수: `FCM_PROJECT_ID`, `FCM_CREDENTIALS_JSON_BASE64` (또는 path).
-- 어댑터: `com.ppiyaki.notification.push.FcmPushSender`.
+- 어댑터: `com.ppiyaki.infrastructure.messaging.fcm.FcmPushSender`.
 - 실패 처리: 3회 exponential backoff retry. 5xx/4xx 분기. `NotFoundError` (token invalid) → device token `is_active=false`.
 - API 키 관리: `.env` + CD `docker run -e` 동기화 (피야키 CD 환경변수 룰).
 

--- a/docs/features/medication-schedule-meal-slot.md
+++ b/docs/features/medication-schedule-meal-slot.md
@@ -75,7 +75,7 @@ last_reviewed: 2026-05-07
 - 컨텍스트: `medication`
 - `MedicationSchedule.scheduled_time` (LocalTime) **제거**
 - `MedicationSchedule.meal_slot` (varchar, Java `MealSlot` enum) **추가, NOT NULL**
-- `MealSlot { BREAKFAST, LUNCH, DINNER }` — `com.ppiyaki.medication.MealSlot`
+- `MealSlot { BREAKFAST, LUNCH, DINNER }` — `com.ppiyaki.medication.domain.MealSlot`
 - `User.breakfastTime/lunchTime/dinnerTime` (Phase 1) 활용. 변경 없음.
 
 ### 5-2) API 엔드포인트
@@ -183,7 +183,7 @@ ALTER TABLE medication_schedules
 | `medication/controller/dto/ScheduleUpdateRequest.java` | 동일 |
 | `medication/controller/dto/ScheduleResponse.java` | `mealSlot` + 동적 `scheduledTime` |
 | `medication/service/MedicationLogService.java` (Phase 2 약 개수 검증) | 슬롯 기준 기대 카운트 쿼리로 전환 |
-| `common/mcp/MedicationMcpTools.java` | LLM 응답 시 슬롯→시각 변환 |
+| `mcp/MedicationMcpTools.java` | LLM 응답 시 슬롯→시각 변환 |
 | `resources/schema.sql` | 컬럼 정의 변경 |
 | `test/.../MedicationScheduleControllerE2ETest.java` | 입력/응답 갱신, 신규 400 케이스 |
 | `test/.../MedicationLogControllerE2ETest.java` | 슬롯 기반 schedule fixture |

--- a/docs/features/pill-identification.md
+++ b/docs/features/pill-identification.md
@@ -259,11 +259,11 @@ CREATE INDEX idx_pill_item_name ON pill_identifications (item_name);
 |---|---|
 | `medicine/PillIdentification.java` | **신규** 엔티티 |
 | `medicine/repository/PillIdentificationRepository.java` | **신규** + searchByAppearance 동적 쿼리 |
-| `common/mfds/MdcinGrnIdntfcInfoClient.java` | **신규** 식약처 OpenAPI 클라이언트 |
+| `infrastructure/mfds/MdcinGrnIdntfcInfoClient.java` | **신규** 식약처 OpenAPI 클라이언트 |
 | `medicine/service/PillIdentificationSyncService.java` | **신규** batch 동기화 |
 | `medicine/scheduler/PillIdentificationSyncScheduler.java` | **신규** `@Scheduled` cron |
 | `medicine/controller/AdminPillSyncController.java` | **신규** 수동 트리거 (비공개) |
-| `common/mcp/PillIdentificationMcpTools.java` | **신규** identifyPillByAppearance |
+| `mcp/PillIdentificationMcpTools.java` | **신규** identifyPillByAppearance |
 | `chat/ChatToolCallbackConfig.java` | PillIdentificationMcpTools 등록 |
 | `chat/service/ChatSessionService.java` | `PHOTO_SYSTEM_PROMPT` 갱신 (외형 묘사 추출 + 도구 호출 유도) |
 | `resources/schema.sql` | 테이블 + 인덱스 |

--- a/docs/features/prescription-schedule-auto-suggest.md
+++ b/docs/features/prescription-schedule-auto-suggest.md
@@ -170,7 +170,7 @@ ALTER TABLE prescription_medicine_candidates
 ### 5-6) 코드 영향 범위
 | 파일 | 변경 |
 |---|---|
-| `common/ai/OpenAiClient.java` | 시스템 프롬프트에 mealSlots 매핑 규칙. `ExtractedMedicine` record에 `List<MealSlot> mealSlots` 추가. 응답 파싱에 enum 검증 |
+| `infrastructure/ai/OpenAiClient.java` | 시스템 프롬프트에 mealSlots 매핑 규칙. `ExtractedMedicine` record에 `List<MealSlot> mealSlots` 추가. 응답 파싱에 enum 검증 |
 | `prescription/PrescriptionMedicineCandidate.java` | 컬럼 2개 + setter/도메인 메서드 |
 | `prescription/PrescriptionMedicineCandidateResponse.java` | 응답 필드 2개 |
 | `prescription/controller/dto/CandidateDecisionRequest.java` | `confirmedMealSlots` 추가 |


### PR DESCRIPTION
## AS-IS

PR #360/#361/#362 머지로 패키지 구조가 ADR 0010 표준으로 정리됐으나, 일부 feature spec이 옛 경로를 그대로 참조.

## TO-BE

6 라인 갱신 (4 파일):

| 파일 | from | to |
|---|---|---|
| medication-schedule-meal-slot.md | \`com.ppiyaki.medication.MealSlot\` | \`com.ppiyaki.medication.domain.MealSlot\` |
| medication-schedule-meal-slot.md | \`common/mcp/MedicationMcpTools.java\` | \`mcp/MedicationMcpTools.java\` |
| medication-notification.md | \`com.ppiyaki.notification.push.FcmPushSender\` | \`com.ppiyaki.infrastructure.messaging.fcm.FcmPushSender\` |
| pill-identification.md | \`common/mfds/MdcinGrnIdntfcInfoClient.java\` | \`infrastructure/mfds/MdcinGrnIdntfcInfoClient.java\` |
| pill-identification.md | \`common/mcp/PillIdentificationMcpTools.java\` | \`mcp/PillIdentificationMcpTools.java\` |
| prescription-schedule-auto-suggest.md | \`common/ai/OpenAiClient.java\` | \`infrastructure/ai/OpenAiClient.java\` |

\`medication-notification.md:96\`의 \`com.ppiyaki.medication.DeviceToken\`은 *과거 위치* 서술이라 그대로.

## 관련 이슈
- closes #363
- 참조: ADR 0010, PR #360 #361 #362

## 라벨 부여 확인
- [x] \`type:docs\`
- [x] \`scope:infra\`
- [x] \`ai-generated\`
- [ ] \`needs-human-review\` — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)