### PR TITLE
feat(infra): Actuator + Micrometer 도입 + 외부 API 캐시 hit/miss 메트릭

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation platform('software.amazon.awssdk:bom:2.28.29')
     implementation 'software.amazon.awssdk:s3'
     implementation platform('org.springframework.ai:spring-ai-bom:1.1.4')

--- a/docs/ai-harness/00-index.md
+++ b/docs/ai-harness/00-index.md
@@ -18,6 +18,7 @@
 - `docs/ai-harness/07-testing-guide.md`: 레이어별 테스트 전략 및 필수 기준
 - `docs/ai-harness/08-code-conventions.md`: 코드 컨벤션 (final/어노테이션/DTO/엔티티/Lombok/null 검증 등)
 - `docs/ai-harness/09-notion-api-spec.md`: Notion API 명세 연동 가이드 (DB 구조, 갱신 규칙, NOTION_API_KEY 관리)
+- `docs/ai-harness/10-observability.md`: 관측성 (Actuator + Micrometer) 메트릭/포트/Phase 2 계획
 
 ## 3-1) 관련 자산
 - `prompts/`: 재사용 프롬프트 저장소 (운영 규칙은 `05-prompt-ops.md`)

--- a/docs/ai-harness/10-observability.md
+++ b/docs/ai-harness/10-observability.md
@@ -1,0 +1,50 @@
+# 관측성 (Observability)
+
+> Spring Boot Actuator + Micrometer 기반. Phase 1은 백엔드 endpoint 노출만, Phase 2(시각화 인프라)는 별도.
+
+## 1) 관리 포트와 노출 endpoint
+
+- **포트**: `MANAGEMENT_PORT` 환경변수(기본 `8081`). 메인 8080과 분리.
+- **공개 endpoint**: `health`, `info`, `metrics`, `prometheus`
+- **외부 노출**: `backend-cd.yml`이 8080만 publish하므로 8081은 **prod에서 외부 접근 불가**. SSH 접속자(또는 같은 Docker network 내 컨테이너)만 호출 가능.
+- Security 설정상 `/actuator/**`는 인증 우회(permitAll). 외부 미노출이 보안 경계.
+
+## 2) 주요 메트릭
+
+### 캐시 hit/miss
+| Counter | 태그 | 의미 |
+|---|---|---|
+| `ppiyaki.cache.hits` | `cache=mfds` | MFDS API 응답 캐시 적중 |
+| `ppiyaki.cache.misses` | `cache=mfds` | MFDS API 응답 캐시 미스 (외부 호출 발생) |
+| `ppiyaki.cache.hits` | `cache=drug_info` | DrugInfo API 응답 캐시 적중 |
+| `ppiyaki.cache.misses` | `cache=drug_info` | DrugInfo API 응답 캐시 미스 |
+| `ppiyaki.cache.hits` | `cache=dur_check` | DUR 점검 결과 캐시 적중 (24h, DB-backed) |
+| `ppiyaki.cache.misses` | `cache=dur_check` | DUR 점검 결과 캐시 미스 (실측 트리거) |
+
+적중률 = `hits / (hits + misses)` per cache tag.
+
+### 자동 노출 메트릭 (Micrometer)
+- `http.server.requests` (히스토그램 활성)
+- `jvm.memory.used`, `jvm.gc.*`
+- `hikaricp.connections.*`
+- `system.cpu.usage`
+
+전체 목록은 `/actuator/metrics`.
+
+## 3) prod 조회 방법 (Phase 1)
+
+```bash
+ssh -i ~/workspace/secret/ppiyaki-key.pem -p 22 ubuntu@211.188.48.217
+sudo docker exec ppiyaki-server curl -s http://localhost:8081/actuator/prometheus | grep ppiyaki_cache
+```
+
+또는 메트릭 단건:
+```bash
+sudo docker exec ppiyaki-server curl -s "http://localhost:8081/actuator/metrics/ppiyaki.cache.hits?tag=cache:mfds"
+```
+
+## 4) Phase 2 (예정)
+
+- Prometheus pull-style scrape (호스팅 위치 TBD)
+- Grafana 대시보드 (캐시 적중률, HTTP latency p95, JVM, DB)
+- 외부 노출 시 actuator 인증 추가 필요 (bearer token / basic auth / IP allowlist)

