### PR TITLE
feat(medication): 복약 인증 사진 정책을 careMode로 분기 (#392)

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -73,7 +73,7 @@
 | 알약 개수 검증 상태 | Log Pill Count Status | 복약 인증 사진 약 개수 AI 검증 결과. `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED`. `medication_logs.pill_count_status`에 enum 매핑 (Phase 2). 사진 + status=TAKEN일 때만 채워짐. Phase 3(낱알 식별) 진입 시 `pill_identification_status` 컬럼 분리 예정 |
 | 복약 이행률 | Adherence Rate | 기간 내 성공 복약 / 예정 복약 |
 | 대리 처리 | Proxy Confirmation | 보호자가 시니어 대신 복용 상태를 확정 (`is_proxy=true`, `confirmed_by_user_id != senior_id`) |
-| 보호자 승인 모드 | Care Mode | 시니어의 처방전 변경 권한 정책. `MANAGED`(보호자 검증 강제, 0~72h 보호자 전용 + 72h 후 시니어 fallback) / `AUTONOMOUS`(시니어 즉시 변경 허용). `users.care_mode`에 저장. 변경은 보호자만 가능 |
+| 보호자 승인 모드 | Care Mode | 시니어의 처방전 변경 권한 + 복약 인증 사진 정책. `MANAGED`(보호자 검증 강제, 0~72h 보호자 전용 + 72h 후 시니어 fallback. 복약 인증 `status=TAKEN` 시 `photo_object_key` **필수**) / `AUTONOMOUS`(시니어 즉시 변경 허용, 복약 인증 사진 선택). `users.care_mode`에 저장. 변경은 보호자만 가능 |
 | DUR 점검 | Drug Utilization Review | 약물 상호작용/중복/금기 검증. 결과는 `dur_checks`에 immutable 로그로 저장 |
 | 약 개수 인식 | Pill Count Recognition | 복약 확인용 비전 기반 약 개수 판정. 세부 구현 보류 |
 | 삐약이 | Ppiyaki / Pet Character | 복약 성공 시 성장하는 게이미피케이션 캐릭터 |
@@ -252,7 +252,7 @@ OCR + LLM 파싱으로 추출된 약물 후보. 처방전 1건당 N행. 보호�
 | target_date | date (`LocalDate`) | 예정 복약 일자 |
 | taken_at | datetime (`LocalDateTime`) nullable | 실제 확인 시각 |
 | status | varchar | 사용자 확정 상태. Java는 `LogStatus` enum(`TAKEN`/`MISSED`/`PENDING`) |
-| photo_object_key | varchar nullable | 복약 인증 사진의 NCP Object Storage `objectKey` (예: `medication-log/{userId}/{uuid}.jpg`). 응답 시 서버가 endpoint·bucket을 조립해 full URL(`photoUrl`)로 반환 |
+| photo_object_key | varchar nullable | 복약 인증 사진의 NCP Object Storage `objectKey` (예: `medication-log/{userId}/{uuid}.jpg`). 응답 시 서버가 endpoint·bucket을 조립해 full URL(`photoUrl`)로 반환. **시니어 `care_mode=MANAGED`이면 `status=TAKEN` 시 필수** (없으면 400 `LOG_001 MEDICATION_LOG_PHOTO_REQUIRED`). `care_mode=AUTONOMOUS`이면 선택 |
 | pill_count_status | varchar nullable | Vision LLM 약 개수 검증 결과. Java `LogPillCountStatus` enum: `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED` (Phase 2). 사진 + status=TAKEN일 때만 채워짐. Phase 3(낱알 식별) 진입 시 `pill_identification_status` 컬럼 분리 예정 |
 | is_proxy | boolean | 보호자 대리 처리 여부 (= `confirmed_by_user_id != senior_id`의 캐시) |
 | confirmed_by_user_id | bigint nullable | 실제로 상태를 확정한 사용자(`users.id` 참조). 시니어 본인일 수도, 보호자일 수도 있음 |

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -33,6 +33,10 @@ public enum ErrorCode {
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE_001", "Schedule not found"),
     SCHEDULE_MEDICINE_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE_002", "Schedule does not belong to this medicine"),
 
+    // Medication Log
+    MEDICATION_LOG_PHOTO_REQUIRED(HttpStatus.BAD_REQUEST, "LOG_001",
+            "Photo is required for senior in MANAGED care mode"),
+
     // DUR
     DUR_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "DUR_001", "DUR service unavailable"),
 

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -17,7 +17,10 @@ import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.domain.CareMode;
+import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -53,6 +56,7 @@ public class MedicationLogService {
     private final MedicationScheduleRepository medicationScheduleRepository;
     private final MedicineRepository medicineRepository;
     private final CareRelationRepository careRelationRepository;
+    private final UserRepository userRepository;
     private final PhotoUrlAssembler photoUrlAssembler;
     private final OpenAiClient openAiClient;
     private final NcpStorageProperties storageProperties;
@@ -66,6 +70,7 @@ public class MedicationLogService {
             final MedicationScheduleRepository medicationScheduleRepository,
             final MedicineRepository medicineRepository,
             final CareRelationRepository careRelationRepository,
+            final UserRepository userRepository,
             final PhotoUrlAssembler photoUrlAssembler,
             final OpenAiClient openAiClient,
             final NcpStorageProperties storageProperties,
@@ -78,6 +83,7 @@ public class MedicationLogService {
         this.medicationScheduleRepository = medicationScheduleRepository;
         this.medicineRepository = medicineRepository;
         this.careRelationRepository = careRelationRepository;
+        this.userRepository = userRepository;
         this.photoUrlAssembler = photoUrlAssembler;
         this.openAiClient = openAiClient;
         this.storageProperties = storageProperties;
@@ -96,6 +102,14 @@ public class MedicationLogService {
         final Long seniorId = medicine.getOwnerId();
 
         final boolean isProxy = resolveProxyFlag(userId, seniorId);
+
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (senior.getCareMode() == CareMode.MANAGED
+                && request.status() == LogStatus.TAKEN
+                && (request.photoObjectKey() == null || request.photoObjectKey().isBlank())) {
+            throw new BusinessException(ErrorCode.MEDICATION_LOG_PHOTO_REQUIRED);
+        }
 
         if (request.photoObjectKey() != null && !request.photoObjectKey().isBlank()) {
             validatePhotoObjectKey(request.photoObjectKey(), userId);

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
@@ -10,7 +10,9 @@ import com.ppiyaki.medication.domain.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.domain.CareMode;
 import com.ppiyaki.user.domain.CareRelation;
+import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import io.restassured.RestAssured;
@@ -239,7 +241,10 @@ class MedicationLogControllerE2ETest {
                 .statusCode(201)
                 .extract()
                 .asString();
-        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final User user = userRepository.findByLoginId(loginId).orElseThrow();
+        user.changeCareMode(CareMode.AUTONOMOUS);
+        userRepository.save(user);
+        final Long userId = user.getId();
         final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
         return new SignupResult(userId, accessToken);
     }

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -3,6 +3,8 @@ package com.ppiyaki.medication.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,7 +22,10 @@ import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.domain.CareMode;
+import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
@@ -53,6 +58,8 @@ class MedicationLogServicePhase2Test {
     private MedicineRepository medicineRepository;
     @Mock
     private CareRelationRepository careRelationRepository;
+    @Mock
+    private UserRepository userRepository;
     @Mock
     private PhotoUrlAssembler photoUrlAssembler;
     @Mock
@@ -195,6 +202,7 @@ class MedicationLogServicePhase2Test {
         givenSiblingSchedules(List.of(triggerSchedule, peerSchedule));
         givenS3Returns(new byte[]{1, 2, 3});
         when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(2));
+        givenAutonomousSenior();
 
         // when
         service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
@@ -257,6 +265,7 @@ class MedicationLogServicePhase2Test {
         givenSiblingSchedules(List.of(triggerSchedule, peerSchedule));
         givenS3Returns(new byte[]{1, 2, 3});
         when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(2));
+        givenAutonomousSenior();
 
         // when
         service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
@@ -290,6 +299,13 @@ class MedicationLogServicePhase2Test {
         final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", 30, 30, "ITEM-1", null);
         setField(medicine, "id", MEDICINE_ID);
         when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(medicine));
+        givenAutonomousSenior();
+    }
+
+    private void givenAutonomousSenior() {
+        final User senior = mock(User.class);
+        lenient().when(senior.getCareMode()).thenReturn(CareMode.AUTONOMOUS);
+        lenient().when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(senior));
     }
 
     private void givenSiblingSchedules(final List<MedicationSchedule> schedules) {

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -3,6 +3,8 @@ package com.ppiyaki.medication.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -19,8 +21,11 @@ import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.domain.CareMode;
 import com.ppiyaki.user.domain.CareRelation;
+import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -47,6 +52,8 @@ class MedicationLogServiceTest {
     private MedicineRepository medicineRepository;
     @Mock
     private CareRelationRepository careRelationRepository;
+    @Mock
+    private UserRepository userRepository;
     @Mock
     private PhotoUrlAssembler photoUrlAssembler;
     @Mock
@@ -248,6 +255,46 @@ class MedicationLogServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("careMode=MANAGED + status=TAKEN + photoObjectKey 누락 시 MEDICATION_LOG_PHOTO_REQUIRED")
+    void managed_senior_taken_without_photo() throws Exception {
+        // given
+        givenScheduleAndMedicine();
+        final User managedSenior = mock(User.class);
+        when(managedSenior.getCareMode()).thenReturn(CareMode.MANAGED);
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(managedSenior));
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when & then
+        assertThatThrownBy(() -> medicationLogService.upsert(SENIOR_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.MEDICATION_LOG_PHOTO_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("careMode=MANAGED + status=MISSED는 photoObjectKey 없어도 통과")
+    void managed_senior_missed_without_photo_ok() throws Exception {
+        // given
+        givenScheduleAndMedicine();
+        final User managedSenior = mock(User.class);
+        when(managedSenior.getCareMode()).thenReturn(CareMode.MANAGED);
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(managedSenior));
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.MISSED, null);
+
+        // when & then — 예외 없이 처리
+        medicationLogService.upsert(SENIOR_ID, request);
     }
 
     @Test
@@ -539,7 +586,14 @@ class MedicationLogServiceTest {
         final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", total, remaining, "ITEM-1", null);
         setField(medicine, "id", MEDICINE_ID);
         when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(medicine));
+        givenAutonomousSenior();
         return medicine;
+    }
+
+    private void givenAutonomousSenior() {
+        final User senior = mock(User.class);
+        lenient().when(senior.getCareMode()).thenReturn(CareMode.AUTONOMOUS);
+        lenient().when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(senior));
     }
 
     private void givenScheduleAndMedicine() throws Exception {
@@ -558,6 +612,7 @@ class MedicationLogServiceTest {
         final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", 30, 30, "ITEM-1", null);
         setField(medicine, "id", MEDICINE_ID);
         when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(medicine));
+        givenAutonomousSenior();
     }
 
     private static void setField(final Object target, final String fieldName, final Object value) throws Exception {

--- a/src/test/java/com/ppiyaki/notification/controller/NotificationAutoTakenE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/NotificationAutoTakenE2ETest.java
@@ -13,6 +13,7 @@ import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.notification.Notification;
 import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.user.domain.CareMode;
 import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.domain.UserRole;
 import com.ppiyaki.user.repository.UserRepository;
@@ -163,6 +164,7 @@ class NotificationAutoTakenE2ETest {
     private Long seedSenior() {
         return transactionTemplate.execute(status -> {
             final User senior = User.createSenior("E2E시니어" + userSequence++, (LocalDate) null);
+            senior.changeCareMode(CareMode.AUTONOMOUS);
             return userRepository.save(senior).getId();
         });
     }


### PR DESCRIPTION
## AS-IS
- `MedicationLogService.upsert()`는 careMode를 읽지 않음.
- 시니어의 careMode와 무관하게 `photoObjectKey`는 항상 선택 (없어도 `status=TAKEN` 확정 가능).
- "강제/여유" 모드 토글 자체가 없음.

## TO-BE
- 시니어의 `careMode == MANAGED`이고 `status == TAKEN`이면 `photoObjectKey` **필수**.
- 누락 시 400 `LOG_001 MEDICATION_LOG_PHOTO_REQUIRED` 반환.
- `AUTONOMOUS`이면 기존처럼 사진 선택 (회귀 없음).
- `status == MISSED`는 careMode 무관하게 사진 선택.
- 보호자 대리 인증도 시니어의 careMode를 기준으로 판단.

## 변경 파일
- `MedicationLogService.java` — `UserRepository` 주입 + `upsert()` 진입부에 careMode 분기
- `ErrorCode.java` — `MEDICATION_LOG_PHOTO_REQUIRED (LOG_001)` 추가
- `MedicationLogServiceTest.java` — MANAGED+사진없음→400, MANAGED+MISSED 통과 케이스 추가, 기존 helper에 UserRepository mock + AUTONOMOUS senior 추가
- `MedicationLogServicePhase2Test.java` — 동일 mock 보강
- `MedicationLogControllerE2ETest.java` — signup 시 senior careMode를 AUTONOMOUS로 명시 (회귀 방지)
- `NotificationAutoTakenE2ETest.java` — seedSenior에 AUTONOMOUS 명시
- `docs/ai-harness/06-domain-model.md` — Care Mode 정의에 사진 정책 추가, `photo_object_key` 컬럼 careMode 필수 조건 명시

## Test plan
- [x] `./gradlew checkstyleMain spotlessCheck test` 통과 (335 tests)
- [ ] MANAGED 시니어 + status=TAKEN + photoObjectKey 누락 → 400 LOG_001
- [ ] MANAGED 시니어 + status=MISSED + 사진 없음 → 200
- [ ] AUTONOMOUS 시니어 + status=TAKEN + 사진 없음 → 200 (회귀 없음)
- [ ] 보호자 대리 인증도 동일 정책 적용

## 관련
- Closes #392
- 같은 회의 결정의 다른 변경(시니어 식사시간 보호자 권한)은 #393 PR로 분리

## AI 체크리스트
- [x] Feature Spec 없음 (단순 정책 분기)
- [x] 도메인 문서 갱신 완료 (06-domain-model.md §4 Care Mode, §5 medication_logs)
- [x] Notion API 명세 갱신 완료 (`복약 기록 업서트` 페이지에 careMode 정책 노트 추가)
- [x] 보호 영역 미변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)