### PR TITLE
release: v0.13.3

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -66,6 +66,7 @@ jobs:
             echo "Starting new container..."
             docker run -d \
               --name ppiyaki-server \
+              --network ppiyaki-monitoring \
               -p 8080:8080 \
               --restart always \
               -e TZ='Asia/Seoul' \

--- a/docs/ai-harness/10-observability.md
+++ b/docs/ai-harness/10-observability.md
@@ -43,8 +43,18 @@ sudo docker exec ppiyaki-server curl -s http://localhost:8081/actuator/prometheu
 sudo docker exec ppiyaki-server curl -s "http://localhost:8081/actuator/metrics/ppiyaki.cache.hits?tag=cache:mfds"
 ```
 
-## 4) Phase 2 (예정)
+## 4) Phase 2 — Prometheus + Grafana docker compose
 
-- Prometheus pull-style scrape (호스팅 위치 TBD)
-- Grafana 대시보드 (캐시 적중률, HTTP latency p95, JVM, DB)
-- 외부 노출 시 actuator 인증 추가 필요 (bearer token / basic auth / IP allowlist)
+같은 NCP 서버에 monitoring 스택을 docker compose로 동거. 백엔드와 같은 docker network(`ppiyaki-monitoring`)에 join하여 `ppiyaki-server:8081/actuator/prometheus` scrape.
+
+상세 운영 절차: `infra/monitoring/README.md`.
+
+- Prometheus 15s scrape, 30일 보관
+- Grafana 3000 포트 외부 노출 (admin 인증)
+- 백업/HA 없음 (실 서비스 아닌 PoC 단계)
+
+## 5) Phase 3 (예정/옵션)
+
+- 알림 (Alertmanager + Discord webhook)
+- 백업 (Prometheus snapshot → NCP Object Storage)
+- 대시보드 .json provisioning

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -1,0 +1,84 @@
+# Monitoring Stack (Phase 2)
+
+Prometheus + Grafana docker compose 스택. 같은 NCP 서버에 백엔드와 함께 실행.
+
+## 구성
+
+- **Prometheus** (`prom/prometheus:v3.0.1`) — 백엔드 `/actuator/prometheus` 엔드포인트를 15초 간격으로 scrape. 30일 보관.
+- **Grafana** (`grafana/grafana:11.4.0`) — 시각화. 3000 포트 외부 노출 (admin 패스워드 인증).
+- 백엔드와 같은 docker network (`ppiyaki-monitoring`)에 join → `ppiyaki-server:8081/actuator/prometheus` scrape.
+
+## 최초 셋업 (prod, 1회)
+
+### 1) docker network 생성
+
+```bash
+sudo docker network create ppiyaki-monitoring
+```
+
+### 2) 기존 백엔드 컨테이너를 network에 join
+
+(backend-cd.yml이 이미 `--network ppiyaki-monitoring`을 추가했으므로, 다음 release deploy 시 자동 적용. 기존 컨테이너는 재시작 전까지는 default network.)
+
+선택: 즉시 적용하려면
+
+```bash
+sudo docker network connect ppiyaki-monitoring ppiyaki-server
+```
+
+### 3) compose 파일 prod에 배치
+
+```bash
+# 로컬에서 prod로 복사
+scp -i ~/workspace/secret/ppiyaki-key.pem -r infra/monitoring ubuntu@211.188.48.217:~/
+```
+
+### 4) Grafana admin 패스워드 설정
+
+prod 서버에서:
+
+```bash
+cd ~/monitoring
+echo "GRAFANA_ADMIN_PASSWORD=<강한_패스워드>" > .env
+chmod 600 .env
+```
+
+### 5) 스택 기동
+
+```bash
+sudo docker compose --env-file .env up -d
+```
+
+### 6) 접속 검증
+
+- Prometheus 타겟 상태: prod localhost로 `sudo docker exec ppiyaki-prometheus wget -qO- http://localhost:9090/api/v1/targets | head`
+- Grafana: 브라우저로 `http://211.188.48.217:3000` → admin/<패스워드> 로그인
+
+## 일상 운영
+
+```bash
+# 스택 상태
+sudo docker compose ps
+
+# 재시작
+sudo docker compose restart
+
+# 종료 (데이터는 volume에 유지)
+sudo docker compose down
+
+# Prometheus 설정 reload (재시작 없이)
+sudo docker exec ppiyaki-prometheus kill -HUP 1
+```
+
+## 알려진 제약
+
+- **백업 없음** (Phase 2 범위 외). Prometheus tsdb / Grafana 설정은 docker volume에만. 서버 장애 시 손실.
+- **HA 없음**. 단일 서버.
+- **외부 노출 보안** = admin 패스워드. IP allowlist / VPN은 별도 옵션.
+- 백엔드 컨테이너가 `ppiyaki-monitoring` network에 join한 후에만 scrape 동작. 미연결 상태에선 target down.
+
+## Phase 3 (예정/옵션)
+
+- 알림 (Alertmanager + Discord/Slack webhook)
+- 백업 (Prometheus snapshot → NCP Object Storage)
+- 대시보드 .json provisioning (JVM, HTTP, 캐시 적중률, DB connection)

--- a/infra/monitoring/docker-compose.yml
+++ b/infra/monitoring/docker-compose.yml
@@ -1,0 +1,45 @@
+name: ppiyaki-monitoring
+
+services:
+  prometheus:
+    image: prom/prometheus:v3.0.1
+    container_name: ppiyaki-prometheus
+    restart: always
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=30d"
+      - "--web.enable-lifecycle"
+    networks:
+      - ppiyaki-monitoring
+    # prometheus는 외부 노출 안 함. Grafana만 외부 노출 (admin 인증).
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    container_name: ppiyaki-grafana
+    restart: always
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD must be set}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_AUTH_ANONYMOUS_ENABLED=false
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    networks:
+      - ppiyaki-monitoring
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  ppiyaki-monitoring:
+    external: true

--- a/infra/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: 15s

--- a/infra/monitoring/prometheus/prometheus.yml
+++ b/infra/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    cluster: ppiyaki-prod
+
+scrape_configs:
+  - job_name: ppiyaki-backend
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - ppiyaki-server:8081
+        labels:
+          application: ppiyaki-backend
+
+  - job_name: prometheus-self
+    static_configs:
+      - targets:
+          - localhost:9090


### PR DESCRIPTION
## 변경 요약

### feat
- `feat(infra)`: monitoring 스택 (Prometheus + Grafana) docker compose 도입 — Phase 2 (#372)

## 프론트 영향
없음.

## prod 마이그레이션
- DB 변경 없음.
- 머지 + CD 후 monitoring stack 별도 셋업 필요 (`infra/monitoring/README.md`).
- 백엔드 컨테이너가 `ppiyaki-monitoring` network에 자동 join (CD가 처리).

🤖 Generated with [Claude Code](https://claude.com/claude-code)