### PR TITLE
refactor(medication): photo_url → photo_object_key 리네임 + dosage legacy 컬럼 제거

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -64,7 +64,7 @@
 | OCR 원문 | Extracted Text | Clova OCR이 추출한 텍스트(구조화 전) |
 | 파싱 결과 | Parsed Result | LLM이 OCR 원문을 구조화한 약물 목록(JSON) |
 | 약물 | Medicine | 처방전에서 파생되거나 수동 등록된 복용 대상 |
-| 복약 일정 | Medication Schedule | 특정 약물을 어떤 식사 슬롯에 복용할지(`meal_slot`, `dosage`). 실제 시각은 시니어 mealTimes로 동적 계산 |
+| 복약 일정 | Medication Schedule | 특정 약물을 어떤 식사 슬롯에 복용할지(`meal_slot`, `dosage_quantity`/`dosage_unit`). 실제 시각은 시니어 mealTimes로 동적 계산 |
 | 식사 슬롯 | Meal Slot | 복약 일정이 묶이는 식사 단위. `BREAKFAST`/`LUNCH`/`DINNER`. 실제 시각은 시니어의 `breakfast_time`/`lunch_time`/`dinner_time`을 매번 참조 |
 | 제안 슬롯 | Suggested Meal Slots | OCR 시점에 LLM이 처방전 복약주기 텍스트로부터 제안한 식사 슬롯 후보. `prescription_medicine_candidates.suggested_meal_slots`(CSV)에 저장. 보호자 검수의 출발점 (Phase 3) |
 | 확정 슬롯 | Confirmed Meal Slots | 보호자가 검수·확정한 식사 슬롯. `prescription_medicine_candidates.confirmed_meal_slots`(CSV). confirm 시 슬롯별 `medication_schedules` 자동 생성에 사용 (Phase 3) |
@@ -230,10 +230,9 @@ OCR + LLM 파싱으로 추출된 약물 후보. 처방전 1건당 N행. 보호�
 | 컬럼 | 타입 | 설명 |
 |---|---|---|
 | id | bigint PK | |
-| medicine_id | bigint | `medicines.id` 참조 |
+| medicine_id | bigint NOT NULL | `medicines.id` 참조 |
 | meal_slot | varchar | DB는 varchar, Java는 `MealSlot` enum(`BREAKFAST`/`LUNCH`/`DINNER`). NOT NULL. 실제 시각은 시니어 mealTimes로 동적 계산 |
-| dosage | varchar | 1회 복용량 raw 문자열 (예: `1정`). **deprecated 예정** — 정수+단위 분리 컬럼으로 점차 이전 (spec `dosage-quantity-unit-split.md`) |
-| dosage_quantity | decimal(5,2) nullable | 1회 복용량의 수치(분수 허용, 예: `1`, `0.5`). PRN 등 정의되지 않은 케이스는 NULL. release 직후 옛 row는 모두 NULL |
+| dosage_quantity | decimal(5,2) nullable | 1회 복용량의 수치(분수 허용, 예: `1`, `0.5`). PRN 등 정의되지 않은 케이스는 NULL |
 | dosage_unit | varchar(16) nullable | 단위 문자열(예: `정`, `캡슐`, `ml`, `mg`, `PRN`). 표준화 enum은 별도 follow-up |
 | days_of_week | varchar | 요일 패턴 (예: `MON,TUE,WED,THU,FRI` 또는 `DAILY`). 7비트 마스크 대신 가독성 우선 |
 | start_date | date | 복약 시작일 |
@@ -253,7 +252,7 @@ OCR + LLM 파싱으로 추출된 약물 후보. 처방전 1건당 N행. 보호�
 | target_date | date (`LocalDate`) | 예정 복약 일자 |
 | taken_at | datetime (`LocalDateTime`) nullable | 실제 확인 시각 |
 | status | varchar | 사용자 확정 상태. Java는 `LogStatus` enum(`TAKEN`/`MISSED`/`PENDING`) |
-| photo_url | varchar nullable | 복약 인증 사진. **값은 NCP Object Storage의 `objectKey`** (예: `medication-log/{userId}/{uuid}.jpg`) — 응답 시 서버가 endpoint·bucket을 조립해 full URL로 반환. 컬럼명 리네임은 별도 리팩터 이슈 |
+| photo_object_key | varchar nullable | 복약 인증 사진의 NCP Object Storage `objectKey` (예: `medication-log/{userId}/{uuid}.jpg`). 응답 시 서버가 endpoint·bucket을 조립해 full URL(`photoUrl`)로 반환 |
 | ai_status | varchar nullable | Vision LLM 약 개수 검증 결과. Java `LogAiStatus` enum: `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED` (Phase 2). 사진 + status=TAKEN일 때만 채워짐. 컬럼명은 Phase 3(알약 식별) 추가 시 `pill_count_status`로 리네임 + `pill_identification_status` 분리 예정 |
 | is_proxy | boolean | 보호자 대리 처리 여부 (= `confirmed_by_user_id != senior_id`의 캐시) |
 | confirmed_by_user_id | bigint nullable | 실제로 상태를 확정한 사용자(`users.id` 참조). 시니어 본인일 수도, 보호자일 수도 있음 |
