### PR TITLE
feat(user): 인증 메트릭 — 로그인/가입/토큰갱신 결과별 카운터

### DIFF
--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -628,6 +628,118 @@
         ]
       },
       "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "row",
+      "title": "인증",
+      "id": 108,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 94},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Auth 결과 분포 (rate by result, 5m)",
+      "id": 27,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 95},
+      "targets": [
+        {"expr": "sum by (result) (rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{result}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "success"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "invalid_credentials"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "duplicate_id"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+          {"matcher": {"id": "byName", "options": "token_expired"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "yellow"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Auth type + action 분포 (5m)",
+      "id": 28,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 95},
+      "targets": [
+        {"expr": "sum by (type, action) (rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{type}} {{action}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "stat",
+      "title": "Login 실패율 (15m)",
+      "id": 29,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 103},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\", action=\"login\", result!=\"success\"}[15m])) / clamp_min(sum(rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\", action=\"login\"}[15m])), 0.0001)", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}, {"value": 0.10, "color": "orange"}, {"value": 0.30, "color": "red"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "Token refresh 실패율 (15m)",
+      "id": 30,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 8, "y": 103},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\", action=\"refresh\", result!=\"success\"}[15m])) / clamp_min(sum(rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\", action=\"refresh\"}[15m])), 0.0001)", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}, {"value": 0.20, "color": "orange"}, {"value": 0.50, "color": "red"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "신규 가입 24h",
+      "id": 31,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 16, "y": 103},
+      "targets": [
+        {"expr": "sum(increase(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\", action=\"signup\", result=\"success\"}[24h]))", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "blue"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
     }
   ],
   "refresh": "30s",

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -20,6 +20,7 @@ import com.ppiyaki.user.domain.UserRole;
 import com.ppiyaki.user.repository.OAuthIdentityRepository;
 import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.LocalDateTime;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,6 +30,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
+    private static final String METRIC_ATTEMPTS = "ppiyaki.auth.attempts.total";
+    private static final String TYPE_KAKAO = "kakao";
+    private static final String TYPE_LOCAL = "local";
+    private static final String ACTION_LOGIN = "login";
+    private static final String ACTION_SIGNUP = "signup";
+    private static final String ACTION_REFRESH = "refresh";
+    private static final String ACTION_LOGOUT = "logout";
+
     private final KakaoIdTokenVerifier kakaoIdTokenVerifier;
     private final JwtProvider jwtProvider;
     private final JwtProperties jwtProperties;
@@ -36,6 +45,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final OAuthIdentityRepository oAuthIdentityRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final MeterRegistry meterRegistry;
 
     public AuthService(
             final KakaoIdTokenVerifier kakaoIdTokenVerifier,
@@ -44,7 +54,8 @@ public class AuthService {
             final PasswordEncoder passwordEncoder,
             final UserRepository userRepository,
             final OAuthIdentityRepository oAuthIdentityRepository,
-            final RefreshTokenRepository refreshTokenRepository
+            final RefreshTokenRepository refreshTokenRepository,
+            final MeterRegistry meterRegistry
     ) {
         this.kakaoIdTokenVerifier = kakaoIdTokenVerifier;
         this.jwtProvider = jwtProvider;
@@ -53,82 +64,110 @@ public class AuthService {
         this.userRepository = userRepository;
         this.oAuthIdentityRepository = oAuthIdentityRepository;
         this.refreshTokenRepository = refreshTokenRepository;
+        this.meterRegistry = meterRegistry;
     }
 
     @Transactional
     public LoginResponse loginWithKakao(final KakaoLoginRequest kakaoLoginRequest) {
-        final KakaoIdTokenPayload payload = kakaoIdTokenVerifier.verify(kakaoLoginRequest.idToken());
+        try {
+            final KakaoIdTokenPayload payload = kakaoIdTokenVerifier.verify(kakaoLoginRequest.idToken());
 
-        final String providerUserId = payload.sub();
-        final User user = oAuthIdentityRepository
-                .findByProviderAndProviderUserId(OAuthProvider.KAKAO, providerUserId)
-                .map(identity -> userRepository.findById(identity.getUserId())
-                        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND)))
-                .orElseGet(() -> createNewUser(payload, providerUserId));
+            final String providerUserId = payload.sub();
+            final User user = oAuthIdentityRepository
+                    .findByProviderAndProviderUserId(OAuthProvider.KAKAO, providerUserId)
+                    .map(identity -> userRepository.findById(identity.getUserId())
+                            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND)))
+                    .orElseGet(() -> createNewUser(payload, providerUserId));
 
-        if (user.isDeleted()) {
-            throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
+            if (user.isDeleted()) {
+                throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
+            }
+
+            final String roleName = user.getRole() != null ? user.getRole().name() : null;
+            final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
+            final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
+            saveRefreshToken(user.getId(), refreshTokenValue);
+
+            final boolean isOnboarded = user.getNickname() != null;
+
+            recordAttempt(TYPE_KAKAO, ACTION_LOGIN, "success");
+            return new LoginResponse(accessToken, refreshTokenValue, isOnboarded);
+        } catch (final BusinessException e) {
+            recordAttempt(TYPE_KAKAO, ACTION_LOGIN, mapResult(e));
+            throw e;
+        } catch (final RuntimeException e) {
+            recordAttempt(TYPE_KAKAO, ACTION_LOGIN, "failed");
+            throw e;
         }
