### PR TITLE
refactor(user): users.pet → pet_id, users.dob → birth_date 컬럼 리네임

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -102,8 +102,8 @@
 | role | varchar | DB는 varchar로 자유도 유지, Java는 `UserRole` enum(`SENIOR`/`CAREGIVER`)로 다루며 컨버터로 변환 |
 | nickname | varchar | 사용자 표시 이름 |
 | gender | varchar | DB는 varchar, Java는 `Gender` enum(`MALE`/`FEMALE`/`OTHER`/`UNKNOWN`) |
-| dob | date | 생년월일 |
-| pet | bigint | `pets.id` PK 참조 (FK 제약 선언 여부는 §7-12) |
+| birth_date | date | 생년월일 |
+| pet_id | bigint | `pets.id` PK 참조 (FK 제약 선언 여부는 §7-12) |
 | care_mode | varchar | DB는 varchar, Java는 `CareMode` enum(`MANAGED` default / `AUTONOMOUS`). 시니어 회원에 적용. 보호자 회원도 컬럼은 갖지만 처방전 흐름에서는 `prescription.owner_id`로 참조하는 시니어 측 값만 사용 |
 | breakfast_time | time nullable | 시니어 식사 시간대(아침). Java는 `LocalTime`. 미설정 가능. Phase 1: 클라이언트가 schedule 등록 시 활용. Phase 2~3: 슬롯 매핑/자동 생성 (별도 spec) |
 | lunch_time | time nullable | 시니어 식사 시간대(점심). 동일 |
@@ -422,8 +422,8 @@ erDiagram
         varchar role
         varchar nickname
         varchar gender
-        date dob
-        bigint pet FK
+        date birth_date
+        bigint pet_id FK
         varchar care_mode "MANAGED default / AUTONOMOUS"
         time breakfast_time "nullable"
         time lunch_time "nullable"

