### PR TITLE
feat(medication): 도메인 비즈니스 카운터 — 복약 인증 + 펫 포인트

### DIFF
--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -740,6 +740,162 @@
         "overrides": []
       },
       "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "row",
+      "title": "복약 / 펫 (도메인)",
+      "id": 109,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 109},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "복약 인증 status 분포 (5m)",
+      "id": 32,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 110},
+      "targets": [
+        {"expr": "sum by (status) (rate(ppiyaki_medication_log_upsert_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{status}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "TAKEN"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "MISSED"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "PENDING"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "복약 transition (new_taken / repeat / other)",
+      "id": 33,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 110},
+      "targets": [
+        {"expr": "sum by (transition) (rate(ppiyaki_medication_log_upsert_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{transition}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Pill count AI 검증 결과 (15m)",
+      "id": 34,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 118},
+      "targets": [
+        {"expr": "sum by (result) (rate(ppiyaki_medication_pill_count_total{job=\"ppiyaki-backend\"}[15m]))", "legendFormat": "{{result}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "COUNT_MATCH"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "COUNT_MISMATCH"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "COUNT_UNKNOWN"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+          {"matcher": {"id": "byName", "options": "COUNT_FAILED"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "yellow"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max", "sum"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "펫 포인트 이벤트 결과 (5m)",
+      "id": 35,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 118},
+      "targets": [
+        {"expr": "sum by (result) (rate(ppiyaki_pet_point_event_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{result}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "granted"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "stat",
+      "title": "COUNT_MATCH 비율 (1h)",
+      "id": 36,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 126},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_medication_pill_count_total{job=\"ppiyaki-backend\", result=\"COUNT_MATCH\"}[1h])) / clamp_min(sum(rate(ppiyaki_medication_pill_count_total{job=\"ppiyaki-backend\"}[1h])), 0.0001)", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "red"}, {"value": 0.5, "color": "orange"}, {"value": 0.7, "color": "green"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "오늘 신규 TAKEN (24h)",
+      "id": 37,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 8, "y": 126},
+      "targets": [
+        {"expr": "sum(increase(ppiyaki_medication_log_upsert_total{job=\"ppiyaki-backend\", transition=\"new_taken\"}[24h]))", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "대리 인증 비율 (24h)",
+      "id": 38,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 16, "y": 126},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_medication_log_upsert_total{job=\"ppiyaki-backend\", is_proxy=\"true\"}[24h])) / clamp_min(sum(rate(ppiyaki_medication_log_upsert_total{job=\"ppiyaki-backend\"}[24h])), 0.0001)", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "blue"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
     }
   ],
   "refresh": "30s",

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -18,6 +18,7 @@ import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -58,6 +59,7 @@ public class MedicationLogService {
     private final S3Client s3Client;
     private final ApplicationEventPublisher eventPublisher;
     private final com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
+    private final MeterRegistry meterRegistry;
 
     public MedicationLogService(
             final MedicationLogRepository medicationLogRepository,
@@ -69,7 +71,8 @@ public class MedicationLogService {
             final NcpStorageProperties storageProperties,
             final S3Client s3Client,
             final ApplicationEventPublisher eventPublisher,
-            final com.ppiyaki.notification.repository.NotificationRepository notificationRepository
+            final com.ppiyaki.notification.repository.NotificationRepository notificationRepository,
+            final MeterRegistry meterRegistry
     ) {
         this.medicationLogRepository = medicationLogRepository;
         this.medicationScheduleRepository = medicationScheduleRepository;
@@ -81,6 +84,7 @@ public class MedicationLogService {
         this.s3Client = s3Client;
         this.eventPublisher = eventPublisher;
         this.notificationRepository = notificationRepository;
+        this.meterRegistry = meterRegistry;
     }
 
     @Transactional
@@ -148,6 +152,8 @@ public class MedicationLogService {
                 && request.photoObjectKey() != null && !request.photoObjectKey().isBlank()) {
             final LogPillCountStatus pillCountStatus = verifyPillCount(seniorId, schedule, request);
             log.updatePillCountStatus(pillCountStatus);
+            meterRegistry.counter("ppiyaki.medication.pill_count.total",
+                    "result", pillCountStatus.name()).increment();
             // COUNT_MATCH일 때 슬롯의 다른 active schedule도 TAKEN 전파 (issue #343).
             // 시니어가 슬롯 전체 약을 사진 한 장에 담아 인증한 경우 == 슬롯 전체 인증으로 인정.
             if (pillCountStatus == LogPillCountStatus.COUNT_MATCH) {
@@ -155,7 +161,23 @@ public class MedicationLogService {
             }
         }
 
+        final String transition = resolveTransition(request.status(), previousStatus);
+        meterRegistry.counter("ppiyaki.medication.log.upsert.total",
+                "status", request.status().name(),
+                "transition", transition,
+                "is_proxy", String.valueOf(isProxy)).increment();
+
         return MedicationLogResponse.from(log, photoUrlAssembler.toFullUrl(log.getPhotoObjectKey()));
+    }
+
+    private static String resolveTransition(final LogStatus current, final LogStatus previous) {
+        if (current == LogStatus.TAKEN && previous != LogStatus.TAKEN) {
+            return "new_taken";
+        }
+        if (current == LogStatus.TAKEN && previous == LogStatus.TAKEN) {
+            return "repeat";
+        }
+        return "other";
     }
 
     /**

--- a/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
+++ b/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
@@ -9,6 +9,7 @@ import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.UserRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.LocalDate;
 import java.util.List;
 import org.slf4j.Logger;
@@ -24,12 +25,14 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class PetPointListener {
 
     private static final Logger log = LoggerFactory.getLogger(PetPointListener.class);
+    private static final String METRIC = "ppiyaki.pet.point.event.total";
 
     private final UserRepository userRepository;
     private final PetRepository petRepository;
     private final MedicationScheduleRepository medicationScheduleRepository;
     private final MedicationLogRepository medicationLogRepository;
     private final BadgeService badgeService;
+    private final MeterRegistry meterRegistry;
     private final long pointPerTaken;
 
     public PetPointListener(
@@ -38,6 +41,7 @@ public class PetPointListener {
             final MedicationScheduleRepository medicationScheduleRepository,
             final MedicationLogRepository medicationLogRepository,
             final BadgeService badgeService,
+            final MeterRegistry meterRegistry,
             @Value("${pet.points.per-taken:10}") final long pointPerTaken
     ) {
         this.userRepository = userRepository;
@@ -45,6 +49,7 @@ public class PetPointListener {
         this.medicationScheduleRepository = medicationScheduleRepository;
         this.medicationLogRepository = medicationLogRepository;
         this.badgeService = badgeService;
+        this.meterRegistry = meterRegistry;
         this.pointPerTaken = pointPerTaken;
     }
 
@@ -54,12 +59,14 @@ public class PetPointListener {
         final User user = userRepository.findById(event.seniorId()).orElse(null);
         if (user == null || user.getPetId() == null) {
             log.debug("Pet not linked for seniorId={}, skipping point", event.seniorId());
+            meterRegistry.counter(METRIC, "result", "skipped_no_pet_link").increment();
             return;
         }
 
         final Pet pet = petRepository.findById(user.getPetId()).orElse(null);
         if (pet == null) {
             log.debug("Pet entity not found for petId={}, skipping point", user.getPetId());
+            meterRegistry.counter(METRIC, "result", "skipped_pet_not_found").increment();
             return;
         }
 
@@ -71,6 +78,7 @@ public class PetPointListener {
         }
 
         badgeService.checkAndAwardBadges(pet);
+        meterRegistry.counter(METRIC, "result", "granted").increment();
     }
 
     private boolean isDayFullyTaken(final Long seniorId, final LocalDate date) {

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -21,6 +21,8 @@ import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.util.List;
@@ -31,15 +33,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.mockito.Spy;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MedicationLogService Phase 2 약 개수 AI 검증")

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -37,6 +37,9 @@ import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.mockito.Spy;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MedicationLogService Phase 2 약 개수 AI 검증")
@@ -62,6 +65,8 @@ class MedicationLogServicePhase2Test {
     private ApplicationEventPublisher eventPublisher;
     @Mock
     private com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
+    @Spy
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @InjectMocks
     private MedicationLogService service;

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -53,6 +53,9 @@ class MedicationLogServiceTest {
     private ApplicationEventPublisher eventPublisher;
     @Mock
     private com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
+    @org.mockito.Spy
+    private io.micrometer.core.instrument.MeterRegistry meterRegistry =
+            new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
 
     @InjectMocks
     private MedicationLogService medicationLogService;

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -54,8 +54,7 @@ class MedicationLogServiceTest {
     @Mock
     private com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
     @org.mockito.Spy
-    private io.micrometer.core.instrument.MeterRegistry meterRegistry =
-            new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    private io.micrometer.core.instrument.MeterRegistry meterRegistry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
 
     @InjectMocks
     private MedicationLogService medicationLogService;

--- a/src/test/java/com/ppiyaki/pet/service/PetPointListenerTest.java
+++ b/src/test/java/com/ppiyaki/pet/service/PetPointListenerTest.java
@@ -15,6 +15,7 @@ import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.UserRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +49,7 @@ class PetPointListenerTest {
     void setUp() {
         petPointListener = new PetPointListener(
                 userRepository, petRepository, medicationScheduleRepository,
-                medicationLogRepository, badgeService, 10L);
+                medicationLogRepository, badgeService, new SimpleMeterRegistry(), 10L);
     }
 
     @Test


### PR DESCRIPTION
## AS-IS
PR #381/#383/#385 후속. 인프라/외부 호출 메트릭은 충분, 핵심 비즈니스 도메인 카운터 빠짐:
- 복약 인증 결과 분포 미관측 (시니어가 약 잘 챙겨먹나가 핵심 SLO인데 LogQL grep 필요)
- Phase 2 Vision 검증(`pill_count_status`) 분포 미관측
- 복약 성공 → 펫 포인트 부여 이벤트 분포 미관측 (granted vs skip 사유)

## TO-BE

### 메트릭
| 이름 | 타입 | 태그 |
|---|---|---|
| `ppiyaki_medication_log_upsert_total` | Counter | `status`, `transition`, `is_proxy` |
| `ppiyaki_medication_pill_count_total` | Counter | `result` |
| `ppiyaki_pet_point_event_total` | Counter | `result` |

**transition 값**:
- `new_taken` — 처음 TAKEN으로 전환 (잔여분 차감 + 펫 이벤트 발생 케이스)
- `repeat` — 이미 TAKEN인 row 재호출 (멱등 케이스)
- `other` — 그 외 (MISSED/PENDING 등)

**pill_count result**: `COUNT_MATCH`/`COUNT_MISMATCH`/`COUNT_UNKNOWN`/`COUNT_FAILED`
**pet_point result**: `granted`/`skipped_no_pet_link`/`skipped_pet_not_found`

### 코드 변경
- `medication/service/MedicationLogService.java` — `MeterRegistry` 생성자 주입. `upsert()` 끝에 status/transition/is_proxy 카운터, `verifyPillCount()` 직후 result 카운터. `resolveTransition()` helper.
- `pet/service/PetPointListener.java` — `MeterRegistry` 생성자 주입. 3개 분기마다 카운터.

### Grafana 패널 (`ppiyaki-overview` 신규 row "복약 / 펫 (도메인)")
- 복약 인증 status 분포 (TAKEN=녹/MISSED=적/PENDING=주, 5m rate)
- 복약 transition 분포 (new_taken 추출용)
- pill_count AI 검증 결과 분포 (COUNT_MATCH=녹 강조, 15m rate)
- 펫 포인트 이벤트 결과 분포 (granted vs skipped)
- **Stat 3종**:
  - COUNT_MATCH 비율 (1h) — 50%/70% threshold
  - 오늘 신규 TAKEN 24h count
  - 대리 인증 비율 (24h) — 보호자 대리 인증 추세

## 영향 범위
- `medication/service/MedicationLogService.java`
- `pet/service/PetPointListener.java`
- 단위 테스트 3개 — `@Spy SimpleMeterRegistry` 주입
- dashboard JSON

## 검증
- [x] `./gradlew compileJava` 통과
- [x] `./gradlew spotlessCheck checkstyleMain` 통과
- [x] `./gradlew test` 전체 통과 (~ 30분, H2 통합 테스트 다수 포함)

## 후속
- 처방전 OCR 카운터 (`PrescriptionService`) — 별도 PR
- 외부 API 통합 카운터 (`ppiyaki_external_api_*`) — 별도 PR
- BadgeService 획득 카운터 — 후속

Closes #386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 모니터링 대시보드에 복약 및 펫 도메인 관련 메트릭 패널 7개 추가 (복약 인증 상태, 복약 전환 비율, Pill count 검증 결과, 펫 포인트 이벤트 결과 등)

* **Chores**
  * 메트릭 기록 기능에 대한 테스트 환경 구성 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->