-
-        final String roleName = user.getRole() != null ? user.getRole().name() : null;
-        final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
-        final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
-        saveRefreshToken(user.getId(), refreshTokenValue);
-
-        final boolean isOnboarded = user.getNickname() != null;
-
-        return new LoginResponse(accessToken, refreshTokenValue, isOnboarded);
     }
 
     @Transactional
     public LoginResponse signup(final SignupRequest signupRequest) {
-        if (userRepository.existsByLoginId(signupRequest.loginId())) {
-            throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
-        }
-
-        final String encodedPassword = passwordEncoder.encode(signupRequest.password());
-        final User user;
         try {
-            user = userRepository.save(
-                    new User(signupRequest.loginId(), encodedPassword, UserRole.CAREGIVER,
-                            AuthProvider.LOCAL, signupRequest.nickname(), null, null, null));
-        } catch (final DataIntegrityViolationException e) {
-            throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
+            if (userRepository.existsByLoginId(signupRequest.loginId())) {
+                throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
+            }
+
+            final String encodedPassword = passwordEncoder.encode(signupRequest.password());
+            final User user;
+            try {
+                user = userRepository.save(
+                        new User(signupRequest.loginId(), encodedPassword, UserRole.CAREGIVER,
+                                AuthProvider.LOCAL, signupRequest.nickname(), null, null, null));
+            } catch (final DataIntegrityViolationException e) {
+                throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
+            }
+
+            final String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());
+            final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
+            saveRefreshToken(user.getId(), refreshTokenValue);
+
+            recordAttempt(TYPE_LOCAL, ACTION_SIGNUP, "success");
+            return new LoginResponse(accessToken, refreshTokenValue, true);
+        } catch (final BusinessException e) {
+            recordAttempt(TYPE_LOCAL, ACTION_SIGNUP, mapResult(e));
+            throw e;
+        } catch (final RuntimeException e) {
+            recordAttempt(TYPE_LOCAL, ACTION_SIGNUP, "failed");
+            throw e;
         }
-
-        final String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());
-        final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
-        saveRefreshToken(user.getId(), refreshTokenValue);
-
-        return new LoginResponse(accessToken, refreshTokenValue, true);
     }
 
     @Transactional
     public LoginResponse login(final LoginRequest loginRequest) {
-        final User user = userRepository.findByLoginId(loginRequest.loginId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS));
+        try {
+            final User user = userRepository.findByLoginId(loginRequest.loginId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS));
 
-        if (user.getAuthProvider() != AuthProvider.LOCAL) {
-            throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+            if (user.getAuthProvider() != AuthProvider.LOCAL) {
+                throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+            }
+
+            if (user.getPassword() == null
+                    || !passwordEncoder.matches(loginRequest.password(), user.getPassword())) {
+                throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+            }
+
+            if (user.isDeleted()) {
+                throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
+            }
+
+            final String roleName = user.getRole() != null ? user.getRole().name() : null;
+            final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
+            final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
+            saveRefreshToken(user.getId(), refreshTokenValue);
+
+            final boolean isOnboarded = user.getRole() != null;
+
+            recordAttempt(TYPE_LOCAL, ACTION_LOGIN, "success");
+            return new LoginResponse(accessToken, refreshTokenValue, isOnboarded);
+        } catch (final BusinessException e) {
+            recordAttempt(TYPE_LOCAL, ACTION_LOGIN, mapResult(e));
+            throw e;
+        } catch (final RuntimeException e) {
+            recordAttempt(TYPE_LOCAL, ACTION_LOGIN, "failed");
+            throw e;
         }