--- a/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
+++ b/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
@@ -52,14 +52,14 @@ public class PetPointListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMedicationTaken(final MedicationTakenEvent event) {
         final User user = userRepository.findById(event.seniorId()).orElse(null);
-        if (user == null || user.getPet() == null) {
+        if (user == null || user.getPetId() == null) {
             log.debug("Pet not linked for seniorId={}, skipping point", event.seniorId());
             return;
         }
 
-        final Pet pet = petRepository.findById(user.getPet()).orElse(null);
+        final Pet pet = petRepository.findById(user.getPetId()).orElse(null);
         if (pet == null) {
-            log.debug("Pet entity not found for petId={}, skipping point", user.getPet());
+            log.debug("Pet entity not found for petId={}, skipping point", user.getPetId());
             return;
         }
 

--- a/src/main/java/com/ppiyaki/pet/service/PetService.java
+++ b/src/main/java/com/ppiyaki/pet/service/PetService.java
@@ -36,11 +36,11 @@ public class PetService {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        if (user.getPet() == null) {
+        if (user.getPetId() == null) {
             throw new BusinessException(ErrorCode.PET_NOT_FOUND);
         }
 
-        final Pet pet = petRepository.findById(user.getPet())
+        final Pet pet = petRepository.findById(user.getPetId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.PET_NOT_FOUND));
 
         pet.checkAndResetIfInactive(LocalDate.now());

--- a/src/main/java/com/ppiyaki/user/controller/dto/SeniorCreateRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/SeniorCreateRequest.java
@@ -5,6 +5,6 @@ import java.time.LocalDate;
 
 public record SeniorCreateRequest(
         @NotBlank String nickname,
-        LocalDate dob
+        LocalDate birthDate
 ) {
 }

--- a/src/main/java/com/ppiyaki/user/controller/dto/SeniorSummaryResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/SeniorSummaryResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 public record SeniorSummaryResponse(
         Long id,
         String nickname,
-        LocalDate dob,
+        LocalDate birthDate,
         Gender gender,
         CareMode careMode
 ) {
@@ -17,7 +17,7 @@ public record SeniorSummaryResponse(
         return new SeniorSummaryResponse(
                 user.getId(),
                 user.getNickname(),
-                user.getDob(),
+                user.getBirthDate(),
                 user.getGender(),
                 user.getCareMode()
         );

--- a/src/main/java/com/ppiyaki/user/domain/User.java
+++ b/src/main/java/com/ppiyaki/user/domain/User.java
@@ -45,11 +45,11 @@ public class User extends BaseTimeEntity {
     @Column(name = "gender")
     private Gender gender;
 
-    @Column(name = "dob")
-    private LocalDate dob;
+    @Column(name = "birth_date")
+    private LocalDate birthDate;
 
-    @Column(name = "pet")
-    private Long pet;
+    @Column(name = "pet_id")
+    private Long petId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "auth_provider", nullable = false)
@@ -81,8 +81,8 @@ public class User extends BaseTimeEntity {
             final AuthProvider authProvider,
             final String nickname,
             final Gender gender,
-            final LocalDate dob,
-            final Long pet
+            final LocalDate birthDate,
+            final Long petId
     ) {
         this.loginId = loginId;
         this.password = password;
@@ -90,14 +90,14 @@ public class User extends BaseTimeEntity {
         this.authProvider = Objects.requireNonNull(authProvider, "authProvider must not be null");
         this.nickname = nickname;
         this.gender = gender;
-        this.dob = dob;
-        this.pet = pet;
+        this.birthDate = birthDate;
+        this.petId = petId;
         this.careMode = CareMode.MANAGED;
     }
 
-    public static User createSenior(final String nickname, final LocalDate dob) {
+    public static User createSenior(final String nickname, final LocalDate birthDate) {
         return new User(null, null, UserRole.SENIOR, AuthProvider.INVITE_ONLY,
-                nickname, null, dob, null);
+                nickname, null, birthDate, null);
     }
 
     public static User createSenior(final String nickname, final Gender gender) {
@@ -116,7 +116,7 @@ public class User extends BaseTimeEntity {
     }
 
     public void assignPet(final Long petId) {
-        this.pet = Objects.requireNonNull(petId, "petId must not be null");
+        this.petId = Objects.requireNonNull(petId, "petId must not be null");
     }
 
     public void changeCareMode(final CareMode careMode) {

--- a/src/main/java/com/ppiyaki/user/service/SeniorService.java
+++ b/src/main/java/com/ppiyaki/user/service/SeniorService.java
@@ -31,7 +31,7 @@ public class SeniorService {
     @Transactional
     public SeniorCreateResponse createSenior(final Long caregiverId, final SeniorCreateRequest seniorCreateRequest) {
         final User senior = userRepository.save(
-                User.createSenior(seniorCreateRequest.nickname(), seniorCreateRequest.dob()));
+                User.createSenior(seniorCreateRequest.nickname(), seniorCreateRequest.birthDate()));
 
         final Pet pet = petRepository.save(Pet.create());
         senior.assignPet(pet.getId());

--- a/src/test/java/com/ppiyaki/notification/controller/NotificationSettingsControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/NotificationSettingsControllerE2ETest.java
@@ -30,7 +30,7 @@ class NotificationSettingsControllerE2ETest {
         jdbcTemplate.update("DELETE FROM care_relations WHERE caregiver_id IN "
                 + "(SELECT id FROM users WHERE login_id IN ('ns_owner', 'ns_other'))");
         jdbcTemplate.update("DELETE FROM pets WHERE id IN "
-                + "(SELECT pet FROM users WHERE nickname = 'NS시니어' AND pet IS NOT NULL)");
+                + "(SELECT pet_id FROM users WHERE nickname = 'NS시니어' AND pet_id IS NOT NULL)");
         jdbcTemplate.update("DELETE FROM users WHERE nickname = 'NS시니어'");
         jdbcTemplate.update("DELETE FROM refresh_tokens WHERE user_id IN "
                 + "(SELECT id FROM users WHERE login_id IN ('ns_owner', 'ns_other'))");

--- a/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/pet/controller/PetControllerE2ETest.java
@@ -30,7 +30,7 @@ class PetControllerE2ETest {
         jdbcTemplate.update("DELETE FROM refresh_tokens WHERE user_id IN "
                 + "(SELECT id FROM users WHERE login_id = 'pet_e2e_user')");
         jdbcTemplate.update("DELETE FROM pets WHERE id IN "
-                + "(SELECT pet FROM users WHERE login_id = 'pet_e2e_user' AND pet IS NOT NULL)");
+                + "(SELECT pet_id FROM users WHERE login_id = 'pet_e2e_user' AND pet_id IS NOT NULL)");
         jdbcTemplate.update("DELETE FROM users WHERE login_id = 'pet_e2e_user'");
     }
 
@@ -59,7 +59,7 @@ class PetControllerE2ETest {
                 "INSERT INTO pets (point, streak, highest_stage, created_at, updated_at) VALUES (40, 0, 'EGG', NOW(6), NOW(6))");
         final Long petId = jdbcTemplate.queryForObject(
                 "SELECT id FROM pets WHERE point = 40 ORDER BY id DESC LIMIT 1", Long.class);
-        jdbcTemplate.update("UPDATE users SET pet = ? WHERE login_id = 'pet_e2e_user'", petId);
+        jdbcTemplate.update("UPDATE users SET pet_id = ? WHERE login_id = 'pet_e2e_user'", petId);
 
         // when & then
         RestAssured.given()

--- a/src/test/java/com/ppiyaki/pet/service/PetPointListenerTest.java
+++ b/src/test/java/com/ppiyaki/pet/service/PetPointListenerTest.java
@@ -56,7 +56,7 @@ class PetPointListenerTest {
     void onMedicationTaken_addsPoint() {
         // given
         final User user = mock(User.class);
-        lenient().when(user.getPet()).thenReturn(1L);
+        lenient().when(user.getPetId()).thenReturn(1L);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
         final Pet pet = Pet.create();
@@ -74,7 +74,7 @@ class PetPointListenerTest {
     void onMedicationTaken_noPet_skips() {
         // given
         final User user = mock(User.class);
-        lenient().when(user.getPet()).thenReturn(null);
+        lenient().when(user.getPetId()).thenReturn(null);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
         // when
@@ -100,7 +100,7 @@ class PetPointListenerTest {
     void onMedicationTaken_allTaken_incrementsStreak() {
         // given
         final User user = mock(User.class);
-        lenient().when(user.getPet()).thenReturn(1L);
+        lenient().when(user.getPetId()).thenReturn(1L);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
         final Pet pet = Pet.create();
@@ -132,7 +132,7 @@ class PetPointListenerTest {
     void onMedicationTaken_moreLogsThanSchedules_noStreakIncrease() {
         // given
         final User user = mock(User.class);
-        lenient().when(user.getPet()).thenReturn(1L);
+        lenient().when(user.getPetId()).thenReturn(1L);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
         final Pet pet = Pet.create();
@@ -166,7 +166,7 @@ class PetPointListenerTest {
     void onMedicationTaken_someMissed_noStreakIncrease() {
         // given
         final User user = mock(User.class);
-        lenient().when(user.getPet()).thenReturn(1L);
+        lenient().when(user.getPetId()).thenReturn(1L);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
         final Pet pet = Pet.create();

--- a/src/test/java/com/ppiyaki/pet/service/PetServiceTest.java
+++ b/src/test/java/com/ppiyaki/pet/service/PetServiceTest.java
@@ -42,7 +42,7 @@ class PetServiceTest {
     void readMyPet_success() {
         // given
         final User user = mock(User.class);
-        lenient().when(user.getPet()).thenReturn(1L);
+        lenient().when(user.getPetId()).thenReturn(1L);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
         final Pet pet = Pet.create();
@@ -64,7 +64,7 @@ class PetServiceTest {
     void readMyPet_noPet_throwsNotFound() {
         // given
         final User user = mock(User.class);
-        lenient().when(user.getPet()).thenReturn(null);
+        lenient().when(user.getPetId()).thenReturn(null);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
         // when & then

--- a/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
@@ -35,7 +35,7 @@ class CareRelationControllerE2ETest {
         jdbcTemplate.update("DELETE FROM refresh_tokens WHERE user_id IN "
                 + "(SELECT id FROM users WHERE nickname = '시니어코드E2E')");
         jdbcTemplate.update("DELETE FROM pets WHERE id IN "
-                + "(SELECT pet FROM users WHERE nickname = '시니어코드E2E' AND pet IS NOT NULL)");
+                + "(SELECT pet_id FROM users WHERE nickname = '시니어코드E2E' AND pet_id IS NOT NULL)");
         jdbcTemplate.update("DELETE FROM users WHERE nickname = '시니어코드E2E'");
         jdbcTemplate.update("DELETE FROM users WHERE login_id = 'cg_code_e2e'");
     }
@@ -67,7 +67,7 @@ class CareRelationControllerE2ETest {
                 .body("""
                         {
                             "nickname": "시니어코드E2E",
-                            "dob": "1945-03-15"
+                            "birthDate": "1945-03-15"
                         }
                         """)
                 .when()
@@ -138,7 +138,7 @@ class CareRelationControllerE2ETest {
                 .body("""
                         {
                             "nickname": "시니어코드E2E",
-                            "dob": "1945-03-15"
+                            "birthDate": "1945-03-15"
                         }
                         """)
                 .when()

--- a/src/test/java/com/ppiyaki/user/controller/OnboardingControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/OnboardingControllerE2ETest.java
@@ -31,7 +31,7 @@ class OnboardingControllerE2ETest {
         jdbcTemplate.update("DELETE FROM care_relations WHERE caregiver_id IN "
                 + "(SELECT id FROM users WHERE login_id = 'onboard_e2e')");
         jdbcTemplate.update("DELETE FROM pets WHERE id IN "
-                + "(SELECT pet FROM users WHERE nickname IN ('온보딩할머니', '온보딩할아버지') AND pet IS NOT NULL)");
+                + "(SELECT pet_id FROM users WHERE nickname IN ('온보딩할머니', '온보딩할아버지') AND pet_id IS NOT NULL)");
         jdbcTemplate.update("DELETE FROM refresh_tokens WHERE user_id IN "
                 + "(SELECT id FROM users WHERE login_id = 'onboard_e2e')");
         jdbcTemplate.update("DELETE FROM users WHERE nickname IN ('온보딩할머니', '온보딩할아버지')");

--- a/src/test/java/com/ppiyaki/user/controller/SeniorControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/SeniorControllerE2ETest.java
@@ -29,7 +29,7 @@ class SeniorControllerE2ETest {
         jdbcTemplate.update("DELETE FROM refresh_tokens WHERE user_id IN "
                 + "(SELECT id FROM users WHERE login_id = 'cg_senior_e2e')");
         jdbcTemplate.update("DELETE FROM pets WHERE id IN "
-                + "(SELECT pet FROM users WHERE nickname = '시니어E2E대리' AND pet IS NOT NULL)");
+                + "(SELECT pet_id FROM users WHERE nickname = '시니어E2E대리' AND pet_id IS NOT NULL)");
         jdbcTemplate.update("DELETE FROM users WHERE nickname = '시니어E2E대리'");
         jdbcTemplate.update("DELETE FROM users WHERE login_id = 'cg_senior_e2e'");
     }
@@ -61,7 +61,7 @@ class SeniorControllerE2ETest {
                 .body("""
                         {
                             "nickname": "시니어E2E대리",
-                            "dob": "1945-03-15"
+                            "birthDate": "1945-03-15"
                         }
                         """)
                 .when()


### PR DESCRIPTION
## AS-IS
- `users.pet` 컬럼이 FK 의미를 명시하지 않음. 엔티티 필드도 `pet` (Long).
- `users.dob` 컬럼이 풀네임 컨벤션(§8)에서 어긋남.
- `SeniorCreateRequest.dob`, `SeniorSummaryResponse.dob`로 API에 그대로 노출 중.

## TO-BE
- DB 컬럼: `users.pet` → `pet_id`, `users.dob` → `birth_date`.
- 엔티티 필드: `pet` → `petId`, `dob` → `birthDate`.
- 응답/요청 JSON 키: `dob` → `birthDate`. (펫은 응답 DTO에 이미 `petId` 키로 노출되어 있어 외부 변경 없음.)
- `getPet()` → `getPetId()` 사용처 갱신 (`PetService`, `PetPointListener` 등).
- E2E 테스트 cleanup SQL의 옛 컬럼명 동시 정정.
- `06-domain-model.md` ERD/엔티티 표 갱신.

## 프론트 영향
**있음** — `dob` JSON 키가 `birthDate`로 변경:
- 시니어 생성 요청 body: `dob` → `birthDate` (POST `/api/v1/seniors`, POST `/api/v1/care-relations/seniors` 등 SeniorCreateRequest 사용처)
- 시니어 정보 응답 body: `dob` → `birthDate` (SeniorSummaryResponse 노출 엔드포인트)

`pet` → `pet_id`는 응답 DTO가 이미 `petId` 키였으므로 외부 노출 변경 없음.

## prod 마이그레이션 (release 머지 시 동반 실행)
```sql
ALTER TABLE users CHANGE pet pet_id bigint;
ALTER TABLE users CHANGE dob birth_date date;
```
옛 컬럼명으로 SELECT/UPDATE하는 prod 백엔드(현재 운영 중)와 충돌하므로 ALTER + 새 백엔드 deploy를 동시에 진행.

## 테스트
- 단위/E2E 전체 통과 (`./gradlew checkstyleMain spotlessCheck test`).

## AI 작업 체크리스트
- [x] Feature Spec 갱신 불필요 (필드 리네임)
- [x] 엔티티 변경 → `06-domain-model.md` ERD·표 갱신 완료
- [x] Notion API 명세 갱신 필요 — `dob` → `birthDate` 키 변경 반영 필요 (프론트 협의와 함께 진행)
- [x] 에러 코드/인덱스 변경 없음
- [x] 보호 영역 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 내부 데이터 필드명을 보다 명확한 명명 규칙으로 정렬했습니다. 생년월일 및 반려동물 식별자 관련 필드의 일관성을 개선하여 코드 유지보수성을 강화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->