### PR TITLE
release: v0.13.4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,3 +93,19 @@ CLOVA_OCR_SECRET=your-clova-ocr-secret
 # 비워두면 LLM 채팅·이미지 분석 기능 비활성.
 # -----------------------------------------------------------------------------
 OPENAI_API_KEY=your-openai-api-key
+
+# -----------------------------------------------------------------------------
+# Management / Observability port
+# Spring Boot Actuator + Micrometer는 메인(8080)과 별도 포트로 노출.
+# backend-cd.yml은 8081을 publish하지 않으므로 prod에서 외부 접근 불가
+# (SSH 접속자 또는 같은 docker network 내 컨테이너만 호출).
+# -----------------------------------------------------------------------------
+MANAGEMENT_PORT=8081
+
+# -----------------------------------------------------------------------------
+# Monitoring stack — Prometheus + Grafana (infra/monitoring/docker-compose.yml)
+# 로컬에선 보통 안 띄움. prod에서 monitoring stack 띄울 때 사용.
+# Grafana admin 로그인 정보. prod는 ~/monitoring/.env에 별도 등록.
+# -----------------------------------------------------------------------------
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=change-me-to-a-strong-password

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -7,6 +7,7 @@ Prometheus + Grafana docker compose 스택. 같은 NCP 서버에 백엔드와 �
 - **Prometheus** (`prom/prometheus:v3.0.1`) — 백엔드 `/actuator/prometheus` 엔드포인트를 15초 간격으로 scrape. 30일 보관.
 - **Grafana** (`grafana/grafana:11.4.0`) — 시각화. 3000 포트 외부 노출 (admin 패스워드 인증).
 - 백엔드와 같은 docker network (`ppiyaki-monitoring`)에 join → `ppiyaki-server:8081/actuator/prometheus` scrape.
+- **Dashboard provisioning** — `grafana/provisioning/dashboards/json/*.json`을 자동 로드 (folder: `ppiyaki`). 현재 `ppiyaki-overview` 한 개.
 
 ## 최초 셋업 (prod, 1회)
 
@@ -77,8 +78,20 @@ sudo docker exec ppiyaki-prometheus kill -HUP 1
 - **외부 노출 보안** = admin 패스워드. IP allowlist / VPN은 별도 옵션.
 - 백엔드 컨테이너가 `ppiyaki-monitoring` network에 join한 후에만 scrape 동작. 미연결 상태에선 target down.
 
+## 대시보드 갱신
+
+대시보드 JSON을 수정한 후 prod 적용:
+
+```bash
+# 로컬에서 prod로 dashboards 디렉토리 동기화
+scp -i ~/workspace/secret/ppiyaki-key.pem -r infra/monitoring/grafana/provisioning ubuntu@211.188.48.217:~/monitoring/grafana/
+
+# Grafana 재시작 (provisioning은 30s 간격 reload 설정이라 재시작 없이도 반영되지만, datasource 변경 시엔 필요)
+ssh -i ~/workspace/secret/ppiyaki-key.pem ubuntu@211.188.48.217 'cd ~/monitoring && sudo docker compose restart grafana'
+```
+
 ## Phase 3 (예정/옵션)
 
 - 알림 (Alertmanager + Discord/Slack webhook)
 - 백업 (Prometheus snapshot → NCP Object Storage)
-- 대시보드 .json provisioning (JVM, HTTP, 캐시 적중률, DB connection)
+- ~~대시보드 .json provisioning (JVM, HTTP, 캐시 적중률, DB connection)~~ ✅ done (`ppiyaki-overview`)

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -1,13 +1,15 @@
-# Monitoring Stack (Phase 2)
+# Monitoring Stack
 
-Prometheus + Grafana docker compose 스택. 같은 NCP 서버에 백엔드와 함께 실행.
+Prometheus(메트릭) + Loki(로그) + Grafana(시각화) docker compose 스택. 같은 NCP 서버에 백엔드와 함께 실행.
 
 ## 구성
 
 - **Prometheus** (`prom/prometheus:v3.0.1`) — 백엔드 `/actuator/prometheus` 엔드포인트를 15초 간격으로 scrape. 30일 보관.
+- **Loki** (`grafana/loki:3.3.2`) — 로그 저장소. filesystem storage, 14일 보관(`limits_config.retention_period: 336h`). 내부망만(외부 노출 X).
+- **Alloy** (`grafana/alloy:v1.5.1`) — 로그 수집 agent. docker socket(`/var/run/docker.sock:ro`)으로 `ppiyaki-server` 컨테이너 stdout JSON을 읽어 Loki에 push. River 설정 `alloy/config.alloy`.
 - **Grafana** (`grafana/grafana:11.4.0`) — 시각화. 3000 포트 외부 노출 (admin 패스워드 인증).
 - 백엔드와 같은 docker network (`ppiyaki-monitoring`)에 join → `ppiyaki-server:8081/actuator/prometheus` scrape.
-- **Dashboard provisioning** — `grafana/provisioning/dashboards/json/*.json`을 자동 로드 (folder: `ppiyaki`). 현재 `ppiyaki-overview` 한 개.
+- **Dashboard provisioning** — `grafana/provisioning/dashboards/json/*.json`을 자동 로드 (folder: `ppiyaki`). 현재 `ppiyaki-overview` 한 개 (메트릭 + Loki 로그 패널).
 
 ## 최초 셋업 (prod, 1회)
 
@@ -54,6 +56,8 @@ sudo docker compose --env-file .env up -d
 
 - Prometheus 타겟 상태: prod localhost로 `sudo docker exec ppiyaki-prometheus wget -qO- http://localhost:9090/api/v1/targets | head`
 - Grafana: 브라우저로 `http://211.188.48.217:3000` → admin/<패스워드> 로그인
+- Loki readiness: `sudo docker exec ppiyaki-loki wget -qO- http://localhost:3100/ready`
+- Alloy → Loki 로그 흐름: Grafana → Explore → datasource=Loki → `{job="ppiyaki-backend"}` 쿼리. 또는 ppiyaki-overview 대시보드 "애플리케이션 로그 (Loki)" row.
 
 ## 일상 운영
 
@@ -73,10 +77,12 @@ sudo docker exec ppiyaki-prometheus kill -HUP 1
 
 ## 알려진 제약
 
-- **백업 없음** (Phase 2 범위 외). Prometheus tsdb / Grafana 설정은 docker volume에만. 서버 장애 시 손실.
+- **백업 없음**. Prometheus tsdb / Loki chunks / Grafana 설정은 docker volume에만. 서버 장애 시 손실.
 - **HA 없음**. 단일 서버.
 - **외부 노출 보안** = admin 패스워드. IP allowlist / VPN은 별도 옵션.
-- 백엔드 컨테이너가 `ppiyaki-monitoring` network에 join한 후에만 scrape 동작. 미연결 상태에선 target down.
+- 백엔드 컨테이너가 `ppiyaki-monitoring` network에 join한 후에만 scrape/log 수집 동작. 미연결 상태에선 target down.
+- **Alloy docker socket 마운트** = root 소켓 접근. 표준 패턴이지만 호스트 컨테이너 통제 권한을 가짐. read-only(`ro`) 마운트.
+- **Loki 디스크 사용량**: 14일 보관 + 트래픽에 따라 수백 MB~수 GB. 부족 시 `limits_config.retention_period` 단축 또는 chunk size 조정.
 
 ## 대시보드 갱신
 
