### PR TITLE
feat(infra): NCP → docker MySQL 마이그레이션 스크립트 (#397)

### DIFF
--- a/scripts/db-migration/README.md
+++ b/scripts/db-migration/README.md
@@ -1,0 +1,38 @@
+# DB Migration Scripts
+
+NCP 매니지드 MySQL → backend 서버 docker MySQL 데이터 이전용 스크립트.
+
+상세 spec: [`docs/features/db-self-hosted-migration.md`](../../docs/features/db-self-hosted-migration.md)
+
+## 사전 조건
+
+- backend 서버에 ssh 접속 가능 (`ssh ppiyaki-prod`)
+- `ppiyaki-server`, `ppiyaki-mysql` 두 컨테이너가 실행 중 (`docker compose up -d mysql`로 docker MySQL 미리 기동)
+- 서버에 mysql client 설치 (`apt install mysql-client-core-8.0` 또는 이미 설치되어 있을 가능성)
+
+## 실행 순서
+
+backend 서버에서 차례로 실행:
+
+```bash
+# 1. NCP 매니지드 DB → 압축 덤프
+./dump-from-ncp.sh
+# → /tmp/ppiyaki-ncp-dump-YYYYMMDD-HHMMSS.sql.gz 생성
+
+# 2. 덤프 → docker MySQL 복원
+./restore-to-docker.sh /tmp/ppiyaki-ncp-dump-YYYYMMDD-HHMMSS.sql.gz
+
+# 3. row count 검증
+./verify-counts.sh
+```
+
+## 주의사항
+
+- credential은 컨테이너 env에서 추출하며 임시 `.my.cnf` 파일에만 노출. EXIT trap으로 즉시 삭제.
+- `restore-to-docker.sh`는 기존 데이터를 덮어쓴다. docker MySQL이 빈 상태인지 확인 후 실행.
+- `verify-counts.sh`의 row count는 `information_schema.tables` 통계값이라 ±10% 오차 가능. 정확한 검증이 필요하면 각 테이블 `SELECT COUNT(*)`를 별도로 비교.
+- 다운타임 무제한 허용 (spec §9 결정). 마이그레이션 중 ppiyaki-server는 살아있어도 되지만, 사진 업로드/복약 인증 등 쓰기 트래픽이 발생하면 NCP에 남은 데이터와 docker MySQL 데이터가 어긋남. 가능하면 ppiyaki-server를 일시 중단 후 진행.
+
+## 롤백
+
+마이그레이션 후 backend 연결 변경 전이면 NCP DB는 그대로 살아있다. PR 3 머지 전 단계에서 문제 발견 시 docker MySQL만 정리하고 NCP를 계속 사용.

--- a/scripts/db-migration/dump-from-ncp.sh
+++ b/scripts/db-migration/dump-from-ncp.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# NCP 매니지드 MySQL → 압축된 sql.gz 덤프 생성.
+# backend 서버(ssh ppiyaki-prod)에서 실행할 것을 가정.
+#
+# 사용법:
+#   ./dump-from-ncp.sh [OUTPUT_PATH]
+#   기본 OUTPUT_PATH = /tmp/ppiyaki-ncp-dump-<timestamp>.sql.gz
+#
+# 동작:
+#   1) 실행 중인 ppiyaki-server 컨테이너의 env에서 DB_URL/USERNAME/PASSWORD 추출
+#   2) DB_URL을 jdbc:mysql://HOST:PORT/DB 패턴에서 분해
+#   3) mysqldump --single-transaction --triggers --routines --events --quick → gzip
+#   4) 결과 경로와 row count 요약 출력
+#
+# 보안: credential은 임시 .my.cnf로만 노출되며 EXIT trap으로 즉시 삭제.
+
+set -euo pipefail
+
+OUTPUT="${1:-/tmp/ppiyaki-ncp-dump-$(date +%Y%m%d-%H%M%S).sql.gz}"
+
+CID=$(sudo docker ps --filter name=ppiyaki-server -q | head -1)
+if [[ -z "$CID" ]]; then
+    echo "ERROR: ppiyaki-server 컨테이너를 찾을 수 없습니다." >&2
+    exit 1
+fi
+
+ENV_FILE=$(mktemp)
+CNF_FILE=$(mktemp)
+trap 'rm -f "$ENV_FILE" "$CNF_FILE"' EXIT
+
+sudo docker inspect "$CID" --format '{{range .Config.Env}}{{println .}}{{end}}' > "$ENV_FILE"
+
+URL=$(grep '^DB_URL=' "$ENV_FILE" | cut -d= -f2-)
+DBUSER=$(grep '^DB_USERNAME=' "$ENV_FILE" | cut -d= -f2-)
+DBPASS=$(grep '^DB_PASSWORD=' "$ENV_FILE" | cut -d= -f2-)
+
+if [[ -z "$URL" || -z "$DBUSER" || -z "$DBPASS" ]]; then
+    echo "ERROR: ppiyaki-server 컨테이너 env에서 DB_URL/USERNAME/PASSWORD 추출 실패." >&2
+    exit 1
+fi
+
+# jdbc:mysql://HOST:PORT/DB?params -> HOST, PORT, DB 분해
+HOST=$(echo "$URL" | sed -E 's|jdbc:mysql://([^:/]+).*|\1|')
+PORT=$(echo "$URL" | sed -nE 's|jdbc:mysql://[^:/]+:([0-9]+).*|\1|p')
+PORT="${PORT:-3306}"
+DBNAME=$(echo "$URL" | sed -nE 's|jdbc:mysql://[^/]+/([^?]+).*|\1|p')
+
+if [[ -z "$HOST" || -z "$DBNAME" ]]; then
+    echo "ERROR: DB_URL 파싱 실패: $URL" >&2
+    exit 1
+fi
+
+{
+    echo "[client]"
+    echo "host=$HOST"
+    echo "port=$PORT"
+    echo "user=$DBUSER"
+    echo "password=$DBPASS"
+} > "$CNF_FILE"
+chmod 600 "$CNF_FILE"
+
+echo "Source: $HOST:$PORT/$DBNAME"
+echo "Target: $OUTPUT"
+
+# Pre-dump row count snapshot
+echo "=== row counts before dump ==="
+mysql --defaults-extra-file="$CNF_FILE" "$DBNAME" -N -e "
+    SELECT table_name, table_rows
+    FROM information_schema.tables
+    WHERE table_schema = '$DBNAME'
+    ORDER BY table_name;
+"
+
+# Dump
+mysqldump --defaults-extra-file="$CNF_FILE" \
+    --single-transaction \
+    --triggers \
+    --routines \
+    --events \
+    --quick \
+    --set-gtid-purged=OFF \
+    --no-tablespaces \
+    "$DBNAME" \
+    | gzip -9 > "$OUTPUT"
+
+DUMP_SIZE=$(du -h "$OUTPUT" | cut -f1)
+echo
+echo "Dump 완료: $OUTPUT ($DUMP_SIZE)"
+echo "다음 단계: ./restore-to-docker.sh $OUTPUT"

--- a/scripts/db-migration/restore-to-docker.sh
+++ b/scripts/db-migration/restore-to-docker.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# 압축된 sql.gz 덤프를 backend 서버의 docker MySQL(ppiyaki-mysql)에 import.
+# backend 서버(ssh ppiyaki-prod)에서 실행할 것을 가정.
+#
+# 사용법:
+#   ./restore-to-docker.sh DUMP_PATH
+#
+# 동작:
+#   1) ppiyaki-mysql 컨테이너 healthy 상태 확인
+#   2) MYSQL_ROOT_PASSWORD를 컨테이너 env에서 추출 (혹은 외부 env에서 받음)
+#   3) gzip -dc | docker exec mysql 로 import (DROP TABLE → CREATE → INSERT 전체)
+#   4) import 직후 row count 출력
+#
+# 주의: import는 기존 데이터를 덮어쓴다. 빈 DB가 아니면 사전에 백업 필요.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "사용법: $0 DUMP_PATH" >&2
+    exit 1
+fi
+
+DUMP="$1"
+if [[ ! -f "$DUMP" ]]; then
+    echo "ERROR: 덤프 파일을 찾을 수 없음: $DUMP" >&2
+    exit 1
+fi
+
+CID=$(sudo docker ps --filter name=ppiyaki-mysql -q | head -1)
+if [[ -z "$CID" ]]; then
+    echo "ERROR: ppiyaki-mysql 컨테이너가 실행 중이 아닙니다." >&2
+    echo "먼저 'docker compose up -d mysql'을 실행하세요." >&2
+    exit 1
+fi
+
+# Healthcheck 통과 대기 (최대 60초)
+echo "ppiyaki-mysql healthy 대기 중..."
+for i in {1..30}; do
+    STATUS=$(sudo docker inspect "$CID" --format '{{.State.Health.Status}}' 2>/dev/null || echo "unknown")
+    if [[ "$STATUS" == "healthy" ]]; then
+        break
+    fi
+    sleep 2
+done
+
+if [[ "$STATUS" != "healthy" ]]; then
+    echo "ERROR: ppiyaki-mysql healthcheck 실패 (current=$STATUS). 컨테이너 로그 확인 필요." >&2
+    exit 1
+fi
+
+# 컨테이너 env에서 root password + db name 추출
+ROOT_PW=$(sudo docker inspect "$CID" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^MYSQL_ROOT_PASSWORD=' | cut -d= -f2-)
+DBNAME=$(sudo docker inspect "$CID" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^MYSQL_DATABASE=' | cut -d= -f2-)
+DBNAME="${DBNAME:-ppiyaki}"
+
+if [[ -z "$ROOT_PW" ]]; then
+    echo "ERROR: MYSQL_ROOT_PASSWORD를 컨테이너 env에서 추출 실패." >&2
+    exit 1
+fi
+
+echo "Source: $DUMP ($(du -h "$DUMP" | cut -f1))"
+echo "Target: ppiyaki-mysql / $DBNAME"
+
+# import
+gzip -dc "$DUMP" | sudo docker exec -i -e "MYSQL_PWD=$ROOT_PW" "$CID" mysql -u root "$DBNAME"
+
+echo
+echo "=== row counts after import ==="
+sudo docker exec -e "MYSQL_PWD=$ROOT_PW" "$CID" mysql -u root -N -e "
+    SELECT table_name, table_rows
+    FROM information_schema.tables
+    WHERE table_schema = '$DBNAME'
+    ORDER BY table_name;
+"
+
+echo
+echo "Restore 완료. 다음 단계: ./verify-counts.sh"

--- a/scripts/db-migration/verify-counts.sh
+++ b/scripts/db-migration/verify-counts.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# NCP 매니지드 MySQL과 backend 서버 docker MySQL의 row count를 비교 검증.
+# backend 서버(ssh ppiyaki-prod)에서 실행할 것을 가정.
+#
+# 사용법:
+#   ./verify-counts.sh
+#
+# 동작:
+#   1) ppiyaki-server env에서 NCP 접속 정보 추출
+#   2) ppiyaki-mysql env에서 local 접속 정보 추출
+#   3) 두 DB에서 information_schema.tables의 table_rows를 가져와 diff
+#   4) 차이가 있는 테이블만 표시 (없으면 OK 메시지)
+#
+# 참고: information_schema.tables.table_rows는 통계값이라 ±10% 오차 가능.
+#       정확한 검증이 필요하면 각 테이블 SELECT COUNT(*)를 별도로 비교할 것.
+
+set -euo pipefail
+
+# === NCP 접속 정보 추출 ===
+SERVER_CID=$(sudo docker ps --filter name=ppiyaki-server -q | head -1)
+if [[ -z "$SERVER_CID" ]]; then
+    echo "ERROR: ppiyaki-server 컨테이너를 찾을 수 없습니다." >&2
+    exit 1
+fi
+
+NCP_ENV=$(mktemp)
+NCP_CNF=$(mktemp)
+LOCAL_CNF=$(mktemp)
+trap 'rm -f "$NCP_ENV" "$NCP_CNF" "$LOCAL_CNF"' EXIT
+
+sudo docker inspect "$SERVER_CID" --format '{{range .Config.Env}}{{println .}}{{end}}' > "$NCP_ENV"
+NCP_URL=$(grep '^DB_URL=' "$NCP_ENV" | cut -d= -f2-)
+NCP_HOST=$(echo "$NCP_URL" | sed -E 's|jdbc:mysql://([^:/]+).*|\1|')
+NCP_PORT=$(echo "$NCP_URL" | sed -nE 's|jdbc:mysql://[^:/]+:([0-9]+).*|\1|p')
+NCP_PORT="${NCP_PORT:-3306}"
+NCP_DB=$(echo "$NCP_URL" | sed -nE 's|jdbc:mysql://[^/]+/([^?]+).*|\1|p')
+
+{
+    echo "[client]"
+    echo "host=$NCP_HOST"
+    echo "port=$NCP_PORT"
+    echo "user=$(grep '^DB_USERNAME=' "$NCP_ENV" | cut -d= -f2-)"
+    echo "password=$(grep '^DB_PASSWORD=' "$NCP_ENV" | cut -d= -f2-)"
+} > "$NCP_CNF"
+chmod 600 "$NCP_CNF"
+
+# === Local docker 접속 정보 추출 ===
+MYSQL_CID=$(sudo docker ps --filter name=ppiyaki-mysql -q | head -1)
+if [[ -z "$MYSQL_CID" ]]; then
+    echo "ERROR: ppiyaki-mysql 컨테이너를 찾을 수 없습니다." >&2
+    exit 1
+fi
+
+LOCAL_ENV=$(sudo docker inspect "$MYSQL_CID" --format '{{range .Config.Env}}{{println .}}{{end}}')
+LOCAL_ROOT_PW=$(echo "$LOCAL_ENV" | grep '^MYSQL_ROOT_PASSWORD=' | cut -d= -f2-)
+LOCAL_DB=$(echo "$LOCAL_ENV" | grep '^MYSQL_DATABASE=' | cut -d= -f2-)
+LOCAL_DB="${LOCAL_DB:-ppiyaki}"
+
+# === row count 가져오기 ===
+NCP_COUNTS=$(mysql --defaults-extra-file="$NCP_CNF" -N -e "
+    SELECT table_name, table_rows
+    FROM information_schema.tables
+    WHERE table_schema = '$NCP_DB'
+    ORDER BY table_name;
+")
+
+LOCAL_COUNTS=$(sudo docker exec -e "MYSQL_PWD=$LOCAL_ROOT_PW" "$MYSQL_CID" mysql -u root -N -e "
+    SELECT table_name, table_rows
+    FROM information_schema.tables
+    WHERE table_schema = '$LOCAL_DB'
+    ORDER BY table_name;
+")
+
+# === diff ===
+echo "=== NCP ($NCP_DB) vs docker ($LOCAL_DB) row counts ==="
+printf "%-50s %12s %12s %s\n" "table" "ncp_rows" "local_rows" "match"
+echo "-----------------------------------------------------------------------------------"
+
+MISMATCH=0
+while IFS=$'\t' read -r TBL NCP_ROWS; do
+    LOCAL_ROWS=$(echo "$LOCAL_COUNTS" | awk -v t="$TBL" '$1==t {print $2}')
+    LOCAL_ROWS="${LOCAL_ROWS:-MISSING}"
+    if [[ "$NCP_ROWS" == "$LOCAL_ROWS" ]]; then
+        MARK="OK"
+    else
+        MARK="MISMATCH"
+        MISMATCH=$((MISMATCH+1))
+    fi
+    printf "%-50s %12s %12s %s\n" "$TBL" "$NCP_ROWS" "$LOCAL_ROWS" "$MARK"
+done <<< "$NCP_COUNTS"
+
+echo
+if [[ "$MISMATCH" -eq 0 ]]; then
+    echo "모든 테이블 row count 일치."
+else
+    echo "$MISMATCH개 테이블 불일치. 통계값이라 ±10% 오차 가능 — 의심되는 테이블은 SELECT COUNT(*)로 정확히 검증할 것."
+fi


### PR DESCRIPTION
## AS-IS
- DB 이전 spec과 docker MySQL 정의는 PR #396에서 머지됨.
- 데이터 이전(mysqldump → restore) 실행에 쓸 스크립트가 없음.

## TO-BE
- `scripts/db-migration/` 디렉터리에 마이그레이션 자동화 스크립트 3종 추가.
- 실제 실행은 사용자가 backend 서버에서 수행 (위임).

## 변경 파일
- `scripts/db-migration/dump-from-ncp.sh` — NCP 매니지드 DB → `sql.gz` 덤프
- `scripts/db-migration/restore-to-docker.sh` — 덤프 → ppiyaki-mysql import (healthcheck 대기 포함)
- `scripts/db-migration/verify-counts.sh` — NCP vs docker row count diff
- `scripts/db-migration/README.md` — 사전 조건/실행 순서/롤백 가이드

## 보안
- credential은 모두 컨테이너 env에서 런타임에 추출. 스크립트에 하드코딩 X.
- 임시 `.my.cnf` 파일로만 노출되며 EXIT trap으로 즉시 삭제.
- `mysql -p$PW` 대신 `--defaults-extra-file` / `MYSQL_PWD` 사용 → process list 노출 방지.

## Test plan
- [x] `bash -n` 문법 검증 통과 (3개 스크립트 모두)
- [ ] (prod 실행 시) `dump-from-ncp.sh` → 22.84MB 덤프 생성 확인
- [ ] (prod 실행 시) `restore-to-docker.sh` → row count 일치 확인
- [ ] (prod 실행 시) `verify-counts.sh` → 모든 테이블 OK

## 사용자 작업 (PR 머지 후)
1. PR #396 머지 후 서버에 docker-compose 배포 (`docker compose up -d mysql`)
2. ssh ppiyaki-prod → 해당 스크립트 path로 이동 → 차례로 실행
3. row count 검증 후 PR 3 진행 (backend-cd `DB_URL` 갱신)

## 관련
- 마일스톤 이슈: #395
- 선행 PR: #396 (머지됨)
- 후속 PR: backend-cd `DB_URL` GitHub Secrets 갱신, NCP 해지

## AI 체크리스트
- [x] Feature Spec §6 PR 2 일치 (`docs/features/db-self-hosted-migration.md`)
- [x] 도메인 문서 갱신 불필요 (운영 스크립트)
- [x] Notion API 명세 갱신 불필요 (API 변경 없음)
- [x] 보호 영역 미변경 (`scripts/db-migration/` 신규)

🤖 Generated with [Claude Code](https://claude.com/claude-code)