@@ -508,7 +507,6 @@ erDiagram
         bigint id PK
         bigint medicine_id FK
         varchar meal_slot "BREAKFAST/LUNCH/DINNER"
-        varchar dosage "deprecated"
         decimal dosage_quantity "nullable"
         varchar dosage_unit "nullable"
         varchar days_of_week
@@ -523,7 +521,7 @@ erDiagram
         date target_date
         datetime taken_at
         varchar status
-        varchar photo_url
+        varchar photo_object_key
         varchar ai_status
         boolean is_proxy
         bigint confirmed_by_user_id FK

--- a/src/main/java/com/ppiyaki/mcp/MedicationMcpTools.java
+++ b/src/main/java/com/ppiyaki/mcp/MedicationMcpTools.java
@@ -57,7 +57,7 @@ public class MedicationMcpTools {
                 result.add(new ScheduleSummary(
                         medicine.getName(),
                         resolved != null ? resolved.toString() : null,
-                        schedule.getDosage()
+                        schedule.composeDosageText()
                 ));
             }
         }

--- a/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/ScheduleResponse.java
@@ -28,7 +28,7 @@ public record ScheduleResponse(
                 schedule.getMedicineId(),
                 schedule.getMealSlot(),
                 schedule.getMealSlot().resolveTime(owner),
-                schedule.getDosage(),
+                schedule.composeDosageText(),
                 schedule.getDosageQuantity() != null
                         ? schedule.getDosageQuantity().stripTrailingZeros()
                         : null,

--- a/src/main/java/com/ppiyaki/medication/domain/MedicationLog.java
+++ b/src/main/java/com/ppiyaki/medication/domain/MedicationLog.java
@@ -46,12 +46,7 @@ public class MedicationLog extends CreatedTimeEntity {
     @Column(name = "status", nullable = false)
     private LogStatus status;
 
-    /**
-     * `photo_url` 컬럼에 실제로는 objectKey를 저장한다 (spec medication-log §5-1, §9 Q2 결정).
-     * 응답에서는 서버가 endpoint/bucket을 조립한 full URL로 변환해 내려준다.
-     * 컬럼명 리네임은 별도 리팩터 이슈.
-     */
-    @Column(name = "photo_url")
+    @Column(name = "photo_object_key")
     private String photoObjectKey;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/ppiyaki/medication/domain/MedicationSchedule.java
+++ b/src/main/java/com/ppiyaki/medication/domain/MedicationSchedule.java
@@ -26,15 +26,12 @@ public class MedicationSchedule extends CreatedTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "medicine_id")
+    @Column(name = "medicine_id", nullable = false)
     private Long medicineId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "meal_slot", nullable = false, length = 16)
     private MealSlot mealSlot;
-
-    @Column(name = "dosage")
-    private String dosage;
 
     @Column(name = "dosage_quantity", precision = 5, scale = 2)
     private BigDecimal dosageQuantity;