@@ -90,8 +96,10 @@ scp -i ~/workspace/secret/ppiyaki-key.pem -r infra/monitoring/grafana/provisioni
 ssh -i ~/workspace/secret/ppiyaki-key.pem ubuntu@211.188.48.217 'cd ~/monitoring && sudo docker compose restart grafana'
 ```
 
-## Phase 3 (예정/옵션)
+## 향후 옵션
 
-- 알림 (Alertmanager + Discord/Slack webhook)
-- 백업 (Prometheus snapshot → NCP Object Storage)
+- 알림 (Alertmanager + Discord/Slack webhook, Loki rules)
+- 백업 (Prometheus snapshot + Loki chunks → NCP Object Storage)
 - ~~대시보드 .json provisioning (JVM, HTTP, 캐시 적중률, DB connection)~~ ✅ done (`ppiyaki-overview`)
+- ~~로그 수집 + Grafana에서 검색~~ ✅ done (Loki + Alloy)
+- LogQL alert (ERROR rate 임계치 → Discord)

--- a/infra/monitoring/alloy/config.alloy
+++ b/infra/monitoring/alloy/config.alloy
@@ -1,0 +1,86 @@
+// Grafana Alloy 설정 — ppiyaki-server 컨테이너 stdout JSON 로그 수집 → Loki push.
+// docs/ai-harness/10-observability.md 및 infra/monitoring/README.md 참고.
+
+// 1) docker socket으로 컨테이너 발견.
+discovery.docker "ppiyaki" {
+  host             = "unix:///var/run/docker.sock"
+  refresh_interval = "30s"
+}
+
+// 2) ppiyaki-server 컨테이너만 keep, label 정리.
+discovery.relabel "ppiyaki" {
+  targets = discovery.docker.ppiyaki.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/ppiyaki-server"
+    action        = "keep"
+  }
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+    replacement   = "$1"
+  }
+}
+
+// 3) docker stdout 수집 → JSON parse stage로 forward.
+loki.source.docker "ppiyaki" {
+  host          = "unix:///var/run/docker.sock"
+  targets       = discovery.relabel.ppiyaki.output
+  forward_to    = [loki.process.json_logs.receiver]
+  relabel_rules = discovery.relabel.ppiyaki.rules
+  labels        = {
+    job = "ppiyaki-backend",
+  }
+}
+
+// 4) LogstashEncoder JSON 파싱 → label 추출 + timestamp 보정.
+loki.process "json_logs" {
+  forward_to = [loki.write.local.receiver]
+
+  // 표준 필드 추출
+  stage.json {
+    expressions = {
+      timestamp = "\"@timestamp\"",
+      level     = "level",
+      logger    = "logger_name",
+      thread    = "thread_name",
+      message   = "message",
+      service   = "service",
+      env       = "env",
+      requestId = "requestId",
+      userId    = "userId",
+    }
+  }
+
+  // 인덱스용 라벨(카디널리티 낮은 것만). requestId/userId/logger는 cardinality 폭발 위험으로 추출만 하고 라벨화 X — LogQL `|=` 검색으로 조회.
+  stage.labels {
+    values = {
+      level   = "",
+      service = "",
+      env     = "",
+    }
+  }
+
+  // ISO-8601 with nanoseconds + tz offset (예: 2026-05-18T13:38:00.143714564+09:00)
+  stage.timestamp {
+    source = "timestamp"
+    format = "RFC3339Nano"
+  }
+
+  // 원본 JSON 그대로 line으로 보존 (Grafana Logs 패널에서 raw view).
+  stage.output {
+    source = "message"
+  }
+}
+
+// 5) Loki push.
+loki.write "local" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+  external_labels = {
+    cluster = "ppiyaki-prod",
+  }
+}

--- a/infra/monitoring/docker-compose.yml
+++ b/infra/monitoring/docker-compose.yml
@@ -35,10 +35,44 @@ services:
       - ppiyaki-monitoring
     depends_on:
       - prometheus
+      - loki
+
+  loki:
+    image: grafana/loki:3.3.2
+    container_name: ppiyaki-loki
+    restart: always
+    command: -config.file=/etc/loki/config.yml
+    volumes:
+      - ./loki/config.yml:/etc/loki/config.yml:ro
+      - loki-data:/loki
+    networks:
+      - ppiyaki-monitoring
+    # 외부 노출 안 함. Grafana는 같은 network에서 http://loki:3100으로 접근.
+
+  alloy:
+    image: grafana/alloy:v1.5.1
+    container_name: ppiyaki-alloy
+    restart: always
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - alloy-data:/var/lib/alloy/data
+    networks:
+      - ppiyaki-monitoring
+    depends_on:
+      - loki
+    # docker socket은 read-only 마운트. 표준 패턴이지만 root socket 접근 권한임을 명시.
 
 volumes:
   prometheus-data:
   grafana-data:
+  loki-data:
+  alloy-data:
 
 networks:
   ppiyaki-monitoring:

--- a/infra/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/infra/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: ppiyaki
+    orgId: 1
+    folder: ppiyaki
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/json
+      foldersFromFilesStructure: false

--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -896,6 +896,113 @@
         "overrides": []
       },
       "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "row",
+      "title": "외부 API + 처방전 / 뱃지",
+      "id": 110,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 132},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "외부 API 호출률 by api (1m)",
+      "id": 39,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 133},
+      "targets": [
+        {"expr": "sum by (api) (rate(ppiyaki_external_api_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{api}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "외부 API p95 지연 by api",
+      "id": 40,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 133},
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum by (le, api) (rate(ppiyaki_external_api_seconds_bucket{job=\"ppiyaki-backend\"}[5m])))", "legendFormat": "p95 {{api}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3,
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "stat",
+      "title": "외부 API 실패율 (15m)",
+      "id": 41,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 141},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_external_api_total{job=\"ppiyaki-backend\", result=\"failed\"}[15m])) / clamp_min(sum(rate(ppiyaki_external_api_total{job=\"ppiyaki-backend\"}[15m])), 0.0001)", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}, {"value": 0.05, "color": "orange"}, {"value": 0.15, "color": "red"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "처방전 confirm 24h",
+      "id": 42,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 8, "y": 141},
+      "targets": [
+        {"expr": "sum(increase(ppiyaki_prescription_confirm_total{job=\"ppiyaki-backend\", result=\"success\"}[24h]))", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "blue"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "timeseries",
+      "title": "뱃지 획득 by badge_type (1h)",
+      "id": 43,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 16, "y": 141},
+      "targets": [
+        {"expr": "sum by (badge_type) (increase(ppiyaki_badge_awarded_total{job=\"ppiyaki-backend\"}[1h]))", "legendFormat": "{{badge_type}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {"drawStyle": "bars", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 70, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["sum"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
     }
   ],
   "refresh": "30s",

--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -628,6 +628,118 @@
         ]
       },
       "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "row",
+      "title": "인증",
+      "id": 108,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 94},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Auth 결과 분포 (rate by result, 5m)",
+      "id": 27,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 95},
+      "targets": [
+        {"expr": "sum by (result) (rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{result}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "success"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "invalid_credentials"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "duplicate_id"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+          {"matcher": {"id": "byName", "options": "token_expired"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "yellow"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Auth type + action 분포 (5m)",
+      "id": 28,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 95},
+      "targets": [
+        {"expr": "sum by (type, action) (rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{type}} {{action}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "stat",
+      "title": "Login 실패율 (15m)",
+      "id": 29,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 103},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\", action=\"login\", result!=\"success\"}[15m])) / clamp_min(sum(rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\", action=\"login\"}[15m])), 0.0001)", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}, {"value": 0.10, "color": "orange"}, {"value": 0.30, "color": "red"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "Token refresh 실패율 (15m)",
+      "id": 30,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 8, "y": 103},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\", action=\"refresh\", result!=\"success\"}[15m])) / clamp_min(sum(rate(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\", action=\"refresh\"}[15m])), 0.0001)", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}, {"value": 0.20, "color": "orange"}, {"value": 0.50, "color": "red"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "신규 가입 24h",
+      "id": 31,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 16, "y": 103},
+      "targets": [
+        {"expr": "sum(increase(ppiyaki_auth_attempts_total{job=\"ppiyaki-backend\", action=\"signup\", result=\"success\"}[24h]))", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "blue"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
     }
   ],
   "refresh": "30s",

--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -348,9 +348,57 @@
     },
     {
       "type": "row",
-      "title": "로그 / Tomcat",
-      "id": 104,
+      "title": "애플리케이션 로그 (Loki)",
+      "id": 105,
       "gridPos": {"h": 1, "w": 24, "x": 0, "y": 40},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "logs",
+      "title": "Recent logs (all levels)",
+      "id": 17,
+      "datasource": {"type": "loki", "uid": "loki"},
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 41},
+      "targets": [
+        {"expr": "{job=\"ppiyaki-backend\"}", "refId": "A", "datasource": {"type": "loki", "uid": "loki"}}
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "prettifyLogMessage": false,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none",
+        "enableLogDetails": true
+      }
+    },
+    {
+      "type": "logs",
+      "title": "ERROR / WARN only",
+      "id": 18,
+      "datasource": {"type": "loki", "uid": "loki"},
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 41},
+      "targets": [
+        {"expr": "{job=\"ppiyaki-backend\", level=~\"ERROR|WARN\"}", "refId": "A", "datasource": {"type": "loki", "uid": "loki"}}
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "prettifyLogMessage": false,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none",
+        "enableLogDetails": true
+      }
+    },
+    {
+      "type": "row",
+      "title": "로그 메트릭 / Tomcat",
+      "id": 104,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 51},
       "collapsed": true,
       "panels": [
         {
@@ -358,7 +406,7 @@
           "title": "Logback events rate by level (1m)",
           "id": 15,
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 41},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 52},
           "targets": [
             {"expr": "sum by (level) (rate(logback_events_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{level}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
           ],
@@ -380,7 +428,7 @@
           "title": "Tomcat sessions",
           "id": 16,
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 41},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 52},
           "targets": [
             {"expr": "tomcat_sessions_active_current_sessions{job=\"ppiyaki-backend\"}", "legendFormat": "active", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}},
             {"expr": "rate(tomcat_sessions_created_sessions_total{job=\"ppiyaki-backend\"}[5m])", "legendFormat": "created/s (5m)", "refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"}}

--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -536,6 +536,98 @@
         "overrides": []
       },
       "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "row",
+      "title": "LLM (OpenAI / STT / TTS)",
+      "id": 107,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 77},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM 호출률 by operation (1m)",
+      "id": 23,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 78},
+      "targets": [
+        {"expr": "sum by (operation) (rate(ppiyaki_llm_request_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{operation}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM 지연 p95 by operation",
+      "id": 24,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 78},
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum by (le, operation) (rate(ppiyaki_llm_request_seconds_bucket{job=\"ppiyaki-backend\"}[5m])))", "legendFormat": "p95 {{operation}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 2,
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM 토큰 사용량 by model + direction (1h increase)",
+      "id": 25,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 86},
+      "targets": [
+        {"expr": "sum by (model, direction) (increase(ppiyaki_llm_tokens_total{job=\"ppiyaki-backend\"}[1h]))", "legendFormat": "{{model}} {{direction}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": ".*completion.*"}, "properties": [{"id": "custom.lineStyle", "value": {"dash": [10, 10], "fill": "dash"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["sum", "mean"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM 결과 분포 (success / failed / empty)",
+      "id": 26,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 86},
+      "targets": [
+        {"expr": "sum by (result) (rate(ppiyaki_llm_request_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{result}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "success"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "empty"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+          {"matcher": {"id": "byName", "options": "failed"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
     }
   ],
   "refresh": "30s",

--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -740,6 +740,162 @@
         "overrides": []
       },
       "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "row",
+      "title": "복약 / 펫 (도메인)",
+      "id": 109,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 109},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "복약 인증 status 분포 (5m)",
+      "id": 32,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 110},
+      "targets": [
+        {"expr": "sum by (status) (rate(ppiyaki_medication_log_upsert_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{status}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "TAKEN"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "MISSED"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "PENDING"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "복약 transition (new_taken / repeat / other)",
+      "id": 33,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 110},
+      "targets": [
+        {"expr": "sum by (transition) (rate(ppiyaki_medication_log_upsert_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{transition}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Pill count AI 검증 결과 (15m)",
+      "id": 34,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 118},
+      "targets": [
+        {"expr": "sum by (result) (rate(ppiyaki_medication_pill_count_total{job=\"ppiyaki-backend\"}[15m]))", "legendFormat": "{{result}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "COUNT_MATCH"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "COUNT_MISMATCH"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "COUNT_UNKNOWN"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+          {"matcher": {"id": "byName", "options": "COUNT_FAILED"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "yellow"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max", "sum"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "펫 포인트 이벤트 결과 (5m)",
+      "id": 35,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 118},
+      "targets": [
+        {"expr": "sum by (result) (rate(ppiyaki_pet_point_event_total{job=\"ppiyaki-backend\"}[5m]))", "legendFormat": "{{result}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "granted"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "stat",
+      "title": "COUNT_MATCH 비율 (1h)",
+      "id": 36,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 126},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_medication_pill_count_total{job=\"ppiyaki-backend\", result=\"COUNT_MATCH\"}[1h])) / clamp_min(sum(rate(ppiyaki_medication_pill_count_total{job=\"ppiyaki-backend\"}[1h])), 0.0001)", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "red"}, {"value": 0.5, "color": "orange"}, {"value": 0.7, "color": "green"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "오늘 신규 TAKEN (24h)",
+      "id": 37,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 8, "y": 126},
+      "targets": [
+        {"expr": "sum(increase(ppiyaki_medication_log_upsert_total{job=\"ppiyaki-backend\", transition=\"new_taken\"}[24h]))", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "대리 인증 비율 (24h)",
+      "id": 38,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 16, "y": 126},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_medication_log_upsert_total{job=\"ppiyaki-backend\", is_proxy=\"true\"}[24h])) / clamp_min(sum(rate(ppiyaki_medication_log_upsert_total{job=\"ppiyaki-backend\"}[24h])), 0.0001)", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "blue"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
     }
   ],
   "refresh": "30s",

--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -1,0 +1,412 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Ppiyaki backend 종합 대시보드 — JVM, HTTP, Hikari, 외부 API 캐시 hit/miss",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "System CPU",
+      "id": 1,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+      "targets": [
+        {"expr": "system_cpu_usage{job=\"ppiyaki-backend\"} * 100", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}, {"value": 70, "color": "orange"}, {"value": 90, "color": "red"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "Process CPU",
+      "id": 2,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 0},
+      "targets": [
+        {"expr": "process_cpu_usage{job=\"ppiyaki-backend\"} * 100", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}, {"value": 70, "color": "orange"}, {"value": 90, "color": "red"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "JVM Heap Used",
+      "id": 3,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 0},
+      "targets": [
+        {"expr": "sum(jvm_memory_used_bytes{job=\"ppiyaki-backend\",area=\"heap\"})", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "HTTP Active",
+      "id": 4,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 4, "w": 4, "x": 12, "y": 0},
+      "targets": [
+        {"expr": "sum(http_server_requests_active_seconds_count{job=\"ppiyaki-backend\"})", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}, {"value": 20, "color": "orange"}, {"value": 50, "color": "red"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "Hikari Active",
+      "id": 5,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 4, "w": 4, "x": 16, "y": 0},
+      "targets": [
+        {"expr": "sum(hikaricp_connections_active{job=\"ppiyaki-backend\"})", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}, {"value": 7, "color": "orange"}, {"value": 9, "color": "red"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "stat",
+      "title": "Cache Hit Ratio (15m)",
+      "id": 6,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 4, "w": 4, "x": 20, "y": 0},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_cache_hits_total{job=\"ppiyaki-backend\"}[15m])) / (sum(rate(ppiyaki_cache_hits_total{job=\"ppiyaki-backend\"}[15m])) + sum(rate(ppiyaki_cache_misses_total{job=\"ppiyaki-backend\"}[15m])))", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "red"}, {"value": 0.5, "color": "orange"}, {"value": 0.8, "color": "green"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
+    },
+    {
+      "type": "row",
+      "title": "HTTP",
+      "id": 100,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 4},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP RPS by status",
+      "id": 7,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5},
+      "targets": [
+        {"expr": "sum by (status) (rate(http_server_requests_seconds_count{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{status}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "stacking": {"mode": "normal", "group": "A"}, "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP latency p95 / p99 (all endpoints)",
+      "id": 8,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 5},
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"ppiyaki-backend\"}[5m])))", "legendFormat": "p95", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"ppiyaki-backend\"}[5m])))", "legendFormat": "p99", "refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3,
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "row",
+      "title": "DB (Hikari)",
+      "id": 101,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 13},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Hikari connections by state",
+      "id": 9,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 14},
+      "targets": [
+        {"expr": "hikaricp_connections_active{job=\"ppiyaki-backend\"}", "legendFormat": "active", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"expr": "hikaricp_connections_idle{job=\"ppiyaki-backend\"}", "legendFormat": "idle", "refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"expr": "hikaricp_connections_pending{job=\"ppiyaki-backend\"}", "legendFormat": "pending", "refId": "C", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"expr": "hikaricp_connections_max{job=\"ppiyaki-backend\"}", "legendFormat": "max", "refId": "D", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {"drawStyle": "line", "lineInterpolation": "stepAfter", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "pending"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "max"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "gray"}}, {"id": "custom.lineStyle", "value": {"dash": [10, 10], "fill": "dash"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Hikari connection acquire / timeouts",
+      "id": 10,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 14},
+      "targets": [
+        {"expr": "rate(hikaricp_connections_acquire_seconds_sum{job=\"ppiyaki-backend\"}[1m]) / clamp_min(rate(hikaricp_connections_acquire_seconds_count{job=\"ppiyaki-backend\"}[1m]), 0.001)", "legendFormat": "acquire avg", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"expr": "hikaricp_connections_acquire_seconds_max{job=\"ppiyaki-backend\"}", "legendFormat": "acquire max", "refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"expr": "rate(hikaricp_connections_timeout_total{job=\"ppiyaki-backend\"}[5m])", "legendFormat": "timeout rate", "refId": "C", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 4,
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "timeout rate"}, "properties": [{"id": "unit", "value": "ops"}, {"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "row",
+      "title": "JVM",
+      "id": 102,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 22},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "JVM memory used by area",
+      "id": 11,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 23},
+      "targets": [
+        {"expr": "sum by (area) (jvm_memory_used_bytes{job=\"ppiyaki-backend\"})", "legendFormat": "{{area}} used", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"expr": "sum by (area) (jvm_memory_committed_bytes{job=\"ppiyaki-backend\"})", "legendFormat": "{{area}} committed", "refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "GC pause time / live threads",
+      "id": 12,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 23},
+      "targets": [
+        {"expr": "rate(jvm_gc_pause_seconds_sum{job=\"ppiyaki-backend\"}[1m])", "legendFormat": "gc pause sec/sec ({{action}})", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"expr": "jvm_threads_live_threads{job=\"ppiyaki-backend\"}", "legendFormat": "live threads", "refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": ".*gc pause.*"}, "properties": [{"id": "unit", "value": "s"}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "row",
+      "title": "외부 API 캐시",
+      "id": 103,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 31},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache requests rate by cache (hits + misses, 1m)",
+      "id": 13,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 32},
+      "targets": [
+        {"expr": "sum by (cache) (rate(ppiyaki_cache_hits_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{cache}} hits", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"expr": "sum by (cache) (rate(ppiyaki_cache_misses_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{cache}} misses", "refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": ".*misses"}, "properties": [{"id": "custom.lineStyle", "value": {"dash": [10, 10], "fill": "dash"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache hit ratio by cache (15m)",
+      "id": 14,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 32},
+      "targets": [
+        {"expr": "sum by (cache) (rate(ppiyaki_cache_hits_total{job=\"ppiyaki-backend\"}[15m])) / clamp_min(sum by (cache) (rate(ppiyaki_cache_hits_total{job=\"ppiyaki-backend\"}[15m])) + sum by (cache) (rate(ppiyaki_cache_misses_total{job=\"ppiyaki-backend\"}[15m])), 0.0001)", "legendFormat": "{{cache}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "row",
+      "title": "로그 / Tomcat",
+      "id": 104,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 40},
+      "collapsed": true,
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "Logback events rate by level (1m)",
+          "id": 15,
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 41},
+          "targets": [
+            {"expr": "sum by (level) (rate(logback_events_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{level}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+              "color": {"mode": "palette-classic"}
+            },
+            "overrides": [
+              {"matcher": {"id": "byName", "options": "error"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+              {"matcher": {"id": "byName", "options": "warn"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]}
+            ]
+          },
+          "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+        },
+        {
+          "type": "timeseries",
+          "title": "Tomcat sessions",
+          "id": 16,
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 41},
+          "targets": [
+            {"expr": "tomcat_sessions_active_current_sessions{job=\"ppiyaki-backend\"}", "legendFormat": "active", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+            {"expr": "rate(tomcat_sessions_created_sessions_total{job=\"ppiyaki-backend\"}[5m])", "legendFormat": "created/s (5m)", "refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+              "color": {"mode": "palette-classic"}
+            },
+            "overrides": []
+          },
+          "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["ppiyaki", "spring-boot"],
+  "templating": {"list": []},
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "Asia/Seoul",
+  "title": "Ppiyaki Overview",
+  "uid": "ppiyaki-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/json/ppiyaki-overview.json
@@ -444,6 +444,98 @@
           "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
         }
       ]
+    },
+    {
+      "type": "row",
+      "title": "알림 발송 (FCM Push)",
+      "id": 106,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 60},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Push 발송률 by category (1m)",
+      "id": 19,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 61},
+      "targets": [
+        {"expr": "sum by (category) (rate(ppiyaki_push_sent_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{category}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Push 결과 분포 (success / token_invalid / failed)",
+      "id": 20,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 61},
+      "targets": [
+        {"expr": "sum by (result) (rate(ppiyaki_push_sent_total{job=\"ppiyaki-backend\"}[1m]))", "legendFormat": "{{result}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "normal", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "success"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+          {"matcher": {"id": "byName", "options": "token_invalid"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+          {"matcher": {"id": "byName", "options": "failed"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]}
+        ]
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max", "sum"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Push 발송 지연 p95 / p99 by category",
+      "id": 21,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 69},
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum by (le, category) (rate(ppiyaki_push_send_seconds_bucket{job=\"ppiyaki-backend\"}[5m])))", "legendFormat": "p95 {{category}}", "refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"expr": "histogram_quantile(0.99, sum by (le, category) (rate(ppiyaki_push_send_seconds_bucket{job=\"ppiyaki-backend\"}[5m])))", "legendFormat": "p99 {{category}}", "refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3,
+          "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never", "spanNulls": true, "axisLabel": "", "axisPlacement": "auto", "gradientMode": "none", "pointSize": 5, "scaleDistribution": {"type": "linear"}, "stacking": {"mode": "none", "group": "A"}, "hideFrom": {"tooltip": false, "viz": false, "legend": false}, "thresholdsStyle": {"mode": "off"}},
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"], "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}
+    },
+    {
+      "type": "stat",
+      "title": "Push 실패율 (15m)",
+      "id": 22,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 69},
+      "targets": [
+        {"expr": "sum(rate(ppiyaki_push_sent_total{job=\"ppiyaki-backend\", result!=\"success\"}[15m])) / clamp_min(sum(rate(ppiyaki_push_sent_total{job=\"ppiyaki-backend\"}[15m])), 0.0001)", "refId": "A", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "green"}, {"value": 0.05, "color": "orange"}, {"value": 0.15, "color": "red"}]}
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}
     }
   ],
   "refresh": "30s",

--- a/infra/monitoring/grafana/provisioning/datasources/loki.yml
+++ b/infra/monitoring/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: false
+    jsonData:
+      maxLines: 1000

--- a/infra/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -2,6 +2,7 @@ apiVersion: 1
 
 datasources:
   - name: Prometheus
+    uid: prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090

--- a/infra/monitoring/loki/config.yml
+++ b/infra/monitoring/loki/config.yml
@@ -1,0 +1,46 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  retention_period: 336h
+  allow_structured_metadata: true
+  volume_enabled: true
+
+compactor:
+  working_directory: /loki/compactor
+  delete_request_store: filesystem
+  retention_enabled: true
+  compaction_interval: 10m
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+
+analytics:
+  reporting_enabled: false

--- a/src/main/java/com/ppiyaki/chat/service/SttService.java
+++ b/src/main/java/com/ppiyaki/chat/service/SttService.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.chat.service;
 
-import lombok.RequiredArgsConstructor;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionOptions;
@@ -9,10 +10,18 @@ import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class SttService {
 
+    private static final String MODEL = "whisper-1";
+    private static final String OPERATION = "stt_transcribe";
+
     private final OpenAiAudioTranscriptionModel transcriptionModel;
+    private final MeterRegistry meterRegistry;
+
+    public SttService(final OpenAiAudioTranscriptionModel transcriptionModel, final MeterRegistry meterRegistry) {
+        this.transcriptionModel = transcriptionModel;
+        this.meterRegistry = meterRegistry;
+    }
 
     public String transcribe(final Resource audioResource, final String language) {
         final OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
@@ -22,10 +31,27 @@ public class SttService {
 
         final AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(audioResource, options);
 
-        final var response = transcriptionModel.call(prompt);
-        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
-            throw new IllegalStateException("STT 변환 결과가 비어있습니다.");
+        final Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            final var response = transcriptionModel.call(prompt);
+            if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+                record("empty", sample);
+                throw new IllegalStateException("STT 변환 결과가 비어있습니다.");
+            }
+            record("success", sample);
+            return response.getResult().getOutput();
+        } catch (final IllegalStateException e) {
+            throw e;
+        } catch (final RuntimeException e) {
+            record("failed", sample);
+            throw e;
         }
-        return response.getResult().getOutput();
+    }
+
+    private void record(final String result, final Timer.Sample sample) {
+        meterRegistry.counter("ppiyaki.llm.request.total",
+                "model", MODEL, "operation", OPERATION, "result", result).increment();
+        sample.stop(meterRegistry.timer("ppiyaki.llm.request.seconds",
+                "model", MODEL, "operation", OPERATION, "result", result));
     }
 }

--- a/src/main/java/com/ppiyaki/chat/service/TtsService.java
+++ b/src/main/java/com/ppiyaki/chat/service/TtsService.java
@@ -1,19 +1,43 @@
 package com.ppiyaki.chat.service;
 
-import lombok.RequiredArgsConstructor;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.springframework.ai.openai.OpenAiAudioSpeechModel;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class TtsService {
 
+    private static final String MODEL = "tts-1";
+    private static final String OPERATION = "tts_synthesize";
+
     private final OpenAiAudioSpeechModel speechModel;
+    private final MeterRegistry meterRegistry;
+
+    public TtsService(final OpenAiAudioSpeechModel speechModel, final MeterRegistry meterRegistry) {
+        this.speechModel = speechModel;
+        this.meterRegistry = meterRegistry;
+    }
 
     public byte[] synthesize(final String text) {
         if (text.isBlank()) {
             throw new IllegalArgumentException("text must not be blank");
         }
-        return speechModel.call(text);
+        final Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            final byte[] audio = speechModel.call(text);
+            record("success", sample);
+            return audio;
+        } catch (final RuntimeException e) {
+            record("failed", sample);
+            throw e;
+        }
+    }
+
+    private void record(final String result, final Timer.Sample sample) {
+        meterRegistry.counter("ppiyaki.llm.request.total",
+                "model", MODEL, "operation", OPERATION, "result", result).increment();
+        sample.stop(meterRegistry.timer("ppiyaki.llm.request.seconds",
+                "model", MODEL, "operation", OPERATION, "result", result));
     }
 }

--- a/src/main/java/com/ppiyaki/infrastructure/ai/OpenAiClient.java
+++ b/src/main/java/com/ppiyaki/infrastructure/ai/OpenAiClient.java
@@ -6,6 +6,8 @@ import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.medication.domain.DosageUnit;
 import com.ppiyaki.medication.domain.MealSlot;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -28,17 +30,29 @@ public class OpenAiClient {
     private static final Logger log = LoggerFactory.getLogger(OpenAiClient.class);
     private static final String API_URL = "https://api.openai.com/v1/chat/completions";
 
+    private static final String METRIC_TOKENS = "ppiyaki.llm.tokens.total";
+    private static final String METRIC_REQUEST = "ppiyaki.llm.request.total";
+    private static final String METRIC_TIMER = "ppiyaki.llm.request.seconds";
+    private static final String OP_EXTRACT = "extract_medicines";
+    private static final String OP_COUNT_PILLS = "count_pills";
+    private static final String RESULT_SUCCESS = "success";
+    private static final String RESULT_FAILED = "failed";
+    private static final String RESULT_EMPTY = "empty";
+
     private final OpenAiProperties properties;
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
 
     public OpenAiClient(
             final OpenAiProperties properties,
             final RestClient.Builder restClientBuilder,
-            final ObjectMapper objectMapper
+            final ObjectMapper objectMapper,
+            final MeterRegistry meterRegistry
     ) {
         this.properties = properties;
         this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
 
         final SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(Duration.ofSeconds(5));
@@ -49,10 +63,11 @@ public class OpenAiClient {
 
     public List<ExtractedMedicine> extractMedicines(final String maskedOcrText) {
         log.info("OpenAI extractMedicines: textLength={}", maskedOcrText.length());
-        final long startTime = System.currentTimeMillis();
+        final Timer.Sample sample = Timer.start(meterRegistry);
+        final String model = properties.textModel();
 
         try {
-            final String requestBody = buildRequest(properties.textModel(), maskedOcrText);
+            final String requestBody = buildRequest(model, maskedOcrText);
 
             final String responseBody = restClient.post()
                     .uri(API_URL)
@@ -62,16 +77,16 @@ public class OpenAiClient {
                     .retrieve()
                     .body(String.class);
 
-            final long elapsed = System.currentTimeMillis() - startTime;
-            log.info("OpenAI response: elapsed={}ms", elapsed);
-
+            recordUsage(model, OP_EXTRACT, responseBody);
+            recordResult(model, OP_EXTRACT, RESULT_SUCCESS, sample);
             return parseResponse(responseBody);
 
         } catch (final BusinessException e) {
+            recordResult(model, OP_EXTRACT, RESULT_FAILED, sample);
             throw e;
         } catch (final Exception e) {
-            final long elapsed = System.currentTimeMillis() - startTime;
-            log.error("OpenAI failed: elapsed={}ms error={}", elapsed, e.getMessage());
+            recordResult(model, OP_EXTRACT, RESULT_FAILED, sample);
+            log.error("OpenAI failed: error={}", e.getMessage());
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
                     "AI extraction failed: " + e.getMessage());
         }
@@ -83,7 +98,7 @@ public class OpenAiClient {
                     당신은 한국 병원 처방전 OCR 텍스트에서 약물 정보를 추출하는 전문가입니다.
 
                     ## 입력 특성
-                    - OCR로 추출된 텍스트라 오인식·띄어쓰기 깨짐·줄바꿈 누락��� 빈번합니다.
+                    - OCR로 추출된 텍스트라 오인식·띄어쓰기 깨짐·줄바꿈 누락이 빈번합니다.
                     - 처방전은 보통 표(테이블) 형식이지만 OCR이 좌→우, 위→아래로 읽어서
                       약품명 중간에 다른 컬럼(투약량·횟수·일수) 값이 섞여 들어옵니다.
                       예: "타이레놀정500mg 1정 3회 7일 부루펜정200mg 1정 2회 5일"
@@ -241,10 +256,11 @@ public class OpenAiClient {
      */
     public Optional<Integer> countPills(final byte[] imageBytes, final String mediaType) {
         log.info("OpenAI countPills: imageSize={}bytes mediaType={}", imageBytes.length, mediaType);
+        final String model = properties.visionModel();
         for (int attempt = 1; attempt <= 2; attempt++) {
-            final long startTime = System.currentTimeMillis();
+            final Timer.Sample sample = Timer.start(meterRegistry);
             try {
-                final String requestBody = buildCountRequest(properties.visionModel(), imageBytes, mediaType);
+                final String requestBody = buildCountRequest(model, imageBytes, mediaType);
 
                 final String responseBody = restClient.post()
                         .uri(API_URL)
@@ -254,14 +270,15 @@ public class OpenAiClient {
                         .retrieve()
                         .body(String.class);
 
-                final long elapsed = System.currentTimeMillis() - startTime;
-                log.info("OpenAI countPills attempt={} elapsed={}ms", attempt, elapsed);
+                recordUsage(model, OP_COUNT_PILLS, responseBody);
+                log.info("OpenAI countPills attempt={}", attempt);
 
-                return parseCountResponse(responseBody);
+                final Optional<Integer> count = parseCountResponse(responseBody);
+                recordResult(model, OP_COUNT_PILLS, count.isPresent() ? RESULT_SUCCESS : RESULT_EMPTY, sample);
+                return count;
             } catch (final Exception e) {
-                final long elapsed = System.currentTimeMillis() - startTime;
-                log.warn("OpenAI countPills attempt={} failed elapsed={}ms error={}",
-                        attempt, elapsed, e.getMessage());
+                recordResult(model, OP_COUNT_PILLS, RESULT_FAILED, sample);
+                log.warn("OpenAI countPills attempt={} failed error={}", attempt, e.getMessage());
             }
         }
         return Optional.empty();
@@ -314,6 +331,39 @@ public class OpenAiClient {
             log.warn("OpenAI countPills parse failed: {}", e.getMessage());
             return Optional.empty();
         }
+    }
+
+    /**
+     * OpenAI 응답의 `usage` 객체에서 prompt/completion 토큰 수를 추출해 카운터 increment.
+     * 응답에 usage가 없거나 파싱 실패 시 조용히 무시 (메트릭이 본 로직 실패시키지 않음).
+     */
+    private void recordUsage(final String model, final String operation, final String responseBody) {
+        try {
+            final JsonNode usage = objectMapper.readTree(responseBody).path("usage");
+            if (usage.isMissingNode() || usage.isNull()) {
+                return;
+            }
+            final long promptTokens = usage.path("prompt_tokens").asLong(0);
+            final long completionTokens = usage.path("completion_tokens").asLong(0);
+            if (promptTokens > 0) {
+                meterRegistry.counter(METRIC_TOKENS,
+                        "model", model, "operation", operation, "direction", "prompt").increment(promptTokens);
+            }
+            if (completionTokens > 0) {
+                meterRegistry.counter(METRIC_TOKENS,
+                        "model", model, "operation", operation, "direction", "completion").increment(completionTokens);
+            }
+        } catch (final Exception ignored) {
+            // usage 파싱 실패는 본 흐름과 무관 — 조용히 통과
+        }
+    }
+
+    private void recordResult(final String model, final String operation, final String result,
+            final Timer.Sample sample) {
+        meterRegistry.counter(METRIC_REQUEST,
+                "model", model, "operation", operation, "result", result).increment();
+        sample.stop(meterRegistry.timer(METRIC_TIMER,
+                "model", model, "operation", operation, "result", result));
     }
 
     public record ExtractedMedicine(

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoClient.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoClient.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.infrastructure.mfds.MfdsApiProperties;
+import com.ppiyaki.infrastructure.observability.ExternalApiMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -30,10 +32,14 @@ public class DrugInfoClient {
     private static final String API_URL = "https://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList";
     private static final Duration CACHE_TTL = Duration.ofHours(24);
 
+    private static final String API = "drug_info";
+    private static final String OPERATION = "search";
+
     private final String serviceKey;
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final Map<String, CachedDrugInfo> cache = new ConcurrentHashMap<>();
+    private final MeterRegistry meterRegistry;
     private final Counter cacheHitCounter;
     private final Counter cacheMissCounter;
 
@@ -45,6 +51,7 @@ public class DrugInfoClient {
     ) {
         this.serviceKey = properties.serviceKey();
         this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
 
         final SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(Duration.ofSeconds(3));
@@ -72,6 +79,7 @@ public class DrugInfoClient {
 
         cacheMissCounter.increment();
         log.info("DrugInfo API call: itemName={}", itemName);
+        final Timer.Sample sample = Timer.start(meterRegistry);
         try {
             final String url = API_URL
                     + "?serviceKey=" + serviceKey
@@ -86,9 +94,11 @@ public class DrugInfoClient {
 
             final Optional<DrugInfoResponse> result = parseResponse(responseBody);
             cache.put(cacheKey, new CachedDrugInfo(result, Instant.now().plus(CACHE_TTL)));
+            ExternalApiMetrics.record(meterRegistry, API, OPERATION, ExternalApiMetrics.RESULT_SUCCESS, sample);
             return result;
 
         } catch (final Exception e) {
+            ExternalApiMetrics.record(meterRegistry, API, OPERATION, ExternalApiMetrics.RESULT_FAILED, sample);
             log.error("DrugInfo API failed: {}", e.getMessage());
             return Optional.empty();
         }

--- a/src/main/java/com/ppiyaki/infrastructure/messaging/fcm/FcmPushSender.java
+++ b/src/main/java/com/ppiyaki/infrastructure/messaging/fcm/FcmPushSender.java
@@ -5,6 +5,8 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.Notification;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,14 +14,25 @@ public class FcmPushSender implements PushSender {
 
     private static final Logger log = LoggerFactory.getLogger(FcmPushSender.class);
 
-    private final FirebaseMessaging firebaseMessaging;
+    private static final String METRIC_SENT = "ppiyaki.push.sent.total";
+    private static final String METRIC_TIMER = "ppiyaki.push.send.seconds";
+    private static final String RESULT_SUCCESS = "success";
+    private static final String RESULT_TOKEN_INVALID = "token_invalid";
+    private static final String RESULT_FAILED = "failed";
+    private static final String CATEGORY_UNKNOWN = "unknown";
 
-    public FcmPushSender(final FirebaseMessaging firebaseMessaging) {
+    private final FirebaseMessaging firebaseMessaging;
+    private final MeterRegistry meterRegistry;
+
+    public FcmPushSender(final FirebaseMessaging firebaseMessaging, final MeterRegistry meterRegistry) {
         this.firebaseMessaging = firebaseMessaging;
+        this.meterRegistry = meterRegistry;
     }
 
     @Override
     public PushSendResult send(final String deviceToken, final PushPayload payload) {
+        final String category = extractCategory(payload);
+        final Timer.Sample sample = Timer.start(meterRegistry);
         final Message.Builder builder = Message.builder()
                 .setToken(deviceToken)
                 .setNotification(Notification.builder()
@@ -32,15 +45,30 @@ public class FcmPushSender implements PushSender {
         try {
             final String messageId = firebaseMessaging.send(builder.build());
             log.info("FCM sent (messageId={}, title={})", messageId, payload.title());
+            record(category, RESULT_SUCCESS, sample);
             return PushSendResult.ok();
         } catch (final FirebaseMessagingException exception) {
             final MessagingErrorCode errorCode = exception.getMessagingErrorCode();
             if (errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
                 log.warn("FCM token invalid (errorCode={}, token={})", errorCode, deviceToken);
+                record(category, RESULT_TOKEN_INVALID, sample);
                 return PushSendResult.tokenInvalid(exception.getMessage());
             }
             log.error("FCM send failed (errorCode={}, token={})", errorCode, deviceToken, exception);
+            record(category, RESULT_FAILED, sample);
             return PushSendResult.failed(exception.getMessage());
         }
+    }
+
+    private void record(final String category, final String result, final Timer.Sample sample) {
+        meterRegistry.counter(METRIC_SENT, "category", category, "result", result).increment();
+        sample.stop(meterRegistry.timer(METRIC_TIMER, "category", category, "result", result));
+    }
+
+    private String extractCategory(final PushPayload payload) {
+        if (payload.data() == null) {
+            return CATEGORY_UNKNOWN;
+        }
+        return payload.data().getOrDefault("category", CATEGORY_UNKNOWN);
     }
 }

--- a/src/main/java/com/ppiyaki/infrastructure/messaging/fcm/PushConfig.java
+++ b/src/main/java/com/ppiyaki/infrastructure/messaging/fcm/PushConfig.java
@@ -4,6 +4,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -20,7 +21,7 @@ public class PushConfig {
     private static final Logger log = LoggerFactory.getLogger(PushConfig.class);
 
     @Bean
-    public PushSender pushSender(final FcmProperties properties) {
+    public PushSender pushSender(final FcmProperties properties, final MeterRegistry meterRegistry) {
         if (!properties.isEnabled()) {
             log.warn("FCM disabled — fcm.project-id or fcm.credentials-json-base64 missing. Push will be no-op.");
             return new NoOpPushSender();
@@ -37,7 +38,7 @@ public class PushConfig {
             final FirebaseApp app = FirebaseApp.getApps().isEmpty()
                     ? FirebaseApp.initializeApp(options)
                     : FirebaseApp.getInstance();
-            return new FcmPushSender(FirebaseMessaging.getInstance(app));
+            return new FcmPushSender(FirebaseMessaging.getInstance(app), meterRegistry);
         } catch (final Exception exception) {
             log.error("FCM initialization failed — fallback to no-op push sender", exception);
             return new NoOpPushSender();

--- a/src/main/java/com/ppiyaki/infrastructure/mfds/MfdsApiClient.java
+++ b/src/main/java/com/ppiyaki/infrastructure/mfds/MfdsApiClient.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.infrastructure.observability.ExternalApiMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -30,10 +32,13 @@ public class MfdsApiClient {
     private static final Logger log = LoggerFactory.getLogger(MfdsApiClient.class);
     private static final String RESULT_CODE_SUCCESS = "00";
 
+    private static final String API = "mfds";
+
     private final MfdsApiProperties properties;
     private final MfdsResponseCache cache;
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
     private final Counter cacheHitCounter;
     private final Counter cacheMissCounter;
 
@@ -47,6 +52,7 @@ public class MfdsApiClient {
         this.properties = properties;
         this.cache = cache;
         this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
 
         final SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(Duration.ofMillis(properties.connectTimeout()));
@@ -80,7 +86,7 @@ public class MfdsApiClient {
 
         cacheMissCounter.increment();
         log.info("MFDS API call: operation={} key={}", operation, cacheKey);
-        final long startTime = System.currentTimeMillis();
+        final Timer.Sample sample = Timer.start(meterRegistry);
 
         try {
             final StringBuilder urlBuilder = new StringBuilder()
@@ -99,19 +105,20 @@ public class MfdsApiClient {
                     .retrieve()
                     .body(String.class);
 
-            final long elapsed = System.currentTimeMillis() - startTime;
-            log.info("MFDS API response: operation={} key={} elapsed={}ms", operation, cacheKey, elapsed);
+            log.info("MFDS API response: operation={} key={}", operation, cacheKey);
 
             final CachedMfdsResponse response = parseResponse(operation, cacheKey, responseBody);
             cache.put(operation, cacheKey, response);
+            ExternalApiMetrics.record(meterRegistry, API, operation, ExternalApiMetrics.RESULT_SUCCESS, sample);
             return response;
 
         } catch (final BusinessException e) {
+            ExternalApiMetrics.record(meterRegistry, API, operation, ExternalApiMetrics.RESULT_FAILED, sample);
             throw e;
         } catch (final Exception e) {
-            final long elapsed = System.currentTimeMillis() - startTime;
-            log.error("MFDS API failed: operation={} key={} elapsed={}ms error={}",
-                    operation, cacheKey, elapsed, e.getMessage());
+            ExternalApiMetrics.record(meterRegistry, API, operation, ExternalApiMetrics.RESULT_FAILED, sample);
+            log.error("MFDS API failed: operation={} key={} error={}",
+                    operation, cacheKey, e.getMessage());
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
                     "MFDS API call failed: " + e.getMessage());
         }

--- a/src/main/java/com/ppiyaki/infrastructure/observability/ExternalApiMetrics.java
+++ b/src/main/java/com/ppiyaki/infrastructure/observability/ExternalApiMetrics.java
@@ -1,0 +1,32 @@
+package com.ppiyaki.infrastructure.observability;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * 외부 API 호출(MFDS, DUR, DrugInfo, Clova OCR 등) 메트릭 기록 헬퍼.
+ * 카운터 + 타이머를 한 호출로 묶어 라벨 일관성 강제.
+ */
+public final class ExternalApiMetrics {
+
+    public static final String COUNTER_NAME = "ppiyaki.external.api.total";
+    public static final String TIMER_NAME = "ppiyaki.external.api.seconds";
+    public static final String RESULT_SUCCESS = "success";
+    public static final String RESULT_FAILED = "failed";
+
+    private ExternalApiMetrics() {
+    }
+
+    public static void record(
+            final MeterRegistry registry,
+            final String api,
+            final String operation,
+            final String result,
+            final Timer.Sample sample
+    ) {
+        registry.counter(COUNTER_NAME,
+                "api", api, "operation", operation, "result", result).increment();
+        sample.stop(registry.timer(TIMER_NAME,
+                "api", api, "operation", operation, "result", result));
+    }
+}

--- a/src/main/java/com/ppiyaki/infrastructure/ocr/ClovaOcrClient.java
+++ b/src/main/java/com/ppiyaki/infrastructure/ocr/ClovaOcrClient.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.infrastructure.observability.ExternalApiMetrics;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -22,18 +25,23 @@ import org.springframework.web.client.RestClient;
 public class ClovaOcrClient {
 
     private static final Logger log = LoggerFactory.getLogger(ClovaOcrClient.class);
+    private static final String API = "clova";
+    private static final String OPERATION = "ocr";
 
     private final ClovaOcrProperties properties;
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
 
     public ClovaOcrClient(
             final ClovaOcrProperties properties,
             final RestClient.Builder restClientBuilder,
-            final ObjectMapper objectMapper
+            final ObjectMapper objectMapper,
+            final MeterRegistry meterRegistry
     ) {
         this.properties = properties;
         this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
 
         final SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(Duration.ofSeconds(2));
@@ -44,7 +52,7 @@ public class ClovaOcrClient {
 
     public OcrResult ocr(final byte[] imageBytes, final String imageFormat) {
         log.info("Clova OCR call: format={} size={}bytes", imageFormat, imageBytes.length);
-        final long startTime = System.currentTimeMillis();
+        final Timer.Sample sample = Timer.start(meterRegistry);
 
         try {
             final String base64Image = Base64.getEncoder().encodeToString(imageBytes);
@@ -59,16 +67,16 @@ public class ClovaOcrClient {
                     .body(byte[].class);
             final String responseBody = new String(responseBytes, java.nio.charset.StandardCharsets.UTF_8);
 
-            final long elapsed = System.currentTimeMillis() - startTime;
-            log.info("Clova OCR response: elapsed={}ms", elapsed);
-
-            return parseResponse(responseBody);
+            final OcrResult result = parseResponse(responseBody);
+            ExternalApiMetrics.record(meterRegistry, API, OPERATION, ExternalApiMetrics.RESULT_SUCCESS, sample);
+            return result;
 
         } catch (final BusinessException e) {
+            ExternalApiMetrics.record(meterRegistry, API, OPERATION, ExternalApiMetrics.RESULT_FAILED, sample);
             throw e;
         } catch (final Exception e) {
-            final long elapsed = System.currentTimeMillis() - startTime;
-            log.error("Clova OCR failed: elapsed={}ms error={}", elapsed, e.getMessage());
+            ExternalApiMetrics.record(meterRegistry, API, OPERATION, ExternalApiMetrics.RESULT_FAILED, sample);
+            log.error("Clova OCR failed: error={}", e.getMessage());
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
                     "OCR failed: " + e.getMessage());
         }

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -18,6 +18,7 @@ import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -58,6 +59,7 @@ public class MedicationLogService {
     private final S3Client s3Client;
     private final ApplicationEventPublisher eventPublisher;
     private final com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
+    private final MeterRegistry meterRegistry;
 
     public MedicationLogService(
             final MedicationLogRepository medicationLogRepository,
@@ -69,7 +71,8 @@ public class MedicationLogService {
             final NcpStorageProperties storageProperties,
             final S3Client s3Client,
             final ApplicationEventPublisher eventPublisher,
-            final com.ppiyaki.notification.repository.NotificationRepository notificationRepository
+            final com.ppiyaki.notification.repository.NotificationRepository notificationRepository,
+            final MeterRegistry meterRegistry
     ) {
         this.medicationLogRepository = medicationLogRepository;
         this.medicationScheduleRepository = medicationScheduleRepository;
@@ -81,6 +84,7 @@ public class MedicationLogService {
         this.s3Client = s3Client;
         this.eventPublisher = eventPublisher;
         this.notificationRepository = notificationRepository;
+        this.meterRegistry = meterRegistry;
     }
 
     @Transactional
@@ -148,6 +152,8 @@ public class MedicationLogService {
                 && request.photoObjectKey() != null && !request.photoObjectKey().isBlank()) {
             final LogPillCountStatus pillCountStatus = verifyPillCount(seniorId, schedule, request);
             log.updatePillCountStatus(pillCountStatus);
+            meterRegistry.counter("ppiyaki.medication.pill_count.total",
+                    "result", pillCountStatus.name()).increment();
             // COUNT_MATCH일 때 슬롯의 다른 active schedule도 TAKEN 전파 (issue #343).
             // 시니어가 슬롯 전체 약을 사진 한 장에 담아 인증한 경우 == 슬롯 전체 인증으로 인정.
             if (pillCountStatus == LogPillCountStatus.COUNT_MATCH) {
@@ -155,7 +161,23 @@ public class MedicationLogService {
             }
         }
 
+        final String transition = resolveTransition(request.status(), previousStatus);
+        meterRegistry.counter("ppiyaki.medication.log.upsert.total",
+                "status", request.status().name(),
+                "transition", transition,
+                "is_proxy", String.valueOf(isProxy)).increment();
+
         return MedicationLogResponse.from(log, photoUrlAssembler.toFullUrl(log.getPhotoObjectKey()));
+    }
+
+    private static String resolveTransition(final LogStatus current, final LogStatus previous) {
+        if (current == LogStatus.TAKEN && previous != LogStatus.TAKEN) {
+            return "new_taken";
+        }
+        if (current == LogStatus.TAKEN && previous == LogStatus.TAKEN) {
+            return "repeat";
+        }
+        return "other";
     }
 
     /**

--- a/src/main/java/com/ppiyaki/notification/service/FamilySafetyDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/FamilySafetyDispatcher.java
@@ -65,9 +65,6 @@ public class FamilySafetyDispatcher {
         for (final User senior : userRepository.findAllByRoleWithMealTimesSet(UserRole.SENIOR)) {
             dispatched += dispatchForSenior(senior, now, today);
         }
-        if (dispatched > 0) {
-            log.info("FamilySafetyDispatcher dispatched {} alerts", dispatched);
-        }
         return dispatched;
     }
 

--- a/src/main/java/com/ppiyaki/notification/service/FamilySafetyScheduler.java
+++ b/src/main/java/com/ppiyaki/notification/service/FamilySafetyScheduler.java
@@ -1,10 +1,14 @@
 package com.ppiyaki.notification.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 public class FamilySafetyScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(FamilySafetyScheduler.class);
 
     private final FamilySafetyDispatcher dispatcher;
 
@@ -14,6 +18,13 @@ public class FamilySafetyScheduler {
 
     @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
     public void runHourly() {
-        dispatcher.run();
+        final long start = System.currentTimeMillis();
+        final int dispatched = dispatcher.run();
+        final long elapsed = System.currentTimeMillis() - start;
+        if (dispatched > 0) {
+            log.info("FamilySafetyScheduler dispatched count={} elapsed={}ms", dispatched, elapsed);
+        } else {
+            log.debug("FamilySafetyScheduler tick count=0 elapsed={}ms", elapsed);
+        }
     }
 }

--- a/src/main/java/com/ppiyaki/notification/service/MedicationDelayScheduler.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationDelayScheduler.java
@@ -23,13 +23,17 @@ public class MedicationDelayScheduler {
 
     @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void dispatchDue() {
+        final long start = System.currentTimeMillis();
         final LocalDate today = LocalDate.now(clock);
         int total = 0;
         for (final User senior : dispatcher.findAllSeniorsWithMealTimes()) {
             total += dispatcher.dispatchForSenior(senior, today);
         }
+        final long elapsed = System.currentTimeMillis() - start;
         if (total > 0) {
-            log.info("MedicationDelayScheduler dispatched {} delay alerts at {}", total, today);
+            log.info("MedicationDelayScheduler dispatched count={} elapsed={}ms (date={})", total, elapsed, today);
+        } else {
+            log.debug("MedicationDelayScheduler tick count=0 elapsed={}ms", elapsed);
         }
     }
 }

--- a/src/main/java/com/ppiyaki/notification/service/MedicationReminderScheduler.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationReminderScheduler.java
@@ -34,10 +34,16 @@ public class MedicationReminderScheduler {
 
     @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void dispatchDue() {
+        final long start = System.currentTimeMillis();
         final LocalDate today = LocalDate.now(clock);
         final LocalTime now = LocalTime.now(clock).withSecond(0).withNano(0);
-        log.info("MedicationReminderScheduler tick at {}", now);
-        run(today, now);
+        final int dispatched = run(today, now);
+        final long elapsed = System.currentTimeMillis() - start;
+        if (dispatched > 0) {
+            log.info("MedicationReminderScheduler dispatched count={} elapsed={}ms", dispatched, elapsed);
+        } else {
+            log.debug("MedicationReminderScheduler tick count=0 elapsed={}ms", elapsed);
+        }
     }
 
     public int run(final LocalDate today, final LocalTime currentMinute) {

--- a/src/main/java/com/ppiyaki/pet/service/BadgeService.java
+++ b/src/main/java/com/ppiyaki/pet/service/BadgeService.java
@@ -4,6 +4,7 @@ import com.ppiyaki.pet.Badge;
 import com.ppiyaki.pet.BadgeType;
 import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.BadgeRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -15,11 +16,14 @@ public class BadgeService {
 
     private static final Logger log = LoggerFactory.getLogger(BadgeService.class);
     private static final int HEALTH_GUARDIAN_STREAK = 30;
+    private static final String METRIC = "ppiyaki.badge.awarded.total";
 
     private final BadgeRepository badgeRepository;
+    private final MeterRegistry meterRegistry;
 
-    public BadgeService(final BadgeRepository badgeRepository) {
+    public BadgeService(final BadgeRepository badgeRepository, final MeterRegistry meterRegistry) {
         this.badgeRepository = badgeRepository;
+        this.meterRegistry = meterRegistry;
     }
 
     @Transactional
@@ -44,6 +48,7 @@ public class BadgeService {
         try {
             badgeRepository.save(new Badge(petId, badgeType));
             badgeRepository.flush();
+            meterRegistry.counter(METRIC, "badge_type", badgeType.name()).increment();
         } catch (final DataIntegrityViolationException e) {
             log.debug("Badge already exists: petId={}, type={}", petId, badgeType);
         }

--- a/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
+++ b/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
@@ -9,6 +9,7 @@ import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.UserRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.LocalDate;
 import java.util.List;
 import org.slf4j.Logger;
@@ -24,12 +25,14 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class PetPointListener {
 
     private static final Logger log = LoggerFactory.getLogger(PetPointListener.class);
+    private static final String METRIC = "ppiyaki.pet.point.event.total";
 
     private final UserRepository userRepository;
     private final PetRepository petRepository;
     private final MedicationScheduleRepository medicationScheduleRepository;
     private final MedicationLogRepository medicationLogRepository;
     private final BadgeService badgeService;
+    private final MeterRegistry meterRegistry;
     private final long pointPerTaken;
 
     public PetPointListener(
@@ -38,6 +41,7 @@ public class PetPointListener {
             final MedicationScheduleRepository medicationScheduleRepository,
             final MedicationLogRepository medicationLogRepository,
             final BadgeService badgeService,
+            final MeterRegistry meterRegistry,
             @Value("${pet.points.per-taken:10}") final long pointPerTaken
     ) {
         this.userRepository = userRepository;
@@ -45,6 +49,7 @@ public class PetPointListener {
         this.medicationScheduleRepository = medicationScheduleRepository;
         this.medicationLogRepository = medicationLogRepository;
         this.badgeService = badgeService;
+        this.meterRegistry = meterRegistry;
         this.pointPerTaken = pointPerTaken;
     }
 
@@ -54,12 +59,14 @@ public class PetPointListener {
         final User user = userRepository.findById(event.seniorId()).orElse(null);
         if (user == null || user.getPetId() == null) {
             log.debug("Pet not linked for seniorId={}, skipping point", event.seniorId());
+            meterRegistry.counter(METRIC, "result", "skipped_no_pet_link").increment();
             return;
         }
 
         final Pet pet = petRepository.findById(user.getPetId()).orElse(null);
         if (pet == null) {
             log.debug("Pet entity not found for petId={}, skipping point", user.getPetId());
+            meterRegistry.counter(METRIC, "result", "skipped_pet_not_found").increment();
             return;
         }
 
@@ -71,6 +78,7 @@ public class PetPointListener {
         }
 
         badgeService.checkAndAwardBadges(pet);
+        meterRegistry.counter(METRIC, "result", "granted").increment();
     }
 
     private boolean isDayFullyTaken(final Long seniorId, final LocalDate date) {

--- a/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
+++ b/src/main/java/com/ppiyaki/prescription/service/PrescriptionService.java
@@ -79,6 +79,7 @@ public class PrescriptionService {
     private final NcpStorageProperties storageProperties;
     private final S3Client s3Client;
     private final PhotoUrlAssembler photoUrlAssembler;
+    private final io.micrometer.core.instrument.MeterRegistry meterRegistry;
 
     public PrescriptionService(
             final PrescriptionRepository prescriptionRepository,
@@ -94,7 +95,8 @@ public class PrescriptionService {
             final ImageOrientationCorrector orientationCorrector,
             final NcpStorageProperties storageProperties,
             final S3Client s3Client,
-            final PhotoUrlAssembler photoUrlAssembler
+            final PhotoUrlAssembler photoUrlAssembler,
+            final io.micrometer.core.instrument.MeterRegistry meterRegistry
     ) {
         this.prescriptionRepository = prescriptionRepository;
         this.candidateRepository = candidateRepository;
@@ -110,6 +112,7 @@ public class PrescriptionService {
         this.storageProperties = storageProperties;
         this.s3Client = s3Client;
         this.photoUrlAssembler = photoUrlAssembler;
+        this.meterRegistry = meterRegistry;
     }
 
     @Transactional
@@ -347,6 +350,7 @@ public class PrescriptionService {
         }
 
         prescription.confirm();
+        meterRegistry.counter("ppiyaki.prescription.confirm.total", "result", "success").increment();
         return PrescriptionDetailResponse.from(prescription, candidates, photoUrlAssembler.toFullUrl(prescription
                 .getMaskedImageObjectKey()));
     }

--- a/src/main/java/com/ppiyaki/user/service/AuthService.java
+++ b/src/main/java/com/ppiyaki/user/service/AuthService.java
@@ -20,6 +20,7 @@ import com.ppiyaki.user.domain.UserRole;
 import com.ppiyaki.user.repository.OAuthIdentityRepository;
 import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.LocalDateTime;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,6 +30,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
+    private static final String METRIC_ATTEMPTS = "ppiyaki.auth.attempts.total";
+    private static final String TYPE_KAKAO = "kakao";
+    private static final String TYPE_LOCAL = "local";
+    private static final String ACTION_LOGIN = "login";
+    private static final String ACTION_SIGNUP = "signup";
+    private static final String ACTION_REFRESH = "refresh";
+    private static final String ACTION_LOGOUT = "logout";
+
     private final KakaoIdTokenVerifier kakaoIdTokenVerifier;
     private final JwtProvider jwtProvider;
     private final JwtProperties jwtProperties;
@@ -36,6 +45,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final OAuthIdentityRepository oAuthIdentityRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final MeterRegistry meterRegistry;
 
     public AuthService(
             final KakaoIdTokenVerifier kakaoIdTokenVerifier,
@@ -44,7 +54,8 @@ public class AuthService {
             final PasswordEncoder passwordEncoder,
             final UserRepository userRepository,
             final OAuthIdentityRepository oAuthIdentityRepository,
-            final RefreshTokenRepository refreshTokenRepository
+            final RefreshTokenRepository refreshTokenRepository,
+            final MeterRegistry meterRegistry
     ) {
         this.kakaoIdTokenVerifier = kakaoIdTokenVerifier;
         this.jwtProvider = jwtProvider;
@@ -53,82 +64,110 @@ public class AuthService {
         this.userRepository = userRepository;
         this.oAuthIdentityRepository = oAuthIdentityRepository;
         this.refreshTokenRepository = refreshTokenRepository;
+        this.meterRegistry = meterRegistry;
     }
 
     @Transactional
     public LoginResponse loginWithKakao(final KakaoLoginRequest kakaoLoginRequest) {
-        final KakaoIdTokenPayload payload = kakaoIdTokenVerifier.verify(kakaoLoginRequest.idToken());
+        try {
+            final KakaoIdTokenPayload payload = kakaoIdTokenVerifier.verify(kakaoLoginRequest.idToken());
 
-        final String providerUserId = payload.sub();
-        final User user = oAuthIdentityRepository
-                .findByProviderAndProviderUserId(OAuthProvider.KAKAO, providerUserId)
-                .map(identity -> userRepository.findById(identity.getUserId())
-                        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND)))
-                .orElseGet(() -> createNewUser(payload, providerUserId));
+            final String providerUserId = payload.sub();
+            final User user = oAuthIdentityRepository
+                    .findByProviderAndProviderUserId(OAuthProvider.KAKAO, providerUserId)
+                    .map(identity -> userRepository.findById(identity.getUserId())
+                            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND)))
+                    .orElseGet(() -> createNewUser(payload, providerUserId));
 
-        if (user.isDeleted()) {
-            throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
+            if (user.isDeleted()) {
+                throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
+            }
+
+            final String roleName = user.getRole() != null ? user.getRole().name() : null;
+            final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
+            final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
+            saveRefreshToken(user.getId(), refreshTokenValue);
+
+            final boolean isOnboarded = user.getNickname() != null;
+
+            recordAttempt(TYPE_KAKAO, ACTION_LOGIN, "success");
+            return new LoginResponse(accessToken, refreshTokenValue, isOnboarded);
+        } catch (final BusinessException e) {
+            recordAttempt(TYPE_KAKAO, ACTION_LOGIN, mapResult(e));
+            throw e;
+        } catch (final RuntimeException e) {
+            recordAttempt(TYPE_KAKAO, ACTION_LOGIN, "failed");
+            throw e;
         }
-
-        final String roleName = user.getRole() != null ? user.getRole().name() : null;
-        final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
-        final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
-        saveRefreshToken(user.getId(), refreshTokenValue);
-
-        final boolean isOnboarded = user.getNickname() != null;
-
-        return new LoginResponse(accessToken, refreshTokenValue, isOnboarded);
     }
 
     @Transactional
     public LoginResponse signup(final SignupRequest signupRequest) {
-        if (userRepository.existsByLoginId(signupRequest.loginId())) {
-            throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
-        }
-
-        final String encodedPassword = passwordEncoder.encode(signupRequest.password());
-        final User user;
         try {
-            user = userRepository.save(
-                    new User(signupRequest.loginId(), encodedPassword, UserRole.CAREGIVER,
-                            AuthProvider.LOCAL, signupRequest.nickname(), null, null, null));
-        } catch (final DataIntegrityViolationException e) {
-            throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
+            if (userRepository.existsByLoginId(signupRequest.loginId())) {
+                throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
+            }
+
+            final String encodedPassword = passwordEncoder.encode(signupRequest.password());
+            final User user;
+            try {
+                user = userRepository.save(
+                        new User(signupRequest.loginId(), encodedPassword, UserRole.CAREGIVER,
+                                AuthProvider.LOCAL, signupRequest.nickname(), null, null, null));
+            } catch (final DataIntegrityViolationException e) {
+                throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
+            }
+
+            final String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());
+            final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
+            saveRefreshToken(user.getId(), refreshTokenValue);
+
+            recordAttempt(TYPE_LOCAL, ACTION_SIGNUP, "success");
+            return new LoginResponse(accessToken, refreshTokenValue, true);
+        } catch (final BusinessException e) {
+            recordAttempt(TYPE_LOCAL, ACTION_SIGNUP, mapResult(e));
+            throw e;
+        } catch (final RuntimeException e) {
+            recordAttempt(TYPE_LOCAL, ACTION_SIGNUP, "failed");
+            throw e;
         }
-
-        final String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());
-        final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
-        saveRefreshToken(user.getId(), refreshTokenValue);
-
-        return new LoginResponse(accessToken, refreshTokenValue, true);
     }
 
     @Transactional
     public LoginResponse login(final LoginRequest loginRequest) {
-        final User user = userRepository.findByLoginId(loginRequest.loginId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS));
+        try {
+            final User user = userRepository.findByLoginId(loginRequest.loginId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS));
 
-        if (user.getAuthProvider() != AuthProvider.LOCAL) {
-            throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+            if (user.getAuthProvider() != AuthProvider.LOCAL) {
+                throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+            }
+
+            if (user.getPassword() == null
+                    || !passwordEncoder.matches(loginRequest.password(), user.getPassword())) {
+                throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+            }
+
+            if (user.isDeleted()) {
+                throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
+            }
+
+            final String roleName = user.getRole() != null ? user.getRole().name() : null;
+            final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
+            final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
+            saveRefreshToken(user.getId(), refreshTokenValue);
+
+            final boolean isOnboarded = user.getRole() != null;
+
+            recordAttempt(TYPE_LOCAL, ACTION_LOGIN, "success");
+            return new LoginResponse(accessToken, refreshTokenValue, isOnboarded);
+        } catch (final BusinessException e) {
+            recordAttempt(TYPE_LOCAL, ACTION_LOGIN, mapResult(e));
+            throw e;
+        } catch (final RuntimeException e) {
+            recordAttempt(TYPE_LOCAL, ACTION_LOGIN, "failed");
+            throw e;
         }
-
-        if (user.getPassword() == null
-                || !passwordEncoder.matches(loginRequest.password(), user.getPassword())) {
-            throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
-        }
-
-        if (user.isDeleted()) {
-            throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
-        }
-
-        final String roleName = user.getRole() != null ? user.getRole().name() : null;
-        final String accessToken = jwtProvider.createAccessToken(user.getId(), roleName);
-        final String refreshTokenValue = jwtProvider.createRefreshToken(user.getId());
-        saveRefreshToken(user.getId(), refreshTokenValue);
-
-        final boolean isOnboarded = user.getRole() != null;
-
-        return new LoginResponse(accessToken, refreshTokenValue, isOnboarded);
     }
 
     private User createNewUser(final KakaoIdTokenPayload payload, final String providerUserId) {
@@ -143,30 +182,57 @@ public class AuthService {
 
     @Transactional
     public TokenResponse refresh(final String refreshTokenValue) {
-        final RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
-                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
+        try {
+            final RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
 
-        if (refreshToken.isExpired()) {
-            refreshTokenRepository.delete(refreshToken);
-            throw new BusinessException(ErrorCode.AUTH_TOKEN_EXPIRED);
+            if (refreshToken.isExpired()) {
+                refreshTokenRepository.delete(refreshToken);
+                throw new BusinessException(ErrorCode.AUTH_TOKEN_EXPIRED);
+            }
+
+            final Long userId = refreshToken.getUserId();
+            final User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+            final String newAccessToken = jwtProvider.createAccessToken(userId, user.getRole().name());
+            final String newRefreshTokenValue = jwtProvider.createRefreshToken(userId);
+
+            final LocalDateTime newExpiresAt = LocalDateTime.now().plusSeconds(jwtProperties.refreshTokenExpiry()
+                    / 1000);
+            refreshToken.rotate(newRefreshTokenValue, newExpiresAt);
+
+            recordAttempt("unknown", ACTION_REFRESH, "success");
+            return new TokenResponse(newAccessToken, newRefreshTokenValue);
+        } catch (final BusinessException e) {
+            recordAttempt("unknown", ACTION_REFRESH, mapResult(e));
+            throw e;
+        } catch (final RuntimeException e) {
+            recordAttempt("unknown", ACTION_REFRESH, "failed");
+            throw e;
         }
-
-        final Long userId = refreshToken.getUserId();
-        final User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        final String newAccessToken = jwtProvider.createAccessToken(userId, user.getRole().name());
-        final String newRefreshTokenValue = jwtProvider.createRefreshToken(userId);
-
-        final LocalDateTime newExpiresAt = LocalDateTime.now().plusSeconds(jwtProperties.refreshTokenExpiry() / 1000);
-        refreshToken.rotate(newRefreshTokenValue, newExpiresAt);
-
-        return new TokenResponse(newAccessToken, newRefreshTokenValue);
     }
 
     @Transactional
     public void logout(final String refreshTokenValue) {
         refreshTokenRepository.findByToken(refreshTokenValue)
                 .ifPresent(refreshTokenRepository::delete);
+        recordAttempt("unknown", ACTION_LOGOUT, "success");
+    }
+
+    private void recordAttempt(final String type, final String action, final String result) {
+        meterRegistry.counter(METRIC_ATTEMPTS,
+                "type", type, "action", action, "result", result).increment();
+    }
+
+    private static String mapResult(final BusinessException exception) {
+        return switch (exception.getErrorCode()) {
+            case AUTH_DUPLICATE_LOGIN_ID -> "duplicate_id";
+            case AUTH_INVALID_CREDENTIALS -> "invalid_credentials";
+            case AUTH_INVALID_TOKEN -> "invalid_token";
+            case AUTH_TOKEN_EXPIRED -> "token_expired";
+            case USER_ALREADY_DELETED -> "user_deleted";
+            default -> "failed";
+        };
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,3 +85,4 @@ management:
     distribution:
       percentiles-histogram:
         http.server.requests: true
+        ppiyaki.push.send: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,3 +86,4 @@ management:
       percentiles-histogram:
         http.server.requests: true
         ppiyaki.push.send: true
+        ppiyaki.llm.request: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,3 +87,4 @@ management:
         http.server.requests: true
         ppiyaki.push.send: true
         ppiyaki.llm.request: true
+        ppiyaki.external.api: true

--- a/src/test/java/com/ppiyaki/chat/SttServiceTest.java
+++ b/src/test/java/com/ppiyaki/chat/SttServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.ppiyaki.chat.service.SttService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ class SttServiceTest {
     @BeforeEach
     void setUp() {
         transcriptionModel = mock(OpenAiAudioTranscriptionModel.class);
-        sttService = new SttService(transcriptionModel);
+        sttService = new SttService(transcriptionModel, new SimpleMeterRegistry());
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/chat/TtsServiceTest.java
+++ b/src/test/java/com/ppiyaki/chat/TtsServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.ppiyaki.chat.service.TtsService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,7 @@ class TtsServiceTest {
     @BeforeEach
     void setUp() {
         speechModel = mock(OpenAiAudioSpeechModel.class);
-        ttsService = new TtsService(speechModel);
+        ttsService = new TtsService(speechModel, new SimpleMeterRegistry());
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -21,6 +21,8 @@ import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.util.List;
@@ -31,6 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import software.amazon.awssdk.core.ResponseBytes;
@@ -62,6 +65,8 @@ class MedicationLogServicePhase2Test {
     private ApplicationEventPublisher eventPublisher;
     @Mock
     private com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
+    @Spy
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @InjectMocks
     private MedicationLogService service;

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -53,6 +53,8 @@ class MedicationLogServiceTest {
     private ApplicationEventPublisher eventPublisher;
     @Mock
     private com.ppiyaki.notification.repository.NotificationRepository notificationRepository;
+    @org.mockito.Spy
+    private io.micrometer.core.instrument.MeterRegistry meterRegistry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
 
     @InjectMocks
     private MedicationLogService medicationLogService;

--- a/src/test/java/com/ppiyaki/pet/service/PetPointListenerTest.java
+++ b/src/test/java/com/ppiyaki/pet/service/PetPointListenerTest.java
@@ -15,6 +15,7 @@ import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.UserRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +49,7 @@ class PetPointListenerTest {
     void setUp() {
         petPointListener = new PetPointListener(
                 userRepository, petRepository, medicationScheduleRepository,
-                medicationLogRepository, badgeService, 10L);
+                medicationLogRepository, badgeService, new SimpleMeterRegistry(), 10L);
     }
 
     @Test


### PR DESCRIPTION
## Release v0.13.4 — 비즈니스 메트릭 / 모니터링 인프라 보강

PR #372 (Prometheus 스택) 이후 모니터링 체계 전면 확장.

### 변경 요약 (8개 PR)

**Infrastructure**
- **#375** `chore(infra)`: `.env.example` 동기화 (MANAGEMENT_PORT, GRAFANA_ADMIN_*)
- **#377** `feat(infra)`: Grafana 대시보드 provisioning — `ppiyaki-overview` 14패널
- **#379** `feat(infra)`: Loki + Grafana Alloy 로그 수집 스택 도입

**Metrics (비즈니스 SLO 신호)**
- **#381** `feat(infra)`: FCM push 메트릭 + Scheduler 집계 로그 통일
  - `ppiyaki_push_sent_total{category, result}` + p95 timer
- **#383** `feat(infra)`: LLM 토큰/지연 메트릭 — OpenAI / STT / TTS
  - `ppiyaki_llm_tokens_total{model, operation, direction}` + request timer
- **#385** `feat(user)`: 인증 메트릭 — 로그인/가입/토큰갱신 결과별 카운터
  - `ppiyaki_auth_attempts_total{type, action, result}`
- **#387** `feat(medication)`: 도메인 비즈니스 카운터 — 복약 인증 + 펫 포인트
  - `ppiyaki_medication_log_upsert_total`, `ppiyaki_medication_pill_count_total`, `ppiyaki_pet_point_event_total`
- **#389** `feat(infra)`: 외부 API 통합 메트릭 + 처방전·뱃지 카운터
  - `ppiyaki_external_api_total/seconds{api, operation, result}`, `ppiyaki_prescription_confirm_total`, `ppiyaki_badge_awarded_total`

### Grafana 대시보드 (현재 `ppiyaki-overview`)
8개 row, ~40 패널. 메트릭 + Loki 로그 한 화면. 카테고리:
- Stat 상단(System CPU, Process CPU, JVM Heap, HTTP Active, Hikari Active, Cache Hit Ratio)
- HTTP / DB(Hikari) / JVM / 외부 API 캐시 / 애플리케이션 로그(Loki) / 로그 메트릭+Tomcat / 알림 발송(FCM Push) / LLM / 인증 / 복약+펫 / 외부 API+처방전+뱃지

### 인프라 변화
- prod NCP 서버에 4개 컨테이너 추가: Prometheus, Loki, Alloy, Grafana
- 디스크 사용량 (현재): Prometheus 15MB/15h, Loki 290KB/0.5h → 30일/14일 예상 ~ 1GB 미만
- application.yml: `ppiyaki.push.send`, `ppiyaki.llm.request`, `ppiyaki.external.api` percentiles-histogram 활성

### Prod 배포 절차
1. 본 PR **Merge commit** 머지 (Squash 아님).
2. CD 파이프라인 자동 트리거 → 백엔드 컨테이너 재배포.
3. 메트릭 데이터가 Prometheus에 새로 흐름 시작 (~수 분).
4. Grafana 대시보드의 "No data" 패널들이 실 데이터로 채워짐.

### Changelog 그룹
- **feat**: 7개 (모니터링 메트릭/로그 스택)
- **chore**: 1개 (.env.example sync)