### PR TITLE
chore(infra): .env.example sync — MANAGEMENT_PORT, GRAFANA_ADMIN_*

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,3 +93,19 @@ CLOVA_OCR_SECRET=your-clova-ocr-secret
 # 비워두면 LLM 채팅·이미지 분석 기능 비활성.
 # -----------------------------------------------------------------------------
 OPENAI_API_KEY=your-openai-api-key
+
+# -----------------------------------------------------------------------------
+# Management / Observability port
+# Spring Boot Actuator + Micrometer는 메인(8080)과 별도 포트로 노출.
+# backend-cd.yml은 8081을 publish하지 않으므로 prod에서 외부 접근 불가
+# (SSH 접속자 또는 같은 docker network 내 컨테이너만 호출).
+# -----------------------------------------------------------------------------
+MANAGEMENT_PORT=8081
+
+# -----------------------------------------------------------------------------
+# Monitoring stack — Prometheus + Grafana (infra/monitoring/docker-compose.yml)
+# 로컬에선 보통 안 띄움. prod에서 monitoring stack 띄울 때 사용.
+# Grafana admin 로그인 정보. prod는 ~/monitoring/.env에 별도 등록.
+# -----------------------------------------------------------------------------
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=change-me-to-a-strong-password


### PR DESCRIPTION
## AS-IS
PR #370 (Actuator + Micrometer) 와 PR #372 (monitoring stack docker-compose) 머지 후, 실제 사용처는 모두 develop에 반영되었지만 `.env.example` 동기화가 누락된 상태.

- `src/main/resources/application.yml:74` — `port: \${MANAGEMENT_PORT:8081}`
- `infra/monitoring/docker-compose.yml:27-28` — `GRAFANA_ADMIN_USER`, `GRAFANA_ADMIN_PASSWORD`

새 개발자가 `.env.example` 보고 `.env` 만들면 위 변수들이 누락되어 의도와 다른 기본값으로 동작 가능.

## TO-BE
`.env.example`에 3개 변수 안내 블록 추가:

- `MANAGEMENT_PORT=8081` — Actuator 노출 포트 (backend-cd.yml은 publish 안 함)
- `GRAFANA_ADMIN_USER=admin`
- `GRAFANA_ADMIN_PASSWORD=change-me-to-a-strong-password`

각 블록에 해설 주석(접속 범위, prod는 `~/monitoring/.env`에 별도 등록 안내) 포함.

## 영향 범위
- 코드 변경 없음 (`.env.example`만).
- 로컬 개발 시 monitoring stack 띄울 일 거의 없으므로 기존 로컬 환경에 영향 없음.
- `GRAFANA_ADMIN_PASSWORD`는 README.md에 명시된 대로 prod에서는 `~/monitoring/.env`로 관리 (이 PR로 변경 없음).

## 체크리스트
- [x] 보호 영역(`.env*`) 변경 — `needs-human-review` 라벨 부여
- [x] AI 보조 — `ai-generated` 라벨 부여
- [x] type:chore + scope:infra 라벨
- [x] 코드 변경 없음 → 신규 테스트/문서 N/A
- [x] Notion API 명세 영향 없음 (엔드포인트 변경 무관)

Closes #374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 시스템 모니터링 및 성능 메트릭 수집을 지원하는 설정 옵션이 추가되었습니다.
  * 모니터링 스택 통합을 위한 관리자 계정 설정과 포트 구성이 새로 포함되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->