@@ -65,7 +62,6 @@ public class MedicationSchedule extends CreatedTimeEntity {
         this.mealSlot = Objects.requireNonNull(mealSlot, "mealSlot must not be null");
         this.dosageQuantity = dosageQuantity;
         this.dosageUnit = dosageUnit;
-        this.dosage = composeLegacyDosage(dosageQuantity, dosageUnit);
         this.daysOfWeek = daysOfWeek;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -86,14 +82,10 @@ public class MedicationSchedule extends CreatedTimeEntity {
             this.dosageQuantity = dosageQuantity;
         }
         if (dosageUnit != null) {
-            // PRN으로 전환 시 quantity는 의미 없음 — null로 정정 (legacy dosage 합성 시 비정상값 회피)
             if (dosageUnit == DosageUnit.PRN) {
                 this.dosageQuantity = null;
             }
             this.dosageUnit = dosageUnit;
-        }
-        if (dosageQuantity != null || dosageUnit != null) {
-            this.dosage = composeLegacyDosage(this.dosageQuantity, this.dosageUnit);
         }
         if (daysOfWeek != null) {
             this.daysOfWeek = daysOfWeek;
@@ -106,16 +98,13 @@ public class MedicationSchedule extends CreatedTimeEntity {
         }
     }
 
-    /**
-     * 옛 dosage String 컬럼은 PR 4(다음 release)에서 drop 예정. 그때까지 호환성을 위해
-     * 분리 두 필드로부터 합성. quantity와 unit이 둘 다 null이면 dosage도 null.
-     */
-    private static String composeLegacyDosage(final BigDecimal quantity, final DosageUnit unit) {
-        if (quantity == null && unit == null) {
+    public String composeDosageText() {
+        if (this.dosageQuantity == null && this.dosageUnit == null) {
             return null;
         }
-        final String quantityText = quantity != null ? quantity.stripTrailingZeros().toPlainString() : "";
-        final String unitText = unit != null ? unit.getDisplayValue() : "";
+        final String quantityText = this.dosageQuantity != null
+                ? this.dosageQuantity.stripTrailingZeros().toPlainString() : "";
+        final String unitText = this.dosageUnit != null ? this.dosageUnit.getDisplayValue() : "";
         return quantityText + unitText;
     }
 }

--- a/src/main/java/com/ppiyaki/medication/service/DashboardService.java
+++ b/src/main/java/com/ppiyaki/medication/service/DashboardService.java
@@ -339,7 +339,7 @@ public class DashboardService {
         for (final MedicationSchedule s : slotSchedules) {
             final Medicine m = medicineById.get(s.getMedicineId());
             if (m != null) {
-                slotMedicines.add(new SlotMedicine(m.getId(), m.getName(), s.getDosage()));
+                slotMedicines.add(new SlotMedicine(m.getId(), m.getName(), s.composeDosageText()));
             }
         }
         return new SlotInfo(slot, status, mealTime, takenAt, photoUrl, slotMedicines);

--- a/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
@@ -185,7 +185,7 @@ public class MedicationDelayDispatcher {
      * 같은 슬롯에 여러 schedule 알림이 발송될 때 보호자가 어떤 약인지 구분 가능하게 함 (issue #345).
      */
     private String resolveMedicineLabel(final MedicationSchedule schedule) {
-        final String dosage = schedule.getDosage();
+        final String dosage = schedule.composeDosageText();
         final String medicineName = medicineRepository.findById(schedule.getMedicineId())
                 .map(Medicine::getName)
                 .orElse("약");

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
@@ -258,7 +258,8 @@ class MedicationLogControllerE2ETest {
         final MedicationSchedule schedule = ctor.newInstance();
         setField(schedule, "medicineId", medicineId);
         setField(schedule, "mealSlot", MealSlot.BREAKFAST);
-        setField(schedule, "dosage", "1정");
+        setField(schedule, "dosageQuantity", new java.math.BigDecimal("1"));
+        setField(schedule, "dosageUnit", com.ppiyaki.medication.domain.DosageUnit.TABLET);
         setField(schedule, "daysOfWeek", "DAILY");
         setField(schedule, "startDate", LocalDate.of(2026, 4, 1));
         return medicationScheduleRepository.save(schedule).getId();

--- a/src/test/java/com/ppiyaki/medication/domain/MedicationScheduleTest.java
+++ b/src/test/java/com/ppiyaki/medication/domain/MedicationScheduleTest.java
@@ -44,7 +44,7 @@ class MedicationScheduleTest {
     }
 
     @Test
-    @DisplayName("update로 PRN 전환 시 dosageQuantity는 null로 강제 — legacy dosage 비정상 합성 회피")
+    @DisplayName("update로 PRN 전환 시 dosageQuantity는 null로 강제 — composeDosageText 비정상 합성 회피")
     void update_toPRN_clearsDosageQuantity() {
         final MedicationSchedule schedule = new MedicationSchedule(
                 1L, MealSlot.BREAKFAST, BigDecimal.ONE, DosageUnit.TABLET, "DAILY", LocalDate.now(), null);
@@ -53,7 +53,6 @@ class MedicationScheduleTest {
 
         assertThat(schedule.getDosageQuantity()).isNull();
         assertThat(schedule.getDosageUnit()).isEqualTo(DosageUnit.PRN);
-        // legacy dosage = "PRN" (quantity 없음)
-        assertThat(schedule.getDosage()).isEqualTo("PRN");
+        assertThat(schedule.composeDosageText()).isEqualTo("PRN");
     }
 }

--- a/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/DashboardServiceTest.java
@@ -434,7 +434,6 @@ class DashboardServiceTest {
         setField(s, "id", id);
         setField(s, "medicineId", medicineId);
         setField(s, "mealSlot", slot);
-        setField(s, "dosage", dosage);
         if (dosage != null) {
             final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
                     .matcher(dosage);

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -322,9 +322,7 @@ class MedicationLogServicePhase2Test {
         final MedicationSchedule s = ctor.newInstance();
         setField(s, "id", id);
         setField(s, "medicineId", MEDICINE_ID);
-        setField(s, "dosage", dosage);
         setField(s, "mealSlot", MEAL_SLOT);
-        // legacy raw 입력을 정수+단위로 정규화. 정수 매칭 안 되면 quantity null (PRN/반알 등)
         if (dosage != null) {
             final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
                     .matcher(dosage);

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -523,9 +523,7 @@ class MedicationLogServiceTest {
         setField(schedule, "id", SCHEDULE_ID);
         setField(schedule, "medicineId", MEDICINE_ID);
         setField(schedule, "mealSlot", com.ppiyaki.medication.domain.MealSlot.BREAKFAST);
-        // legacy "1정"/"2정"/"반정" raw 입력을 정수+단위로 정규화
         if (dosage != null) {
-            setField(schedule, "dosage", dosage);
             final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
                     .matcher(dosage);
             if (m.find()) {

--- a/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
@@ -197,7 +197,15 @@ class MedicationDelayDispatcherTest {
         setField(s, "id", id);
         setField(s, "medicineId", medicineId);
         setField(s, "mealSlot", MealSlot.BREAKFAST);
-        setField(s, "dosage", dosage);
+        if (dosage != null) {
+            final java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+(?:\\.\\d+)?)(.*)$")
+                    .matcher(dosage);
+            if (m.find()) {
+                setField(s, "dosageQuantity", new java.math.BigDecimal(m.group(1)));
+                setField(s, "dosageUnit",
+                        com.ppiyaki.medication.domain.DosageUnit.fromInput(m.group(2).trim()).orElse(null));
+            }
+        }
         return s;
     }
 

--- a/src/test/java/com/ppiyaki/prescription/controller/PrescriptionMutationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/prescription/controller/PrescriptionMutationControllerE2ETest.java
@@ -175,7 +175,8 @@ class PrescriptionMutationControllerE2ETest {
                         {
                             "itemSeq": "199500096",
                             "itemName": "타이레놀정 500mg",
-                            "dosage": "1정",
+                            "dosageQuantity": 1,
+                            "dosageUnit": "TABLET",
                             "schedule": "1일 3회"
                         }
                         """)


### PR DESCRIPTION
## AS-IS
- `medication_logs.photo_url` 컬럼명이 실제 저장 값(NCP Object Storage `objectKey`)과 어긋남. 엔티티는 이미 `photoObjectKey` 필드로 매핑했으나 DB 컬럼명은 옛 이름 잔존.
- `medication_schedules.dosage` (varchar) 레거시 컬럼이 `dosage_quantity` + `dosage_unit` 분리 후에도 호환용으로 entity·DB 양쪽에 남아있음(`composeLegacyDosage()` 합성).

## TO-BE
- DB 컬럼 `photo_url` → `photo_object_key`. 엔티티 `@Column` 갱신.
- `medication_schedules.dosage` 컬럼·엔티티 필드 제거. 응답에서 dosage 키는 entity의 `composeDosageText()` 합성으로 유지(`dosage_quantity` + `dosage_unit` → "1정" 등).
- `medication_schedules.medicine_id` NOT NULL 명시(이미 prod DB는 NOT NULL).
- `06-domain-model.md` ERD/엔티티 표 갱신.

## 프론트 영향
**없음.** 응답 키(`photoUrl`, `dosage`) 모두 그대로 유지. DB 컬럼명/엔티티 필드명만 변경.

## prod 마이그레이션 (release 머지 시 동반 실행)
```sql
ALTER TABLE medication_logs CHANGE photo_url photo_object_key varchar(255);
ALTER TABLE medication_schedules DROP COLUMN dosage;
```
옛 컬럼명으로 INSERT/UPDATE하는 prod 백엔드(현재 운영 중)와 충돌하므로 ALTER + 새 백엔드 deploy를 동시에 진행해야 함. 메모 패턴: `project_pending_prod_migration_2026_05_12`.

## 테스트
- 단위/E2E 전체 통과 (`./gradlew checkstyleMain spotlessCheck test`).
- legacy `dosage` 필드 reflection 세팅하던 테스트 helper 5종을 `dosageQuantity` + `dosageUnit` 기반으로 정리.

## AI 작업 체크리스트
- [x] Feature Spec 갱신 불필요 (단순 리네임/cleanup, 신규 기능 아님)
- [x] 엔티티 변경 → `06-domain-model.md` ERD·표 갱신 완료
- [x] Notion API 명세 변경 없음 (응답 키 동일)
- [x] 에러 코드/인덱스 변경 없음
- [x] 보호 영역 변경 없음 (`db/migration`, `application*.yml`, `build.gradle` 등 미수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 약물 복용 일정 관리 도메인 모델 정의 업데이트

* **Refactor**
  * 복약량 정보 저장 구조 개선 (수량 및 단위 분리)
  * 복약 인증 이미지 저장소 참조 방식 정정

* **Tests**
  * 업데이트된 데이터 구조에 맞게 전체 테스트 코드 수정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->