### PR TITLE
feat(infra): Loki + Grafana Alloy 로그 수집 스택 도입

### DIFF
--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -1,13 +1,15 @@
-# Monitoring Stack (Phase 2)
+# Monitoring Stack
 
-Prometheus + Grafana docker compose 스택. 같은 NCP 서버에 백엔드와 함께 실행.
+Prometheus(메트릭) + Loki(로그) + Grafana(시각화) docker compose 스택. 같은 NCP 서버에 백엔드와 함께 실행.
 
 ## 구성
 
 - **Prometheus** (`prom/prometheus:v3.0.1`) — 백엔드 `/actuator/prometheus` 엔드포인트를 15초 간격으로 scrape. 30일 보관.
+- **Loki** (`grafana/loki:3.3.2`) — 로그 저장소. filesystem storage, 14일 보관(`limits_config.retention_period: 336h`). 내부망만(외부 노출 X).
+- **Alloy** (`grafana/alloy:v1.5.1`) — 로그 수집 agent. docker socket(`/var/run/docker.sock:ro`)으로 `ppiyaki-server` 컨테이너 stdout JSON을 읽어 Loki에 push. River 설정 `alloy/config.alloy`.
 - **Grafana** (`grafana/grafana:11.4.0`) — 시각화. 3000 포트 외부 노출 (admin 패스워드 인증).
 - 백엔드와 같은 docker network (`ppiyaki-monitoring`)에 join → `ppiyaki-server:8081/actuator/prometheus` scrape.
-- **Dashboard provisioning** — `grafana/provisioning/dashboards/json/*.json`을 자동 로드 (folder: `ppiyaki`). 현재 `ppiyaki-overview` 한 개.
+- **Dashboard provisioning** — `grafana/provisioning/dashboards/json/*.json`을 자동 로드 (folder: `ppiyaki`). 현재 `ppiyaki-overview` 한 개 (메트릭 + Loki 로그 패널).
 
 ## 최초 셋업 (prod, 1회)
 
@@ -54,6 +56,8 @@ sudo docker compose --env-file .env up -d
 
 - Prometheus 타겟 상태: prod localhost로 `sudo docker exec ppiyaki-prometheus wget -qO- http://localhost:9090/api/v1/targets | head`
 - Grafana: 브라우저로 `http://211.188.48.217:3000` → admin/<패스워드> 로그인
+- Loki readiness: `sudo docker exec ppiyaki-loki wget -qO- http://localhost:3100/ready`
+- Alloy → Loki 로그 흐름: Grafana → Explore → datasource=Loki → `{job="ppiyaki-backend"}` 쿼리. 또는 ppiyaki-overview 대시보드 "애플리케이션 로그 (Loki)" row.
 
 ## 일상 운영
 
@@ -73,10 +77,12 @@ sudo docker exec ppiyaki-prometheus kill -HUP 1
 
 ## 알려진 제약
 
-- **백업 없음** (Phase 2 범위 외). Prometheus tsdb / Grafana 설정은 docker volume에만. 서버 장애 시 손실.
+- **백업 없음**. Prometheus tsdb / Loki chunks / Grafana 설정은 docker volume에만. 서버 장애 시 손실.
 - **HA 없음**. 단일 서버.
 - **외부 노출 보안** = admin 패스워드. IP allowlist / VPN은 별도 옵션.
-- 백엔드 컨테이너가 `ppiyaki-monitoring` network에 join한 후에만 scrape 동작. 미연결 상태에선 target down.
+- 백엔드 컨테이너가 `ppiyaki-monitoring` network에 join한 후에만 scrape/log 수집 동작. 미연결 상태에선 target down.
+- **Alloy docker socket 마운트** = root 소켓 접근. 표준 패턴이지만 호스트 컨테이너 통제 권한을 가짐. read-only(`ro`) 마운트.
+- **Loki 디스크 사용량**: 14일 보관 + 트래픽에 따라 수백 MB~수 GB. 부족 시 `limits_config.retention_period` 단축 또는 chunk size 조정.
 
 ## 대시보드 갱신
 
