### PR TITLE
feat(infra): FCM push 메트릭 + Scheduler 집계 로그 통일

### DIFF
--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -444,6 +444,98 @@
           "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
         }
       ]
+    },
+    {
+      "type": "row",
+      "title": "알림 발송 (FCM Push)",
+      "id": 106,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 60},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Push 발송률 by category (1m)",
+      "id": 19,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 61},
+      "targets": [
+        {"expr": "sum by (category) (rate(ppiyaki_push_sent_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{category}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Push 결과 분포 (success / token_invalid / failed)",
+      "id": 20,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 61},
+      "targets": [
+        {"expr": "sum by (result) (rate(ppiyaki_push_sent_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{result}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "success"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "token_invalid"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+          {"matcher": {"id": "byName", "options": "failed"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max", "sum"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Push 발송 지연 p95 / p99 by category",
+      "id": 21,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 69},
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum by (le, category) (rate(ppiyaki_push_send_seconds_bucket{job=\"ppiyaki-backend\"}[5m])))", "legendFormat": "p95 {{category}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"expr": "histogram_quantile(0.99, sum by (le, category) (rate(ppiyaki_push_send_seconds_bucket{job=\"ppiyaki-backend\"}[5m])))", "legendFormat": "p99 {{category}}", "refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3,
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "stat",
+      "title": "Push 실패율 (15m)",
+      "id": 22,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 69},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_push_sent_total{job=\"ppiyaki-backend\", result!=\"success\"}[15m])) / clamp_min(sum(rate(ppiyaki_push_sent_total{job=\"ppiyaki-backend\"}[15m])), 0.0001)", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}, {"value": 0.05, "color": "orange"}, {"value": 0.15, "color": "red"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
     }
   ],
   "refresh": "30s",

--- a/src/main/java/com/ppiyaki/infrastructure/messaging/fcm/FcmPushSender.java
+++ b/src/main/java/com/ppiyaki/infrastructure/messaging/fcm/FcmPushSender.java
@@ -5,6 +5,8 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.Notification;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,14 +14,25 @@ public class FcmPushSender implements PushSender {
 
     private static final Logger log = LoggerFactory.getLogger(FcmPushSender.class);
 
-    private final FirebaseMessaging firebaseMessaging;
+    private static final String METRIC_SENT = "ppiyaki.push.sent.total";
+    private static final String METRIC_TIMER = "ppiyaki.push.send.seconds";
+    private static final String RESULT_SUCCESS = "success";
+    private static final String RESULT_TOKEN_INVALID = "token_invalid";
+    private static final String RESULT_FAILED = "failed";
+    private static final String CATEGORY_UNKNOWN = "unknown";
 
-    public FcmPushSender(final FirebaseMessaging firebaseMessaging) {
+    private final FirebaseMessaging firebaseMessaging;
+    private final MeterRegistry meterRegistry;
+
+    public FcmPushSender(final FirebaseMessaging firebaseMessaging, final MeterRegistry meterRegistry) {
         this.firebaseMessaging = firebaseMessaging;
+        this.meterRegistry = meterRegistry;
     }
 
     @Override
     public PushSendResult send(final String deviceToken, final PushPayload payload) {
+        final String category = extractCategory(payload);
+        final Timer.Sample sample = Timer.start(meterRegistry);
         final Message.Builder builder = Message.builder()
                 .setToken(deviceToken)
                 .setNotification(Notification.builder()
@@ -32,15 +45,30 @@ public class FcmPushSender implements PushSender {
         try {
             final String messageId = firebaseMessaging.send(builder.build());
             log.info("FCM sent (messageId={}, title={})", messageId, payload.title());
+            record(category, RESULT_SUCCESS, sample);
             return PushSendResult.ok();
         } catch (final FirebaseMessagingException exception) {
             final MessagingErrorCode errorCode = exception.getMessagingErrorCode();
             if (errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
                 log.warn("FCM token invalid (errorCode={}, token={})", errorCode, deviceToken);
+                record(category, RESULT_TOKEN_INVALID, sample);
                 return PushSendResult.tokenInvalid(exception.getMessage());
             }
             log.error("FCM send failed (errorCode={}, token={})", errorCode, deviceToken, exception);
+            record(category, RESULT_FAILED, sample);
             return PushSendResult.failed(exception.getMessage());
         }
+    }
+
+    private void record(final String category, final String result, final Timer.Sample sample) {
+        meterRegistry.counter(METRIC_SENT, "category", category, "result", result).increment();
+        sample.stop(meterRegistry.timer(METRIC_TIMER, "category", category, "result", result));
+    }
+
+    private String extractCategory(final PushPayload payload) {
+        if (payload.data() == null) {
+            return CATEGORY_UNKNOWN;
+        }
+        return payload.data().getOrDefault("category", CATEGORY_UNKNOWN);
     }
 }

--- a/src/main/java/com/ppiyaki/infrastructure/messaging/fcm/PushConfig.java
+++ b/src/main/java/com/ppiyaki/infrastructure/messaging/fcm/PushConfig.java
@@ -4,6 +4,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -20,7 +21,7 @@ public class PushConfig {
     private static final Logger log = LoggerFactory.getLogger(PushConfig.class);
 
     @Bean
-    public PushSender pushSender(final FcmProperties properties) {
+    public PushSender pushSender(final FcmProperties properties, final MeterRegistry meterRegistry) {
         if (!properties.isEnabled()) {
             log.warn("FCM disabled — fcm.project-id or fcm.credentials-json-base64 missing. Push will be no-op.");
             return new NoOpPushSender();
@@ -37,7 +38,7 @@ public class PushConfig {
             final FirebaseApp app = FirebaseApp.getApps().isEmpty()
                     ? FirebaseApp.initializeApp(options)
                     : FirebaseApp.getInstance();
-            return new FcmPushSender(FirebaseMessaging.getInstance(app));
+            return new FcmPushSender(FirebaseMessaging.getInstance(app), meterRegistry);
         } catch (final Exception exception) {
             log.error("FCM initialization failed — fallback to no-op push sender", exception);
             return new NoOpPushSender();

--- a/src/main/java/com/ppiyaki/notification/service/FamilySafetyDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/FamilySafetyDispatcher.java
@@ -65,9 +65,6 @@ public class FamilySafetyDispatcher {
         for (final User senior : userRepository.findAllByRoleWithMealTimesSet(UserRole.SENIOR)) {
             dispatched += dispatchForSenior(senior, now, today);
         }
-        if (dispatched > 0) {
-            log.info("FamilySafetyDispatcher dispatched {} alerts", dispatched);
-        }
         return dispatched;
     }
 

--- a/src/main/java/com/ppiyaki/notification/service/FamilySafetyScheduler.java
+++ b/src/main/java/com/ppiyaki/notification/service/FamilySafetyScheduler.java
@@ -1,10 +1,14 @@
 package com.ppiyaki.notification.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 public class FamilySafetyScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(FamilySafetyScheduler.class);
 
     private final FamilySafetyDispatcher dispatcher;
 
@@ -14,6 +18,13 @@ public class FamilySafetyScheduler {
 
     @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
     public void runHourly() {
-        dispatcher.run();
+        final long start = System.currentTimeMillis();
+        final int dispatched = dispatcher.run();
+        final long elapsed = System.currentTimeMillis() - start;
+        if (dispatched > 0) {
+            log.info("FamilySafetyScheduler dispatched count={} elapsed={}ms", dispatched, elapsed);
+        } else {
+            log.debug("FamilySafetyScheduler tick count=0 elapsed={}ms", elapsed);
+        }
     }
 }

--- a/src/main/java/com/ppiyaki/notification/service/MedicationDelayScheduler.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationDelayScheduler.java
@@ -23,13 +23,17 @@ public class MedicationDelayScheduler {
 
     @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void dispatchDue() {
+        final long start = System.currentTimeMillis();
         final LocalDate today = LocalDate.now(clock);
         int total = 0;
         for (final User senior : dispatcher.findAllSeniorsWithMealTimes()) {
             total += dispatcher.dispatchForSenior(senior, today);
         }
+        final long elapsed = System.currentTimeMillis() - start;
         if (total > 0) {
-            log.info("MedicationDelayScheduler dispatched {} delay alerts at {}", total, today);
+            log.info("MedicationDelayScheduler dispatched count={} elapsed={}ms (date={})", total, elapsed, today);
+        } else {
+            log.debug("MedicationDelayScheduler tick count=0 elapsed={}ms", elapsed);
         }
     }
 }

--- a/src/main/java/com/ppiyaki/notification/service/MedicationReminderScheduler.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationReminderScheduler.java
@@ -34,10 +34,16 @@ public class MedicationReminderScheduler {
 
     @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void dispatchDue() {
+        final long start = System.currentTimeMillis();
         final LocalDate today = LocalDate.now(clock);
         final LocalTime now = LocalTime.now(clock).withSecond(0).withNano(0);
-        log.info("MedicationReminderScheduler tick at {}", now);
-        run(today, now);
+        final int dispatched = run(today, now);
+        final long elapsed = System.currentTimeMillis() - start;
+        if (dispatched > 0) {
+            log.info("MedicationReminderScheduler dispatched count={} elapsed={}ms", dispatched, elapsed);
+        } else {
+            log.debug("MedicationReminderScheduler tick count=0 elapsed={}ms", elapsed);
+        }
     }
 
     public int run(final LocalDate today, final LocalTime currentMinute) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,3 +85,4 @@ management:
     distribution:
       percentiles-histogram:
         http.server.requests: true
+        ppiyaki.push.send: true


### PR DESCRIPTION
## AS-IS
모니터링 스택은 구축 완료(PR #372/#377/#379)했지만 비즈니스 메트릭 0개. Push 발송은 개별 INFO/WARN/ERROR 줄만 있어 "분당 N건 발송 / M건 실패" 시계열 신호가 없음. Scheduler 집계 로그도 일관성 없음:
- `MedicationReminderScheduler` — 매분 tick만 INFO, dispatched 카운트 X
- `MedicationDelayScheduler` — N>0일 때만 INFO
- `FamilySafetyScheduler` — 로그 0줄 (Dispatcher 내부에 N>0일 때만)

## TO-BE

### 메트릭
- **`ppiyaki_push_sent_total{category, result}`** — Counter. result=`success`/`token_invalid`/`failed`. category는 `payload.data["category"]`에서 추출 (`MEDICATION_REMINDER`, `MEDICATION_DELAY`, `FAMILY_SAFETY`, ...).
- **`ppiyaki_push_send_seconds{category, result}`** — Timer. FCM 호출 지연.
- `FcmPushSender.send()` 한 곳에 통합 (단일 지점). `NoOpPushSender`는 메트릭 없음(no-op).
- `application.yml`에 `ppiyaki.push.send: true` percentiles-histogram 활성 — p95/p99 계산 가능.

### Scheduler 집계 로그 통일
형식: `"{Name}Scheduler dispatched count={} elapsed={}ms"`. 0건은 DEBUG.
- `MedicationReminderScheduler` — 기존 tick 로그 제거, count + elapsed 추가.
- `MedicationDelayScheduler` — 0건 DEBUG 추가, elapsed 측정.
- `FamilySafetyScheduler` — Logger 신설, 통일 형식. `FamilySafetyDispatcher` 내부 중복 INFO 제거.

### Grafana 대시보드
`ppiyaki-overview` 끝에 **"알림 발송 (FCM Push)" row** 추가 (4 패널):
- 카테고리별 발송률 (stacked)
- 결과 분포 (success=녹, token_invalid=주, failed=적)
- p95/p99 지연 by category
- **15분 실패율 stat** (5% 주의/오렌지, 15% 위험/적)

> 위치 주의: 가독성 면에서 JVM row 다음이 이상적이지만 후속 y 좌표 대거 시프트가 발생해 본 PR에선 dashboard 끝에 배치. PR-B 작업 때 함께 재배치 예정.

## 영향 범위
- `infrastructure/messaging/fcm/FcmPushSender.java` — Constructor에 `MeterRegistry` 추가, record() helper.
- `infrastructure/messaging/fcm/PushConfig.java` — 빈 주입 시그니처에 `MeterRegistry` 추가.
- `notification/service/MedicationReminderScheduler.java`
- `notification/service/MedicationDelayScheduler.java`
- `notification/service/FamilySafetyScheduler.java`
- `notification/service/FamilySafetyDispatcher.java` (중복 로그 제거)
- `src/main/resources/application.yml` (보호 영역 — `needs-human-review`)
- `infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json`

## 검증
- [x] `./gradlew compileJava` 통과
- [x] `./gradlew spotlessCheck checkstyleMain` 통과
- [x] `./gradlew test` 전체 통과 (2분 1초)
- [ ] prod 배포 후 Grafana에서 메트릭 확인

## Prod 배포 (머지 후)
1. 새 release 배포 시 자동 적용 (백엔드 코드 변경).
2. Dashboard만 즉시 적용 원하면:
```bash
scp -i ~/workspace/secret/ppiyaki-key.pem -r infra/monitoring/grafana/provisioning ubuntu@211.188.48.217:~/monitoring/grafana/
ssh -i ~/workspace/secret/ppiyaki-key.pem ubuntu@211.188.48.217 'cd ~/monitoring && sudo docker compose restart grafana'
```
(메트릭은 백엔드 배포 후에야 데이터 흐름)

## 후속 (다른 PR — PR-B/C 순차 진행)
- LLM 토큰/지연 메트릭
- 인증 메트릭 (로그인/토큰갱신)

Closes #380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **모니터링 및 관찰성 개선**
  * FCM 푸시 알림 발송 모니터링을 위한 Grafana 대시보드 영역 추가 (발송률, 결과 분포, 지연 시간, 실패율 패널)
  * 푸시 발송 메트릭 수집 기능 추가로 발송 성공/실패/토큰 오류 현황 추적 가능
  
* **로깅 개선**
  * 알림 발송 스케줄러의 실행 시간 측정 및 조건부 로깅 추가
  * 발송 건수에 따른 세분화된 로그 레벨 적용 (성공 시 정보 로그, 미발송 시 디버그 로그)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->