### PR TITLE
feat(infra): LLM 토큰/지연 메트릭 — OpenAI / STT / TTS

### DIFF
--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -536,6 +536,98 @@
         "overrides": []
       },
       "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "row",
+      "title": "LLM (OpenAI / STT / TTS)",
+      "id": 107,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 77},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM 호출률 by operation (1m)",
+      "id": 23,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 78},
+      "targets": [
+        {"expr": "sum by (operation) (rate(ppiyaki_llm_request_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{operation}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM 지연 p95 by operation",
+      "id": 24,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 78},
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum by (le, operation) (rate(ppiyaki_llm_request_seconds_bucket{job=\"ppiyaki-backend\"}[5m])))", "legendFormat": "p95 {{operation}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 2,
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM 토큰 사용량 by model + direction (1h increase)",
+      "id": 25,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 86},
+      "targets": [
+        {"expr": "sum by (model, direction) (increase(ppiyaki_llm_tokens_total{job=\"ppiyaki-backend\"}[1h]))", "legendFormat": "{{model}} {{direction}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": ".*completion.*"}, "properties": [{"id": "custom.lineStyle", "value": {"dash": [10, 10], "fill": "dash"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["sum", "mean"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM 결과 분포 (success / failed / empty)",
+      "id": 26,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 86},
+      "targets": [
+        {"expr": "sum by (result) (rate(ppiyaki_llm_request_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{result}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "success"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "empty"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+          {"matcher": {"id": "byName", "options": "failed"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
     }
   ],
   "refresh": "30s",

--- a/src/main/java/com/ppiyaki/chat/service/SttService.java
+++ b/src/main/java/com/ppiyaki/chat/service/SttService.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.chat.service;
 
-import lombok.RequiredArgsConstructor;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionOptions;
@@ -9,10 +10,18 @@ import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class SttService {
 
+    private static final String MODEL = "whisper-1";
+    private static final String OPERATION = "stt_transcribe";
+
     private final OpenAiAudioTranscriptionModel transcriptionModel;
+    private final MeterRegistry meterRegistry;
+
+    public SttService(final OpenAiAudioTranscriptionModel transcriptionModel, final MeterRegistry meterRegistry) {
+        this.transcriptionModel = transcriptionModel;
+        this.meterRegistry = meterRegistry;
+    }
 
     public String transcribe(final Resource audioResource, final String language) {
         final OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
@@ -22,10 +31,27 @@ public class SttService {
 
         final AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(audioResource, options);
 
-        final var response = transcriptionModel.call(prompt);
-        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
-            throw new IllegalStateException("STT 변환 결과가 비어있습니다.");
+        final Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            final var response = transcriptionModel.call(prompt);
+            if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+                record("empty", sample);
+                throw new IllegalStateException("STT 변환 결과가 비어있습니다.");
+            }
+            record("success", sample);
+            return response.getResult().getOutput();
+        } catch (final IllegalStateException e) {
+            throw e;
+        } catch (final RuntimeException e) {
+            record("failed", sample);
+            throw e;
         }
-        return response.getResult().getOutput();
+    }
+
+    private void record(final String result, final Timer.Sample sample) {
+        meterRegistry.counter("ppiyaki.llm.request.total",
+                "model", MODEL, "operation", OPERATION, "result", result).increment();
+        sample.stop(meterRegistry.timer("ppiyaki.llm.request.seconds",
+                "model", MODEL, "operation", OPERATION, "result", result));
     }
 }

--- a/src/main/java/com/ppiyaki/chat/service/TtsService.java
+++ b/src/main/java/com/ppiyaki/chat/service/TtsService.java
@@ -1,19 +1,43 @@
 package com.ppiyaki.chat.service;
 
-import lombok.RequiredArgsConstructor;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.springframework.ai.openai.OpenAiAudioSpeechModel;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class TtsService {
 
+    private static final String MODEL = "tts-1";
+    private static final String OPERATION = "tts_synthesize";
+
     private final OpenAiAudioSpeechModel speechModel;
+    private final MeterRegistry meterRegistry;
+
+    public TtsService(final OpenAiAudioSpeechModel speechModel, final MeterRegistry meterRegistry) {
+        this.speechModel = speechModel;
+        this.meterRegistry = meterRegistry;
+    }
 
     public byte[] synthesize(final String text) {
         if (text.isBlank()) {
             throw new IllegalArgumentException("text must not be blank");
         }
-        return speechModel.call(text);
+        final Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            final byte[] audio = speechModel.call(text);
+            record("success", sample);
+            return audio;
+        } catch (final RuntimeException e) {
+            record("failed", sample);
+            throw e;
+        }
+    }
+
+    private void record(final String result, final Timer.Sample sample) {
+        meterRegistry.counter("ppiyaki.llm.request.total",
+                "model", MODEL, "operation", OPERATION, "result", result).increment();
+        sample.stop(meterRegistry.timer("ppiyaki.llm.request.seconds",
+                "model", MODEL, "operation", OPERATION, "result", result));
     }
 }

--- a/src/main/java/com/ppiyaki/infrastructure/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/infrastructure/ai/OpenAiClient.java
@@ -6,6 +6,8 @@ import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.medication.domain.DosageUnit;
 import com.ppiyaki.medication.domain.MealSlot;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -28,17 +30,29 @@ public class OpenAiClient {
     private static final Logger log = LoggerFactory.getLogger(OpenAiClient.class);
     private static final String API_URL = "https://api.openai.com/v1/chat/completions";
 
+    private static final String METRIC_TOKENS = "ppiyaki.llm.tokens.total";
+    private static final String METRIC_REQUEST = "ppiyaki.llm.request.total";
+    private static final String METRIC_TIMER = "ppiyaki.llm.request.seconds";
+    private static final String OP_EXTRACT = "extract_medicines";
+    private static final String OP_COUNT_PILLS = "count_pills";
+    private static final String RESULT_SUCCESS = "success";
+    private static final String RESULT_FAILED = "failed";
+    private static final String RESULT_EMPTY = "empty";
+
     private final OpenAiProperties properties;
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
 
     public OpenAiClient(
             final OpenAiProperties properties,
             final RestClient.Builder restClientBuilder,
-            final ObjectMapper objectMapper
+            final ObjectMapper objectMapper,
+            final MeterRegistry meterRegistry
     ) {
         this.properties = properties;
         this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
 
         final SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(Duration.ofSeconds(5));
@@ -49,10 +63,11 @@ public class OpenAiClient {
 
     public List<ExtractedMedicine> extractMedicines(final String maskedOcrText) {
         log.info("OpenAI extractMedicines: textLength={}", maskedOcrText.length());
-        final long startTime = System.currentTimeMillis();
+        final Timer.Sample sample = Timer.start(meterRegistry);
+        final String model = properties.textModel();
 
         try {
-            final String requestBody = buildRequest(properties.textModel(), maskedOcrText);
+            final String requestBody = buildRequest(model, maskedOcrText);
 
             final String responseBody = restClient.post()
                     .uri(API_URL)
@@ -62,16 +77,16 @@ public class OpenAiClient {
                     .retrieve()
                     .body(String.class);
 
-            final long elapsed = System.currentTimeMillis() - startTime;
-            log.info("OpenAI response: elapsed={}ms", elapsed);
-
+            recordUsage(model, OP_EXTRACT, responseBody);
+            recordResult(model, OP_EXTRACT, RESULT_SUCCESS, sample);
             return parseResponse(responseBody);
 
         } catch (final BusinessException e) {
+            recordResult(model, OP_EXTRACT, RESULT_FAILED, sample);
             throw e;
         } catch (final Exception e) {
-            final long elapsed = System.currentTimeMillis() - startTime;
-            log.error("OpenAI failed: elapsed={}ms error={}", elapsed, e.getMessage());
+            recordResult(model, OP_EXTRACT, RESULT_FAILED, sample);
+            log.error("OpenAI failed: error={}", e.getMessage());
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
                     "AI extraction failed: " + e.getMessage());
         }
@@ -83,7 +98,7 @@ public class OpenAiClient {
                     당신은 한국 병원 처방전 OCR 텍스트에서 약물 정보를 추출하는 전문가입니다.
 
                     ## 입력 특성
-                    - OCR로 추출된 텍스트라 오인식·띄어쓰기 깨짐·줄바꿈 누락��� 빈번합니다.
+                    - OCR로 추출된 텍스트라 오인식·띄어쓰기 깨짐·줄바꿈 누락이 빈번합니다.
                     - 처방전은 보통 표(테이블) 형식이지만 OCR이 좌→우, 위→아래로 읽어서
                       약품명 중간에 다른 컬럼(투약량·횟수·일수) 값이 섞여 들어옵니다.
                       예: "타이레놀정500mg 1정 3회 7일 부루펜정200mg 1정 2회 5일"
@@ -241,10 +256,11 @@ public class OpenAiClient {
      */
     public Optional<Integer> countPills(final byte[] imageBytes, final String mediaType) {
         log.info("OpenAI countPills: imageSize={}bytes mediaType={}", imageBytes.length, mediaType);
+        final String model = properties.visionModel();
         for (int attempt = 1; attempt <= 2; attempt++) {
-            final long startTime = System.currentTimeMillis();
+            final Timer.Sample sample = Timer.start(meterRegistry);
             try {
-                final String requestBody = buildCountRequest(properties.visionModel(), imageBytes, mediaType);
+                final String requestBody = buildCountRequest(model, imageBytes, mediaType);
 
                 final String responseBody = restClient.post()
                         .uri(API_URL)
@@ -254,14 +270,15 @@ public class OpenAiClient {
                         .retrieve()
                         .body(String.class);
 
-                final long elapsed = System.currentTimeMillis() - startTime;
-                log.info("OpenAI countPills attempt={} elapsed={}ms", attempt, elapsed);
+                recordUsage(model, OP_COUNT_PILLS, responseBody);
+                log.info("OpenAI countPills attempt={}", attempt);
 
-                return parseCountResponse(responseBody);
+                final Optional<Integer> count = parseCountResponse(responseBody);
+                recordResult(model, OP_COUNT_PILLS, count.isPresent() ? RESULT_SUCCESS : RESULT_EMPTY, sample);
+                return count;
             } catch (final Exception e) {
-                final long elapsed = System.currentTimeMillis() - startTime;
-                log.warn("OpenAI countPills attempt={} failed elapsed={}ms error={}",
-                        attempt, elapsed, e.getMessage());
+                recordResult(model, OP_COUNT_PILLS, RESULT_FAILED, sample);
+                log.warn("OpenAI countPills attempt={} failed error={}", attempt, e.getMessage());
             }
         }
         return Optional.empty();
@@ -314,6 +331,39 @@ public class OpenAiClient {
             log.warn("OpenAI countPills parse failed: {}", e.getMessage());
             return Optional.empty();
         }
+    }
+
+    /**
+     * OpenAI 응답의 `usage` 객체에서 prompt/completion 토큰 수를 추출해 카운터 increment.
+     * 응답에 usage가 없거나 파싱 실패 시 조용히 무시 (메트릭이 본 로직 실패시키지 않음).
+     */
+    private void recordUsage(final String model, final String operation, final String responseBody) {
+        try {
+            final JsonNode usage = objectMapper.readTree(responseBody).path("usage");
+            if (usage.isMissingNode() || usage.isNull()) {
+                return;
+            }
+            final long promptTokens = usage.path("prompt_tokens").asLong(0);
+            final long completionTokens = usage.path("completion_tokens").asLong(0);
+            if (promptTokens > 0) {
+                meterRegistry.counter(METRIC_TOKENS,
+                        "model", model, "operation", operation, "direction", "prompt").increment(promptTokens);
+            }
+            if (completionTokens > 0) {
+                meterRegistry.counter(METRIC_TOKENS,
+                        "model", model, "operation", operation, "direction", "completion").increment(completionTokens);
+            }
+        } catch (final Exception ignored) {
+            // usage 파싱 실패는 본 흐름과 무관 — 조용히 통과
+        }
+    }
+
+    private void recordResult(final String model, final String operation, final String result,
+            final Timer.Sample sample) {
+        meterRegistry.counter(METRIC_REQUEST,
+                "model", model, "operation", operation, "result", result).increment();
+        sample.stop(meterRegistry.timer(METRIC_TIMER,
+                "model", model, "operation", operation, "result", result));
     }
 
     public record ExtractedMedicine(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,3 +86,4 @@ management:
       percentiles-histogram:
         http.server.requests: true
         ppiyaki.push.send: true
+        ppiyaki.llm.request: true

--- a/src/test/java/com/ppiyaki/chat/SttServiceTest.java
+++ b/src/test/java/com/ppiyaki/chat/SttServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.ppiyaki.chat.service.SttService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ class SttServiceTest {
     @BeforeEach
     void setUp() {
         transcriptionModel = mock(OpenAiAudioTranscriptionModel.class);
-        sttService = new SttService(transcriptionModel);
+        sttService = new SttService(transcriptionModel, new SimpleMeterRegistry());
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/chat/TtsServiceTest.java
+++ b/src/test/java/com/ppiyaki/chat/TtsServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.ppiyaki.chat.service.TtsService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,7 @@ class TtsServiceTest {
     @BeforeEach
     void setUp() {
         speechModel = mock(OpenAiAudioSpeechModel.class);
-        ttsService = new TtsService(speechModel);
+        ttsService = new TtsService(speechModel, new SimpleMeterRegistry());
     }
 
     @Test


### PR DESCRIPTION
## AS-IS
PR #381 (push 메트릭) 후속 — 두 번째 큰 갭. 현재 OpenAI 호출은:
- 비용 예측 불가능 (토큰 사용량 미관측)
- 지연 분포 미관측 (어떤 operation이 병목인지 불명)
- 실패 카운트 없음 (countPills는 retry 1회 후 Optional.empty()로 조용히 처리)

## TO-BE

### 메트릭 (Micrometer)
| 이름 | 타입 | 태그 |
|---|---|---|
| `ppiyaki_llm_tokens_total` | Counter | `model`, `operation`, `direction=prompt/completion` |
| `ppiyaki_llm_request_total` | Counter | `model`, `operation`, `result=success/failed/empty` |
| `ppiyaki_llm_request_seconds` | Timer (histogram) | `model`, `operation`, `result` |

**operation 태그**:
- `extract_medicines` — 처방전 OCR → 약물 추출 (text model)
- `count_pills` — Vision 알약 카운트
- `stt_transcribe` — Whisper STT
- `tts_synthesize` — TTS

### 코드 변경
- `infrastructure/ai/OpenAiClient.java`:
  - `MeterRegistry` 생성자 주입.
  - 응답 JSON `usage.{prompt,completion}_tokens` 파싱 → `recordUsage()` helper.
  - `recordResult()` helper로 카운터+타이머 일괄 기록.
  - usage 파싱 실패는 try/catch로 흡수 (메트릭이 본 로직 실패시키지 않음).
- `chat/service/SttService.java`, `chat/service/TtsService.java`:
  - `@RequiredArgsConstructor` 제거 + 명시적 생성자 (MeterRegistry 추가).
  - Timer.Sample wrap + try/catch에 result 기록.
- `application.yml`: `ppiyaki.llm.request: true` percentiles-histogram 활성.
- 테스트: `SttServiceTest`, `TtsServiceTest`에 `SimpleMeterRegistry` 주입.

### Grafana 패널 (`ppiyaki-overview` 신규 row "LLM (OpenAI / STT / TTS)")
- Operation별 호출률 (stacked area, 1m rate)
- Operation별 p95 지연
- **Model + direction별 토큰 사용량** (`increase[1h]`) — 비용 추적의 핵심 신호
- 결과 분포 (success=녹/empty=주/failed=적)

## 영향 범위
- `infrastructure/ai/OpenAiClient.java`
- `chat/service/SttService.java`, `chat/service/TtsService.java`
- `src/main/resources/application.yml` (보호 영역 → `needs-human-review`)
- 테스트 파일 2개 (생성자 시그니처 변경 따라)
- dashboard JSON

## 검증
- [x] `./gradlew compileJava` 통과
- [x] `./gradlew spotlessCheck checkstyleMain` 통과
- [x] `./gradlew test` 전체 통과 (42s)

## 후속
- Spring AI `ChatClient` 자체의 토큰/지연 — Spring AI observability advisor 활용 (별도 PR)
- 모델별 비용 환산 (Grafana table 또는 별도 metric)

Closes #382