@@ -90,8 +96,10 @@ scp -i ~/workspace/secret/ppiyaki-key.pem -r infra/monitoring/grafana/provisioni
 ssh -i ~/workspace/secret/ppiyaki-key.pem ubuntu@211.188.48.217 'cd ~/monitoring && sudo docker compose restart grafana'
 ```
 
-## Phase 3 (예정/옵션)
+## 향후 옵션
 
-- 알림 (Alertmanager + Discord/Slack webhook)
-- 백업 (Prometheus snapshot → NCP Object Storage)
+- 알림 (Alertmanager + Discord/Slack webhook, Loki rules)
+- 백업 (Prometheus snapshot + Loki chunks → NCP Object Storage)
 - ~~대시보드 .json provisioning (JVM, HTTP, 캐시 적중률, DB connection)~~ ✅ done (`ppiyaki-overview`)
+- ~~로그 수집 + Grafana에서 검색~~ ✅ done (Loki + Alloy)
+- LogQL alert (ERROR rate 임계치 → Discord)

--- a/infra/monitoring/alloy/config.alloy
+++ b/infra/monitoring/alloy/config.alloy
@@ -1,0 +1,86 @@
+// Grafana Alloy 설정 — ppiyaki-server 컨테이너 stdout JSON 로그 수집 → Loki push.
+// docs/ai-harness/10-observability.md 및 infra/monitoring/README.md 참고.
+
+// 1) docker socket으로 컨테이너 발견.
+discovery.docker "ppiyaki" {
+  host             = "unix:///var/run/docker.sock"
+  refresh_interval = "30s"
+}
+
+// 2) ppiyaki-server 컨테이너만 keep, label 정리.
+discovery.relabel "ppiyaki" {
+  targets = discovery.docker.ppiyaki.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/ppiyaki-server"
+    action        = "keep"
+  }
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+    replacement   = "$1"
+  }
+}
+
+// 3) docker stdout 수집 → JSON parse stage로 forward.
+loki.source.docker "ppiyaki" {
+  host          = "unix:///var/run/docker.sock"
+  targets       = discovery.relabel.ppiyaki.output
+  forward_to    = [loki.process.json_logs.receiver]
+  relabel_rules = discovery.relabel.ppiyaki.rules
+  labels        = {
+    job = "ppiyaki-backend",
+  }
+}
+
+// 4) LogstashEncoder JSON 파싱 → label 추출 + timestamp 보정.
+loki.process "json_logs" {
+  forward_to = [loki.write.local.receiver]
+
+  // 표준 필드 추출
+  stage.json {
+    expressions = {
+      timestamp = "\"@timestamp\"",
+      level     = "level",
+      logger    = "logger_name",
+      thread    = "thread_name",
+      message   = "message",
+      service   = "service",
+      env       = "env",
+      requestId = "requestId",
+      userId    = "userId",
+    }
+  }
+
+  // 인덱스용 라벨(카디널리티 낮은 것만). requestId/userId/logger는 cardinality 폭발 위험으로 추출만 하고 라벨화 X — LogQL `|=` 검색으로 조회.
+  stage.labels {
+    values = {
+      level   = "",
+      service = "",
+      env     = "",
+    }
+  }
+
+  // ISO-8601 with nanoseconds + tz offset (예: 2026-05-18T13:38:00.143714564+09:00)
+  stage.timestamp {
+    source = "timestamp"
+    format = "RFC3339Nano"
+  }
+
+  // 원본 JSON 그대로 line으로 보존 (Grafana Logs 패널에서 raw view).
+  stage.output {
+    source = "message"
+  }
+}
+
+// 5) Loki push.
+loki.write "local" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+  external_labels = {
+    cluster = "ppiyaki-prod",
+  }
+}

--- a/infra/monitoring/docker-compose.yml
+++ b/infra/monitoring/docker-compose.yml
@@ -35,10 +35,44 @@ services:
       - ppiyaki-monitoring
     depends_on:
       - prometheus
+      - loki
+
+  loki:
+    image: grafana/loki:3.3.2
+    container_name: ppiyaki-loki
+    restart: always
+    command: -config.file=/etc/loki/config.yml
+    volumes:
+      - ./loki/config.yml:/etc/loki/config.yml:ro
+      - loki-data:/loki
+    networks:
+      - ppiyaki-monitoring
+    # 외부 노출 안 함. Grafana는 같은 network에서 http://loki:3100으로 접근.
+
+  alloy:
+    image: grafana/alloy:v1.5.1
+    container_name: ppiyaki-alloy
+    restart: always
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - alloy-data:/var/lib/alloy/data
+    networks:
+      - ppiyaki-monitoring
+    depends_on:
+      - loki
+    # docker socket은 read-only 마운트. 표준 패턴이지만 root socket 접근 권한임을 명시.
 
 volumes:
   prometheus-data:
   grafana-data:
+  loki-data:
+  alloy-data:
 
 networks:
   ppiyaki-monitoring:

--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -348,9 +348,57 @@
     },
     {
       "type": "row",
-      "title": "로그 / Tomcat",
-      "id": 104,
+      "title": "애플리케이션 로그 (Loki)",
+      "id": 105,
       "gridPos": {"h": 1, "w": 24, "x": 0, "y": 40},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "logs",
+      "title": "Recent logs (all levels)",
+      "id": 17,
+      "datasource": {"type": "loki", "uid": "loki"},
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 41},
+      "targets": [
+        {"expr": "{job=\"ppiyaki-backend\"}", "refId": "A", "datasource": {"type": "loki", "uid": "loki"}}
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "prettifyLogMessage": false,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none",
+        "enableLogDetails": true
+      }
+    },
+    {
+      "type": "logs",
+      "title": "ERROR / WARN only",
+      "id": 18,
+      "datasource": {"type": "loki", "uid": "loki"},
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 41},
+      "targets": [
+        {"expr": "{job=\"ppiyaki-backend\", level=~\"ERROR|WARN\"}", "refId": "A", "datasource": {"type": "loki", "uid": "loki"}}
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "prettifyLogMessage": false,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none",
+        "enableLogDetails": true
+      }
+    },
+    {
+      "type": "row",
+      "title": "로그 메트릭 / Tomcat",
+      "id": 104,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 51},
       "collapsed": true,
       "panels": [
         {
@@ -358,7 +406,7 @@
           "title": "Logback events rate by level (1m)",
           "id": 15,
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 41},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 52},
           "targets": [
             {"expr": "sum by (level) (rate(logback_events_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{level}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
           ],
@@ -380,7 +428,7 @@
           "title": "Tomcat sessions",
           "id": 16,
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 41},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 52},
           "targets": [
             {"expr": "tomcat_sessions_active_current_sessions{job=\"ppiyaki-backend\"}", "legendFormat": "active", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}},
             {"expr": "rate(tomcat_sessions_created_sessions_total{job=\"ppiyaki-backend\"}[5m])", "legendFormat": "created/s (5m)", "refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"}}

--- a/infra/monitoring/grafana/provisioning/datasources/loki.yml
+++ b/infra/monitoring/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: false
+    jsonData:
+      maxLines: 1000

--- a/infra/monitoring/loki/config.yml
+++ b/infra/monitoring/loki/config.yml
@@ -1,0 +1,46 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  retention_period: 336h
+  allow_structured_metadata: true
+  volume_enabled: true
+
+compactor:
+  working_directory: /loki/compactor
+  delete_request_store: filesystem
+  retention_enabled: true
+  compaction_interval: 10m
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+
+analytics:
+  reporting_enabled: false


### PR DESCRIPTION
## AS-IS
PR #372(monitoring) + PR #377(dashboards)로 메트릭은 Grafana에서 보지만 **로그는 ssh + `docker logs`로만** 접근. 대시보드의 logback events 패널은 level별 카운트만 보여서 ERROR 발생 사실은 알아도 메시지·스택트레이스 확인 불가.

## TO-BE
**Loki + Grafana Alloy** 도입. Alloy가 docker socket으로 `ppiyaki-server` 컨테이너 stdout JSON을 수집해 Loki에 push. Grafana에서 LogQL로 검색·시각화.

### 왜 Alloy?
Grafana Labs 공식 권장이 Promtail → Alloy 이전. Promtail은 maintenance mode(deprecated 아님)이지만 신규 도입이라 미래 마이그레이션 부담 회피 차원에서 Alloy.

### 구성
| 서비스 | 이미지 | 역할 | 외부 노출 |
|---|---|---|---|
| Loki | `grafana/loki:3.3.2` | 로그 저장소 (filesystem, 14일 retention) | X (내부망만) |
| Alloy | `grafana/alloy:v1.5.1` | 로그 수집 agent (docker socket → JSON parse → Loki push) | X |
| Grafana | 기존 11.4.0 | Loki datasource 추가, depends_on에 loki |  3000 (기존) |

### Alloy River 설정 (`alloy/config.alloy`)
1. `discovery.docker` — docker socket으로 컨테이너 발견
2. `discovery.relabel` — `ppiyaki-server`만 keep, `container` 라벨 정리
3. `loki.source.docker` — stdout 읽기
4. `loki.process` — LogstashEncoder JSON 파싱 (`@timestamp`, `level`, `logger_name`, `thread_name`, `message`, `requestId`, `userId`)
5. `loki.write` — Loki push (`external_labels: cluster=ppiyaki-prod`)

**라벨화는 `level`, `service`, `env`만** — `requestId`/`userId`/`logger`는 cardinality 폭발 위험으로 추출만 하고 LogQL `|=` 검색으로 조회.

### Loki 설정 (`loki/config.yml`)
- monolithic single-binary mode
- filesystem storage (`/loki/chunks`, `/loki/rules`)
- retention 14일 (`retention_period: 336h`)
- compactor로 retention 강제
- `analytics.reporting_enabled: false`

### Grafana 대시보드 (`ppiyaki-overview` 수정)
새 row "애플리케이션 로그 (Loki)" expanded(접지 않음), Logs 패널 2개:
- **Recent logs (all levels)** — `{job="ppiyaki-backend"}`
- **ERROR / WARN only** — `{job="ppiyaki-backend", level=~"ERROR|WARN"}`

기존 "로그/Tomcat" row는 "로그 메트릭 / Tomcat"으로 리네임, collapsed 유지.

## 영향 범위
- 백엔드 코드 변경 없음. `infra/monitoring/**` 만.
- prod 디스크: Loki 14일 보관 + 트래픽에 따라 수백 MB~수 GB. 부족 시 `limits_config.retention_period` 단축.
- 보안: Alloy가 `/var/run/docker.sock`을 **read-only** 마운트. 표준 패턴이지만 root socket 접근이라 README에 명시.

## Prod 배포 절차 (PR 머지 후)
```bash
# 1. develop pull
git checkout develop && git pull

# 2. prod로 monitoring 디렉토리 동기화 (loki/, alloy/ 새 폴더 포함)
scp -i ~/workspace/secret/ppiyaki-key.pem -r infra/monitoring ubuntu@211.188.48.217:~/

# 3. 스택 기동 (기존 .env 그대로 사용)
ssh -i ~/workspace/secret/ppiyaki-key.pem ubuntu@211.188.48.217 \
  'cd ~/monitoring && sudo docker compose --env-file .env up -d'

# 4. Loki readiness 확인
ssh -i ~/workspace/secret/ppiyaki-key.pem ubuntu@211.188.48.217 \
  'sudo docker exec ppiyaki-loki wget -qO- http://localhost:3100/ready'

# 5. 브라우저: http://211.188.48.217:3000 → ppiyaki-overview → "애플리케이션 로그 (Loki)" row 확인
```

## 테스트 계획
- [ ] `docker compose config` 통과(로컬 검증 완료)
- [ ] prod up -d 후 4개 컨테이너 모두 Up
- [ ] Loki readiness 200 OK
- [ ] Alloy 로그에 ppiyaki-server target discovery 메시지
- [ ] Grafana Explore → datasource=Loki → `{job="ppiyaki-backend"}` 결과 표시
- [ ] 대시보드 "애플리케이션 로그 (Loki)" row에 로그 흐름

## 후속 (별도)
- LogQL alert (ERROR rate 임계치 → Discord)
- Loki backup (NCP Object Storage)
- Promtail → Alloy 마이그레이션 가이드는 본 PR로 불필요(처음부터 Alloy)

Closes #378