### PR TITLE
feat(user): 시니어 식사시간을 연결된 보호자도 수정 가능하게 (#391)

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -105,7 +105,7 @@
 | birth_date | date | 생년월일 |
 | pet_id | bigint | `pets.id` PK 참조 (FK 제약 선언 여부는 §7-12) |
 | care_mode | varchar | DB는 varchar, Java는 `CareMode` enum(`MANAGED` default / `AUTONOMOUS`). 시니어 회원에 적용. 보호자 회원도 컬럼은 갖지만 처방전 흐름에서는 `prescription.owner_id`로 참조하는 시니어 측 값만 사용 |
-| breakfast_time | time nullable | 시니어 식사 시간대(아침). Java는 `LocalTime`. 미설정 가능. Phase 1: 클라이언트가 schedule 등록 시 활용. Phase 2~3: 슬롯 매핑/자동 생성 (별도 spec) |
+| breakfast_time | time nullable | 시니어 식사 시간대(아침). Java는 `LocalTime`. 미설정 가능. Phase 1: 클라이언트가 schedule 등록 시 활용. Phase 2~3: 슬롯 매핑/자동 생성 (별도 spec). 변경 권한: 시니어 본인(`PUT /api/v1/users/me/meal-times`) 또는 연결된 보호자(`PUT /api/v1/users/{seniorId}/meal-times`, CareRelation 검증) |
 | lunch_time | time nullable | 시니어 식사 시간대(점심). 동일 |
 | dinner_time | time nullable | 시니어 식사 시간대(저녁). 동일 |
 | notification_mode | varchar nullable | 알림 프리셋. Java는 `NotificationMode` enum(`BASIC_ALERT`/`INTENSIVE_CARE`). 시니어에만 적용. 온보딩 시 설정, 이후 개별 조정 가능 |

--- a/src/main/java/com/ppiyaki/user/controller/UserController.java
+++ b/src/main/java/com/ppiyaki/user/controller/UserController.java
@@ -42,6 +42,15 @@ public class UserController {
         return ResponseEntity.ok(userService.updateMealTimes(userId, request));
     }
 
+    @PutMapping("/{seniorId}/meal-times")
+    public ResponseEntity<UserMeResponse> updateMealTimesForSenior(
+            @AuthenticationPrincipal final Long requesterId,
+            @PathVariable final Long seniorId,
+            @Valid @RequestBody final MealTimesUpdateRequest request
+    ) {
+        return ResponseEntity.ok(userService.updateMealTimesForSenior(requesterId, seniorId, request));
+    }
+
     @DeleteMapping("/me")
     public ResponseEntity<Void> withdraw(@AuthenticationPrincipal final Long userId) {
         userService.withdraw(userId);

--- a/src/main/java/com/ppiyaki/user/service/UserService.java
+++ b/src/main/java/com/ppiyaki/user/service/UserService.java
@@ -60,6 +60,22 @@ public class UserService {
     }
 
     @Transactional
+    public UserMeResponse updateMealTimesForSenior(
+            final Long requesterId,
+            final Long seniorId,
+            final MealTimesUpdateRequest request
+    ) {
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(requesterId, seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+
+        senior.updateMealTimes(request.breakfast(), request.lunch(), request.dinner());
+        return UserMeResponse.from(senior);
+    }
+
+    @Transactional
     public void withdraw(final Long userId) {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));

--- a/src/test/java/com/ppiyaki/user/controller/MealTimesControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/MealTimesControllerE2ETest.java
@@ -5,7 +5,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.ppiyaki.user.domain.CareRelation;
 import com.ppiyaki.user.domain.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -26,6 +28,9 @@ class MealTimesControllerE2ETest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private CareRelationRepository careRelationRepository;
 
     private static long userSequence = 800000L;
 
@@ -121,6 +126,89 @@ class MealTimesControllerE2ETest {
                 .put("/api/v1/users/me/meal-times")
                 .then()
                 .statusCode(401);
+    }
+
+    @Test
+    @DisplayName("활성 보호자가 시니어 mealTimes 변경 시 200 + DB 반영")
+    void caregiver_updates_senior_meal_times_success() {
+        // given
+        final SignupResult senior = signup("시니어E");
+        final SignupResult caregiver = signup("보호자E");
+        careRelationRepository.save(CareRelation.createLinked(senior.userId(), caregiver.userId()));
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .body("""
+                        {
+                            "breakfast": "07:30:00",
+                            "lunch": "12:00:00",
+                            "dinner": "19:00:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/" + senior.userId() + "/meal-times")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(senior.userId().intValue()))
+                .body("mealTimes.breakfast", is("07:30:00"))
+                .body("mealTimes.lunch", is("12:00:00"))
+                .body("mealTimes.dinner", is("19:00:00"));
+
+        final User reloaded = userRepository.findById(senior.userId()).orElseThrow();
+        assertThat(reloaded.getBreakfastTime()).isEqualTo(LocalTime.of(7, 30));
+        assertThat(reloaded.getLunchTime()).isEqualTo(LocalTime.of(12, 0));
+        assertThat(reloaded.getDinnerTime()).isEqualTo(LocalTime.of(19, 0));
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자가 시니어 mealTimes 변경 시도하면 403 CARE_001")
+    void unrelated_user_rejected_when_updating_senior_meal_times() {
+        // given
+        final SignupResult senior = signup("시니어F");
+        final SignupResult stranger = signup("타인G");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + stranger.accessToken())
+                .body("""
+                        {
+                            "breakfast": "08:00:00",
+                            "lunch": "12:30:00",
+                            "dinner": "18:30:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/" + senior.userId() + "/meal-times")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    @Test
+    @DisplayName("seniorId 미존재 시 404 USER_001")
+    void senior_not_found_when_updating_meal_times() {
+        // given
+        final SignupResult caregiver = signup("보호자H");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .body("""
+                        {
+                            "breakfast": "08:00:00",
+                            "lunch": "12:30:00",
+                            "dinner": "18:30:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/9999999/meal-times")
+                .then()
+                .statusCode(404)
+                .body("error.code", is("USER_001"));
     }
 
     private SignupResult signup(final String nickname) {


### PR DESCRIPTION
## AS-IS
- `PUT /api/v1/users/me/meal-times`는 시니어 본인 토큰만 가능 (`UserController.java:37-43`).
- 시니어가 직접 입력이 어려운 경우 보호자가 대신 설정할 방법이 없었음.

## TO-BE
- `PUT /api/v1/users/{seniorId}/meal-times` 신설 (보호자 토큰).
- `CareRelation` 검증 후 시니어 mealTimes 갱신.
- 기존 `/me/meal-times`는 시니어 본인 전용으로 유지.

## 변경 파일
- `UserController.java` — 새 엔드포인트 추가
- `UserService.java` — `updateMealTimesForSenior()` 추가 (`updateCareMode` 패턴 재사용)
- `MealTimesControllerE2ETest.java` — 보호자 성공 / 무관계자 403 / seniorId 미존재 404 케이스 3개 추가
- `docs/ai-harness/06-domain-model.md` — `breakfast_time` 컬럼 변경 권한 설명 보강

## Test plan
- [x] `./gradlew checkstyleMain spotlessCheck test` 통과
- [ ] 보호자 토큰으로 `PUT /api/v1/users/{seniorId}/meal-times` 200 + DB 반영
- [ ] 무관계자 토큰으로 호출 시 403 CARE_001
- [ ] 시니어 본인이 자기 ID로 `/{seniorId}/meal-times` 호출 시 403 CARE_001 (`/me/meal-times` 사용 유도)
- [ ] seniorId 미존재 시 404 USER_001

## 관련
- Closes #391
- 같은 회의 결정의 다른 변경(복약 인증 사진 careMode 분기)은 #392 PR로 분리

## AI 체크리스트
- [x] Feature Spec 없음 (단순 권한 확장)
- [x] 도메인 문서 갱신 완료 (06-domain-model.md §5 users)
- [x] Notion API 명세 갱신 완료 (`시니어 식사 시간대 일괄 갱신 (보호자)` 페이지 추가)
- [x] 보호 영역 미변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 간병인이 돌보는 시니어의 식사 시간을 관리할 수 있는 새로운 API 엔드포인트 추가
  * 간병 관계 검증 및 사용자 존재 여부 확인으로 안전한 업데이트 지원

* **Documentation**
  * 도메인 모델 문서에 식사 시간대 컬럼 정의 추가 및 정리

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->