### PR TITLE
refactor(medication): ai_status → pill_count_status 리네임 (Phase 3 분리 사전 정리)

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -68,9 +68,9 @@
 | 식사 슬롯 | Meal Slot | 복약 일정이 묶이는 식사 단위. `BREAKFAST`/`LUNCH`/`DINNER`. 실제 시각은 시니어의 `breakfast_time`/`lunch_time`/`dinner_time`을 매번 참조 |
 | 제안 슬롯 | Suggested Meal Slots | OCR 시점에 LLM이 처방전 복약주기 텍스트로부터 제안한 식사 슬롯 후보. `prescription_medicine_candidates.suggested_meal_slots`(CSV)에 저장. 보호자 검수의 출발점 (Phase 3) |
 | 확정 슬롯 | Confirmed Meal Slots | 보호자가 검수·확정한 식사 슬롯. `prescription_medicine_candidates.confirmed_meal_slots`(CSV). confirm 시 슬롯별 `medication_schedules` 자동 생성에 사용 (Phase 3) |
-| 복약 기록 | Medication Log | 실제 복용 이행 여부 기록 (`status`, `ai_status`) |
+| 복약 기록 | Medication Log | 실제 복용 이행 여부 기록 (`status`, `pill_count_status`) |
 | 복약 상태 | Log Status | 복약 기록의 사용자 확정 상태. `TAKEN` / `MISSED` / `PENDING`. `medication_logs.status`에 enum 매핑 |
-| AI 검증 상태 | Log AI Status | 복약 인증 사진 약 개수 AI 검증 결과. `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED`. `medication_logs.ai_status`에 enum 매핑 (Phase 2). 사진 + status=TAKEN일 때만 채워짐 |
+| 알약 개수 검증 상태 | Log Pill Count Status | 복약 인증 사진 약 개수 AI 검증 결과. `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED`. `medication_logs.pill_count_status`에 enum 매핑 (Phase 2). 사진 + status=TAKEN일 때만 채워짐. Phase 3(낱알 식별) 진입 시 `pill_identification_status` 컬럼 분리 예정 |
 | 복약 이행률 | Adherence Rate | 기간 내 성공 복약 / 예정 복약 |
 | 대리 처리 | Proxy Confirmation | 보호자가 시니어 대신 복용 상태를 확정 (`is_proxy=true`, `confirmed_by_user_id != senior_id`) |
 | 보호자 승인 모드 | Care Mode | 시니어의 처방전 변경 권한 정책. `MANAGED`(보호자 검증 강제, 0~72h 보호자 전용 + 72h 후 시니어 fallback) / `AUTONOMOUS`(시니어 즉시 변경 허용). `users.care_mode`에 저장. 변경은 보호자만 가능 |
@@ -253,7 +253,7 @@ OCR + LLM 파싱으로 추출된 약물 후보. 처방전 1건당 N행. 보호�
 | taken_at | datetime (`LocalDateTime`) nullable | 실제 확인 시각 |
 | status | varchar | 사용자 확정 상태. Java는 `LogStatus` enum(`TAKEN`/`MISSED`/`PENDING`) |
 | photo_object_key | varchar nullable | 복약 인증 사진의 NCP Object Storage `objectKey` (예: `medication-log/{userId}/{uuid}.jpg`). 응답 시 서버가 endpoint·bucket을 조립해 full URL(`photoUrl`)로 반환 |
-| ai_status | varchar nullable | Vision LLM 약 개수 검증 결과. Java `LogAiStatus` enum: `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED` (Phase 2). 사진 + status=TAKEN일 때만 채워짐. 컬럼명은 Phase 3(알약 식별) 추가 시 `pill_count_status`로 리네임 + `pill_identification_status` 분리 예정 |
+| pill_count_status | varchar nullable | Vision LLM 약 개수 검증 결과. Java `LogPillCountStatus` enum: `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED` (Phase 2). 사진 + status=TAKEN일 때만 채워짐. Phase 3(낱알 식별) 진입 시 `pill_identification_status` 컬럼 분리 예정 |
 | is_proxy | boolean | 보호자 대리 처리 여부 (= `confirmed_by_user_id != senior_id`의 캐시) |
 | confirmed_by_user_id | bigint nullable | 실제로 상태를 확정한 사용자(`users.id` 참조). 시니어 본인일 수도, 보호자일 수도 있음 |
 | created_at | timestamp | `CreatedTimeEntity` |
@@ -522,7 +522,7 @@ erDiagram
         datetime taken_at
         varchar status
         varchar photo_object_key