--- a/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
+++ b/src/main/java/com/ppiyaki/common/auth/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/v1/auth/**",
                                 "/h2-console/**",
-                                "/actuator/health"
+                                "/actuator/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/ppiyaki/health/service/DurCheckService.java
+++ b/src/main/java/com/ppiyaki/health/service/DurCheckService.java
@@ -15,6 +15,8 @@ import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -51,6 +53,8 @@ public class DurCheckService {
     private final CareRelationRepository careRelationRepository;
     private final MfdsApiClient mfdsApiClient;
     private final com.ppiyaki.notification.service.DurWarningDispatcher durWarningDispatcher;
+    private final Counter cacheHitCounter;
+    private final Counter cacheMissCounter;
 
     public DurCheckService(
             final DurCheckRepository durCheckRepository,
@@ -58,7 +62,8 @@ public class DurCheckService {
             final MedicationScheduleRepository medicationScheduleRepository,
             final CareRelationRepository careRelationRepository,
             final MfdsApiClient mfdsApiClient,
-            final com.ppiyaki.notification.service.DurWarningDispatcher durWarningDispatcher
+            final com.ppiyaki.notification.service.DurWarningDispatcher durWarningDispatcher,
+            final MeterRegistry meterRegistry
     ) {
         this.durCheckRepository = durCheckRepository;
         this.medicineRepository = medicineRepository;
@@ -66,6 +71,14 @@ public class DurCheckService {
         this.careRelationRepository = careRelationRepository;
         this.mfdsApiClient = mfdsApiClient;
         this.durWarningDispatcher = durWarningDispatcher;
+        this.cacheHitCounter = Counter.builder("ppiyaki.cache.hits")
+                .tag("cache", "dur_check")
+                .description("DUR 점검 결과 캐시 hit (24h, DB-backed)")
+                .register(meterRegistry);
+        this.cacheMissCounter = Counter.builder("ppiyaki.cache.misses")
+                .tag("cache", "dur_check")
+                .description("DUR 점검 결과 캐시 miss (MFDS API 호출 트리거)")
+                .register(meterRegistry);
     }
 
     @Transactional
@@ -86,10 +99,12 @@ public class DurCheckService {
                     .findFirstByMedicineIdAndComboHashAndCheckedAtAfterAndWarningLevelIsNotNullOrderByCheckedAtDesc(
                             medicineId, comboHash, LocalDateTime.now().minusHours(CACHE_TTL_HOURS));
             if (cached.isPresent()) {
+                cacheHitCounter.increment();
                 log.debug("DUR Layer 2 cache hit: medicineId={} comboHash={}", medicineId, comboHash);
                 return DurCheckResponse.from(cached.get(), List.of(), true);
             }
         }
+        cacheMissCounter.increment();
 
         final List<DurWarningItem> warnings = new ArrayList<>();
 

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoClient.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoClient.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.infrastructure.mfds.MfdsApiProperties;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -32,11 +34,14 @@ public class DrugInfoClient {
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final Map<String, CachedDrugInfo> cache = new ConcurrentHashMap<>();
+    private final Counter cacheHitCounter;
+    private final Counter cacheMissCounter;
 
     public DrugInfoClient(
             final MfdsApiProperties properties,
             final RestClient.Builder restClientBuilder,
-            final ObjectMapper objectMapper
+            final ObjectMapper objectMapper,
+            final MeterRegistry meterRegistry
     ) {
         this.serviceKey = properties.serviceKey();
         this.objectMapper = objectMapper;
@@ -46,15 +51,26 @@ public class DrugInfoClient {
         factory.setReadTimeout(Duration.ofSeconds(5));
 
         this.restClient = restClientBuilder.requestFactory(factory).build();
+
+        this.cacheHitCounter = Counter.builder("ppiyaki.cache.hits")
+                .tag("cache", "drug_info")
+                .description("DrugInfo API 응답 캐시 hit")
+                .register(meterRegistry);
+        this.cacheMissCounter = Counter.builder("ppiyaki.cache.misses")
+                .tag("cache", "drug_info")
+                .description("DrugInfo API 응답 캐시 miss (외부 API 호출 발생)")
+                .register(meterRegistry);
     }
 
     public Optional<DrugInfoResponse> search(final String itemName) {
         final String cacheKey = itemName.strip().toLowerCase();
         final CachedDrugInfo cached = cache.get(cacheKey);
         if (cached != null && cached.expiresAt().isAfter(Instant.now())) {
+            cacheHitCounter.increment();
             return cached.response();
         }
 
+        cacheMissCounter.increment();
         log.info("DrugInfo API call: itemName={}", itemName);
         try {
             final String url = API_URL

--- a/src/main/java/com/ppiyaki/infrastructure/mfds/MfdsApiClient.java
+++ b/src/main/java/com/ppiyaki/infrastructure/mfds/MfdsApiClient.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -32,12 +34,15 @@ public class MfdsApiClient {
     private final MfdsResponseCache cache;
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
+    private final Counter cacheHitCounter;
+    private final Counter cacheMissCounter;
 
     public MfdsApiClient(
             final MfdsApiProperties properties,
             final MfdsResponseCache cache,
             final RestClient.Builder restClientBuilder,
-            final ObjectMapper objectMapper
+            final ObjectMapper objectMapper,
+            final MeterRegistry meterRegistry
     ) {
         this.properties = properties;
         this.cache = cache;
@@ -50,6 +55,15 @@ public class MfdsApiClient {
         this.restClient = restClientBuilder
                 .requestFactory(factory)
                 .build();
+
+        this.cacheHitCounter = Counter.builder("ppiyaki.cache.hits")
+                .tag("cache", "mfds")
+                .description("MFDS API 응답 캐시 hit")
+                .register(meterRegistry);
+        this.cacheMissCounter = Counter.builder("ppiyaki.cache.misses")
+                .tag("cache", "mfds")
+                .description("MFDS API 응답 캐시 miss (외부 API 호출 발생)")
+                .register(meterRegistry);
     }
 
     public CachedMfdsResponse call(
@@ -59,10 +73,12 @@ public class MfdsApiClient {
     ) {
         final Optional<CachedMfdsResponse> cached = cache.get(operation, cacheKey);
         if (cached.isPresent()) {
+            cacheHitCounter.increment();
             log.debug("MFDS cache hit: operation={} key={}", operation, cacheKey);
             return cached.get();
         }
 
+        cacheMissCounter.increment();
         log.info("MFDS API call: operation={} key={}", operation, cacheKey);
         final long startTime = System.currentTimeMillis();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,3 +68,20 @@ openai:
 fcm:
   project-id: ${FCM_PROJECT_ID:}
   credentials-json-base64: ${FCM_CREDENTIALS_JSON_BASE64:}
+
+management:
+  server:
+    port: ${MANAGEMENT_PORT:8081}
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: never
+  metrics:
+    tags:
+      application: ppiyaki-backend
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true


### PR DESCRIPTION
## AS-IS
- 외부 API 캐시 3종(MFDS, DrugInfo, DUR) 동작 중인데 **적중률을 측정할 인프라가 없음**.
- 캐시 hit 로그는 `log.debug(...)`라 prod root level=INFO에서 안 찍힘.
- `/actuator/*` endpoint 자체가 없어 표준 관측성 도구로 메트릭 노출 불가.

## TO-BE
Phase 1 — 백엔드 측 endpoint 노출 (이 PR 범위)

- `spring-boot-starter-actuator` + `micrometer-registry-prometheus` 의존성 추가.
- `management.server.port=${MANAGEMENT_PORT:8081}` 별도 포트로 분리. 메인 8080은 그대로.
- exposure: `health, info, metrics, prometheus`.
- 캐시 3종에 Counter instrumentation:
  - `ppiyaki.cache.hits{cache="mfds"|"drug_info"|"dur_check"}`
  - `ppiyaki.cache.misses{cache="..."}`
- `http.server.requests` 히스토그램 활성 (p95/p99 측정).
- `SecurityConfig`: `/actuator/**` permitAll. **외부 노출 안 됨** — `backend-cd.yml`의 `-p 8080:8080`만 그대로라 8081은 prod에서 외부 접근 불가. SSH 접속자(또는 같은 docker network 컨테이너)만 호출 가능.

Phase 2 (별도 작업) — Prometheus/Grafana 호스팅 위치 결정 후 진행

## 보호 영역
- `build.gradle`: 의존성 2건 추가
- `src/main/resources/application.yml`: management 블록 신설
- → `needs-human-review` 라벨 부여

## 검증
- `./gradlew checkstyleMain spotlessCheck test` 전체 통과.
- prod 조회(머지 후):
  ```bash
  sudo docker exec ppiyaki-server curl -s "http://localhost:8081/actuator/metrics/ppiyaki.cache.hits?tag=cache:mfds"
  ```

## 영향 없음
- 외부 API 응답 / 프론트 / 기존 동작 변경 없음.
- 메인 포트(8080) 트래픽 동일.

## AI 작업 체크리스트
- [x] Feature Spec 갱신 불필요 (인프라 단일 변경)
- [x] 도메인 문서 영향 없음
- [x] Notion API 명세 변경 없음 (외부 API endpoint 추가 아님)
- [x] 보호 영역 변경 → needs-human-review 라벨
- [x] 새 가이드 추가: docs/ai-harness/10-observability.md + 00-index에 등재

🤖 Generated with [Claude Code](https://claude.com/claude-code)