-
-        if (user.getPassword() == null
-                || !passwordEncoder.matches(loginRequest.password(), user.getPassword())) {
-            throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
-        }
-
-        if (user.isDeleted()) {
-            throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
-        }
-
-        final String roleName = user.getRole() != null ? user.getRole().name() : null;
-        final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
-        final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
-        saveRefreshToken(user.getId(), refreshTokenValue);
-
-        final boolean isOnboarded = user.getRole() != null;
-
-        return new LoginResponse(accessToken, refreshTokenValue, isOnboarded);
     }
 
     private User createNewUser(final KakaoIdTokenPayload payload, final String providerUserId) {
@@ -143,30 +182,57 @@ public class AuthService {
 
     @Transactional
     public TokenResponse refresh(final String refreshTokenValue) {
-        final RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
-                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
+        try {
+            final RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
 
-        if (refreshToken.isExpired()) {
-            refreshTokenRepository.delete(refreshToken);
-            throw new BusinessException(ErrorCode.AUTH_TOKEN_EXPIRED);
+            if (refreshToken.isExpired()) {
+                refreshTokenRepository.delete(refreshToken);
+                throw new BusinessException(ErrorCode.AUTH_TOKEN_EXPIRED);
+            }
+
+            final Long userId = refreshToken.getUserId();
+            final User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+            final String newAccessToken = jwtProvider.createAccessToken(userId, user.getRole().name());
+            final String newRefreshTokenValue = jwtProvider.createRefreshToken(userId);
+
+            final LocalDateTime newExpiresAt = LocalDateTime.now().plusSeconds(jwtProperties.refreshTokenExpiry()
+                    / 1000);
+            refreshToken.rotate(newRefreshTokenValue, newExpiresAt);
+
+            recordAttempt("unknown", ACTION_REFRESH, "success");
+            return new TokenResponse(newAccessToken, newRefreshTokenValue);
+        } catch (final BusinessException e) {
+            recordAttempt("unknown", ACTION_REFRESH, mapResult(e));
+            throw e;
+        } catch (final RuntimeException e) {
+            recordAttempt("unknown", ACTION_REFRESH, "failed");
+            throw e;
         }
-
-        final Long userId = refreshToken.getUserId();
-        final User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        final String newAccessToken = jwtProvider.createAccessToken(userId, user.getRole().name());
-        final String newRefreshTokenValue = jwtProvider.createRefreshToken(userId);
-
-        final LocalDateTime newExpiresAt = LocalDateTime.now().plusSeconds(jwtProperties.refreshTokenExpiry() / 1000);
-        refreshToken.rotate(newRefreshTokenValue, newExpiresAt);
-
-        return new TokenResponse(newAccessToken, newRefreshTokenValue);
     }
 
     @Transactional
     public void logout(final String refreshTokenValue) {
         refreshTokenRepository.findByToken(refreshTokenValue)
                 .ifPresent(refreshTokenRepository::delete);
+        recordAttempt("unknown", ACTION_LOGOUT, "success");
+    }
+
+    private void recordAttempt(final String type, final String action, final String result) {
+        meterRegistry.counter(METRIC_ATTEMPTS,
+                "type", type, "action", action, "result", result).increment();
+    }
+
+    private static String mapResult(final BusinessException exception) {
+        return switch (exception.getErrorCode()) {
+            case AUTH_DUPLICATE_LOGIN_ID -> "duplicate_id";
+            case AUTH_INVALID_CREDENTIALS -> "invalid_credentials";
+            case AUTH_INVALID_TOKEN -> "invalid_token";
+            case AUTH_TOKEN_EXPIRED -> "token_expired";
+            case USER_ALREADY_DELETED -> "user_deleted";
+            default -> "failed";
+        };
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## AS-IS
PR #381 (push) + PR #383 (LLM) 후속. 인증 흐름은 개별 예외만 던지고 메트릭은 없음:
- 로그인 실패율 시계열 미관측 → 브루트포스/credential stuffing 탐지 불가
- kakao vs local 비율 미관측
- 토큰 갱신 실패율 미관측 (TTL 최적화 지표)

## TO-BE

### 메트릭
| 이름 | 타입 | 태그 |
|---|---|---|
| `ppiyaki_auth_attempts_total` | Counter | `type`, `action`, `result` |

**태그 값**:
- `type` — `kakao` / `local` / `unknown` (refresh/logout은 토큰만 받으니 type 미확정)
- `action` — `login` / `signup` / `refresh` / `logout`
- `result` — `success` / `invalid_credentials` / `duplicate_id` / `user_deleted` / `invalid_token` / `token_expired` / `failed`

### 코드 변경
- `user/service/AuthService.java`:
  - `MeterRegistry` 생성자 주입.
  - 5개 메서드 try/catch wrap. `BusinessException`은 `mapResult()` helper로 ErrorCode → result 변환. 그 외 RuntimeException은 `failed`.
  - `recordAttempt()` / `mapResult()` private helper.

### Grafana 패널 (`ppiyaki-overview` 신규 row "인증")
- **결과 분포 (rate by result, 5m)** — success=녹, invalid_credentials=적, duplicate_id=주, token_expired=황 색 매핑
- **type + action 분포** — kakao login vs local login 등 분리 시각화
- **Login 실패율 stat** (15m, 10% 주의/30% 위험)
- **Token refresh 실패율 stat** (15m, 20% 주의/50% 위험)
- **신규 가입 24h count** — `increase(action="signup", result="success")[24h]`

## 영향 범위
- `user/service/AuthService.java`만. 다른 도메인 영향 X.

## 검증
- [x] `./gradlew compileJava` 통과
- [x] `./gradlew spotlessApply` 적용 (line break 정리)
- [x] `./gradlew test` 전체 통과 (37s) — AuthServiceTest 등 기존 테스트 회귀 없음 (Spring autoconfig가 SimpleMeterRegistry 자동 주입).

## 후속
- InviteCode 로그인 메트릭 (별도 서비스 존재 시) — 본 PR 범위 외
- Rate limit 메트릭 — 별도 PR
- IP별 실패율 집계 (현재는 전역만)

Closes #384