-        varchar ai_status
+        varchar pill_count_status
         boolean is_proxy
         bigint confirmed_by_user_id FK
         timestamp created_at

--- a/src/main/java/com/ppiyaki/medication/controller/dto/MedicationLogResponse.java
+++ b/src/main/java/com/ppiyaki/medication/controller/dto/MedicationLogResponse.java
@@ -1,6 +1,6 @@
 package com.ppiyaki.medication.controller.dto;
 
-import com.ppiyaki.medication.domain.LogAiStatus;
+import com.ppiyaki.medication.domain.LogPillCountStatus;
 import com.ppiyaki.medication.domain.LogStatus;
 import com.ppiyaki.medication.domain.MedicationLog;
 import java.time.LocalDate;
@@ -14,7 +14,7 @@ public record MedicationLogResponse(
         LocalDateTime takenAt,
         LogStatus status,
         String photoUrl,
-        LogAiStatus aiStatus,
+        LogPillCountStatus pillCountStatus,
         Boolean isProxy,
         Long confirmedByUserId,
         LocalDateTime createdAt
@@ -29,7 +29,7 @@ public record MedicationLogResponse(
                 log.getTakenAt(),
                 log.getStatus(),
                 photoUrl,
-                log.getAiStatus(),
+                log.getPillCountStatus(),
                 log.getIsProxy(),
                 log.getConfirmedByUserId(),
                 log.getCreatedAt()

--- a/src/main/java/com/ppiyaki/medication/domain/LogPillCountStatus.java
+++ b/src/main/java/com/ppiyaki/medication/domain/LogPillCountStatus.java
@@ -1,6 +1,6 @@
 package com.ppiyaki.medication.domain;
 
-public enum LogAiStatus {
+public enum LogPillCountStatus {
 
     /** Vision 추출 개수 == dosage 합 */
     COUNT_MATCH,

--- a/src/main/java/com/ppiyaki/medication/domain/MedicationLog.java
+++ b/src/main/java/com/ppiyaki/medication/domain/MedicationLog.java
@@ -50,8 +50,8 @@ public class MedicationLog extends CreatedTimeEntity {
     private String photoObjectKey;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "ai_status")
-    private LogAiStatus aiStatus;
+    @Column(name = "pill_count_status")
+    private LogPillCountStatus pillCountStatus;
 
     @Column(name = "is_proxy", nullable = false)
     private Boolean isProxy;
@@ -93,7 +93,7 @@ public class MedicationLog extends CreatedTimeEntity {
         this.photoObjectKey = photoObjectKey;
     }
 
-    public void updateAiStatus(final LogAiStatus aiStatus) {
-        this.aiStatus = aiStatus;
+    public void updatePillCountStatus(final LogPillCountStatus pillCountStatus) {
+        this.pillCountStatus = pillCountStatus;
     }
 }

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -8,7 +8,7 @@ import com.ppiyaki.infrastructure.storage.PhotoUrlAssembler;
 import com.ppiyaki.medication.controller.dto.MedicationLogListResponse;
 import com.ppiyaki.medication.controller.dto.MedicationLogResponse;
 import com.ppiyaki.medication.controller.dto.MedicationLogUpsertRequest;
-import com.ppiyaki.medication.domain.LogAiStatus;
+import com.ppiyaki.medication.domain.LogPillCountStatus;
 import com.ppiyaki.medication.domain.LogStatus;
 import com.ppiyaki.medication.domain.MedicationLog;
 import com.ppiyaki.medication.domain.MedicationSchedule;
@@ -146,11 +146,11 @@ public class MedicationLogService {
         // Phase 2: 사진 + status=TAKEN일 때 약 개수 AI 검증 (spec medication-log-phase2 §5-4)
         if (request.status() == LogStatus.TAKEN
                 && request.photoObjectKey() != null && !request.photoObjectKey().isBlank()) {
-            final LogAiStatus aiStatus = verifyPillCount(seniorId, schedule, request);
-            log.updateAiStatus(aiStatus);
+            final LogPillCountStatus pillCountStatus = verifyPillCount(seniorId, schedule, request);
+            log.updatePillCountStatus(pillCountStatus);
             // COUNT_MATCH일 때 슬롯의 다른 active schedule도 TAKEN 전파 (issue #343).
             // 시니어가 슬롯 전체 약을 사진 한 장에 담아 인증한 경우 == 슬롯 전체 인증으로 인정.
-            if (aiStatus == LogAiStatus.COUNT_MATCH) {
+            if (pillCountStatus == LogPillCountStatus.COUNT_MATCH) {
                 propagateTakenToSlotSchedules(seniorId, schedule, request, takenAt, isProxy, userId);
             }
         }
@@ -163,7 +163,7 @@ public class MedicationLogService {
      * spec medication-log-phase2 §5-4: AI COUNT_MATCH 시 슬롯 전체 인증으로 인정.
      *
      * <p>이미 TAKEN인 row는 skip (멱등). 새로 TAKEN 전환되는 schedule의 medicine 잔여분도 차감.
-     * propagated log의 aiStatus는 COUNT_MATCH로 마킹 (슬롯 전체가 검증된 상태이므로).
+     * propagated log의 pillCountStatus는 COUNT_MATCH로 마킹 (슬롯 전체가 검증된 상태이므로).
      */
     private void propagateTakenToSlotSchedules(
             final Long seniorId,
@@ -194,7 +194,7 @@ public class MedicationLogService {
                     .orElseGet(() -> medicationLogRepository.saveAndFlush(new MedicationLog(
                             seniorId, peer.getId(), request.targetDate(),
                             takenAt, LogStatus.TAKEN, request.photoObjectKey(), isProxy, recorderId)));
-            peerLog.updateAiStatus(LogAiStatus.COUNT_MATCH);
+            peerLog.updatePillCountStatus(LogPillCountStatus.COUNT_MATCH);
 
             final BigDecimal dosageQuantity = peer.getDosageQuantity();
             if (dosageQuantity != null) {
@@ -211,7 +211,7 @@ public class MedicationLogService {
      * 동일 식사 슬롯 schedule들의 dosage 합 vs Vision 추출 개수 비교.
      * spec medication-log-phase2 §5-4.
      */
-    private LogAiStatus verifyPillCount(
+    private LogPillCountStatus verifyPillCount(
             final Long seniorId,
             final MedicationSchedule triggerSchedule,
             final MedicationLogUpsertRequest request
@@ -224,12 +224,12 @@ public class MedicationLogService {
         for (final MedicationSchedule s : schedules) {
             final BigDecimal quantity = s.getDosageQuantity();
             if (quantity == null) {
-                return LogAiStatus.COUNT_UNKNOWN;
+                return LogPillCountStatus.COUNT_UNKNOWN;
             }
             expected += quantity.setScale(0, java.math.RoundingMode.CEILING).intValueExact();
         }
         if (schedules.isEmpty()) {
-            return LogAiStatus.COUNT_UNKNOWN;
+            return LogPillCountStatus.COUNT_UNKNOWN;
         }
 
         final byte[] imageBytes;
@@ -239,14 +239,14 @@ public class MedicationLogService {
                     .key(request.photoObjectKey())
                     .build()).asByteArray();
         } catch (final Exception e) {
-            return LogAiStatus.COUNT_FAILED;
+            return LogPillCountStatus.COUNT_FAILED;
         }
         final String mediaType = guessMediaType(request.photoObjectKey());
         final Optional<Integer> actual = openAiClient.countPills(imageBytes, mediaType);
         if (actual.isEmpty()) {
-            return LogAiStatus.COUNT_FAILED;
+            return LogPillCountStatus.COUNT_FAILED;
         }
-        return actual.get() == expected ? LogAiStatus.COUNT_MATCH : LogAiStatus.COUNT_MISMATCH;
+        return actual.get() == expected ? LogPillCountStatus.COUNT_MATCH : LogPillCountStatus.COUNT_MISMATCH;
     }
 
     private String guessMediaType(final String objectKey) {

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -11,7 +11,7 @@ import com.ppiyaki.infrastructure.ai.OpenAiClient;
 import com.ppiyaki.infrastructure.storage.NcpStorageProperties;
 import com.ppiyaki.infrastructure.storage.PhotoUrlAssembler;
 import com.ppiyaki.medication.controller.dto.MedicationLogUpsertRequest;
-import com.ppiyaki.medication.domain.LogAiStatus;
+import com.ppiyaki.medication.domain.LogPillCountStatus;
 import com.ppiyaki.medication.domain.LogStatus;
 import com.ppiyaki.medication.domain.MealSlot;
 import com.ppiyaki.medication.domain.MedicationLog;
@@ -74,7 +74,7 @@ class MedicationLogServicePhase2Test {
     private static final String VALID_OBJECT_KEY = "medication-log/100/9b3e7a1c-8d55-4f0a-b2e1-5f9a7b3d8c21.jpg";
 
     @Test
-    @DisplayName("status=MISSED면 AI 검증 스킵, ai_status=null")
+    @DisplayName("status=MISSED면 AI 검증 스킵, pill_count_status=null")
     void status_missed_skip_verification() throws Exception {
         givenScheduleAndMedicine();
         givenUpsertSucceeds();
@@ -112,7 +112,7 @@ class MedicationLogServicePhase2Test {
         service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
                 SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
 
-        assertThat(saved.get().getAiStatus()).isEqualTo(LogAiStatus.COUNT_MATCH);
+        assertThat(saved.get().getPillCountStatus()).isEqualTo(LogPillCountStatus.COUNT_MATCH);
     }
 
     @Test
@@ -128,7 +128,7 @@ class MedicationLogServicePhase2Test {
         service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
                 SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
 
-        assertThat(saved.get().getAiStatus()).isEqualTo(LogAiStatus.COUNT_MISMATCH);
+        assertThat(saved.get().getPillCountStatus()).isEqualTo(LogPillCountStatus.COUNT_MISMATCH);
     }
 
     @Test
@@ -142,7 +142,7 @@ class MedicationLogServicePhase2Test {
         service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
                 SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
 
-        assertThat(saved.get().getAiStatus()).isEqualTo(LogAiStatus.COUNT_UNKNOWN);
+        assertThat(saved.get().getPillCountStatus()).isEqualTo(LogPillCountStatus.COUNT_UNKNOWN);
         verify(openAiClient, never()).countPills(any(), any());
     }
 
@@ -159,7 +159,7 @@ class MedicationLogServicePhase2Test {
         service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
                 SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
 
-        assertThat(saved.get().getAiStatus()).isEqualTo(LogAiStatus.COUNT_FAILED);
+        assertThat(saved.get().getPillCountStatus()).isEqualTo(LogPillCountStatus.COUNT_FAILED);
     }
 
     @Test


### PR DESCRIPTION
## AS-IS
- `medication_logs.ai_status` 컬럼명이 광범위해서 Phase 3(낱알 식별) 추가 시 의미 충돌. 현재 enum 값은 모두 `COUNT_*`로 개수 검증에 한정.
- 향후 `IDENT_*` 같은 식별 결과를 같이 담아야 하는데 컬럼 하나로는 표현 불가(혼합 케이스 `COUNT_MATCH + IDENT_MISMATCH` 등).

## TO-BE
- DB 컬럼 `ai_status` → `pill_count_status` (단순 리네임).
- Java enum `LogAiStatus` → `LogPillCountStatus`.
- enum 값(`COUNT_MATCH`/`COUNT_MISMATCH`/`COUNT_UNKNOWN`/`COUNT_FAILED`)은 그대로 유지 — prod 데이터 마이그레이션 없음.
- entity 필드/메서드: `aiStatus` → `pillCountStatus`, `updateAiStatus` → `updatePillCountStatus`.
- 응답 DTO 키: `aiStatus` → `pillCountStatus` (`MedicationLogResponse`).
- `06-domain-model.md` 유비쿼터스 랭귀지/엔티티 표/ERD 갱신.

## 보류 — Phase 3 spec과 함께
메모 `project_pill_status_column_rename`의 5단계 중 다음은 Phase 3 spec 트랙으로 분리:
- `pill_identification_status` 컬럼 신설
- `LogPillIdentificationStatus` enum 신설

Phase 3 spec 없이 신설하면 enum 값 정의 근거 없음. 본 PR은 컬럼 리네임만 선행.

## 프론트 영향
**있음** — 응답 JSON 키 `aiStatus` → `pillCountStatus`:
- 영향 엔드포인트: `MedicationLogResponse` 노출 API (PUT/GET `/api/v1/medication-logs` 등)
- enum 값(`COUNT_MATCH` 문자열)은 그대로라 표시·매핑 로직 변경 불필요. 키 이름만 갈아주면 됨.

## prod 마이그레이션 (release 머지 시 동반)
```sql
ALTER TABLE medication_logs CHANGE ai_status pill_count_status varchar(32);
```

## 테스트
- 단위/E2E 전체 통과 (`./gradlew checkstyleMain spotlessCheck test`).

## AI 작업 체크리스트
- [x] Feature Spec 갱신 불필요 (단순 리네임)
- [x] 엔티티 변경 → `06-domain-model.md` 갱신 완료
- [x] Notion API 명세 갱신 필요 — 응답 키 변경 반영
- [x] 보호 영역 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 약 개수 검증 상태 필드의 명칭을 명확하게 개선하여 시스템 일관성을 강화했습니다. API 응답, 데이터베이스 스키마, 도메인 모델이 통일된 표현을 사용하도록 정렬되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->