### PR TITLE
docs(infra): DB 이전 완료 기록 — ADR 0011 + spec done (#399)

### DIFF
--- a/docs/decisions/0001-mysql-on-ncp-8.4.6.md
+++ b/docs/decisions/0001-mysql-on-ncp-8.4.6.md
@@ -1,10 +1,12 @@
 ---
 id: 0001
 title: 운영 DB는 NCP 매니지드 MySQL 8.4.6
-status: accepted
+status: superseded by 0011
 date: 2026-04-08
 deciders: [@goohong]
 ---
+
+> **2026-05-20 supersede**: 비용 절감 목적으로 운영 DB를 backend 서버 docker MySQL로 이전 (ADR 0011). MySQL 8.4.6 버전 선택과 로컬 docker-compose 정렬 결정은 ADR 0011에서도 유지된다.
 
 # 0001. 운영 DB는 NCP 매니지드 MySQL 8.4.6
 

--- a/docs/decisions/0011-self-hosted-mysql-docker.md
+++ b/docs/decisions/0011-self-hosted-mysql-docker.md
@@ -1,0 +1,46 @@
+---
+id: 0011
+title: 운영 DB를 backend 서버 docker MySQL로 자체 호스팅
+status: accepted
+date: 2026-05-20
+deciders: [@goohong]
+---
+
+# 0011. 운영 DB를 backend 서버 docker MySQL로 자체 호스팅
+
+## Context
+ADR 0001로 NCP 매니지드 MySQL 8.4.6을 도입했으나, 베타 사용자 < 100명 규모에서는 매니지드 백업·HA 기능이 비용 대비 과잉이다. 운영 데이터 사이즈도 22.84MB로 매우 작고(`pill_identifications` 캐시 21.59MB가 대부분), 다운타임 허용폭이 넓어 단일 인스턴스로 충분하다. 매니지드 월 구독료를 줄이는 것이 우선순위가 됐다.
+
+## Decision
+운영 DB를 **backend 서버(211.188.48.217) 의 docker MySQL 8.4.6** 으로 이전한다.
+- `ppiyaki-monitoring` docker network 내부에만 노출, 외부 포트 미공개
+- `mysql-data` 영속 볼륨에만 데이터 보관 (외부/오프사이트 백업 없음)
+- backend는 `jdbc:mysql://mysql:3306/ppiyaki` (network DNS)로 접속
+- credential은 backend 컨테이너 env(`DB_USERNAME`/`DB_PASSWORD`)와 동일하게 .env에 주입
+- 메모리 1GB 제한, healthcheck로 기동 검증
+
+ADR 0001은 superseded.
+
+## Consequences
+### 긍정적
+- 매니지드 월 구독료 제거 (가장 큰 비용 절감 효과)
+- backend ↔ DB 간 네트워크 hop이 사라져 평균 latency 감소
+- 모니터링 stack과 동일한 docker compose로 통합 관리
+
+### 부정적
+- **단일 장애점**: backend 서버 디스크/하드웨어 장애 시 데이터 손실 (외부 백업 없음 — 결정 시 명시적으로 수용)
+- **HA 없음**: 매니지드의 자동 fail-over 기능 상실
+- **자원 경합 위험**: backend + monitoring 5종 + MySQL이 같은 서버(2 vCPU / 3.8GB RAM)에서 공존 — 트래픽 증가 시 분리 필요
+- 백업·복구 운영 부담이 운영자에게 이전됨 (현재는 자동 cron 백업 없음)
+
+## Alternatives (considered)
+- (A) **별도 저렴한 VM에 docker MySQL** — 자원 분리는 안전하지만 VM 고정 비용이 다시 발생 → 비용 절감 효과 절반 이하
+- (B) **다른 클라우드의 저렴한 매니지드** (AWS RDS 등) — NCP Object Storage·CD 와 분리되어 운영 복잡도 증가
+- (C) **현 상태 유지** — 비용 절감 목표 미달성
+
+## References
+- Spec: `docs/features/db-self-hosted-migration.md`
+- Supersedes: ADR 0001
+- 마일스톤: 이슈 #395
+- 관련 PR: #396 (spec + docker-compose), #398 (migration scripts), #399 (마무리)
+- 마이그레이션 일시: 2026-05-20

--- a/docs/features/db-self-hosted-migration.md
+++ b/docs/features/db-self-hosted-migration.md
@@ -1,7 +1,7 @@
 ---
 feature: DB 자체 호스팅 이전 (NCP 매니지드 MySQL → backend 서버 docker MySQL)
 slug: db-self-hosted-migration
-status: ready
+status: done
 owner: @goohong
 scope: infra
 related_issues: []
@@ -131,3 +131,13 @@ sequenceDiagram
   - Q3 = NCP 매니지드 DB 해지 시점 = 마이그레이션 직후 (롤백 여지 미확보 — 단순/빠른 정리 우선)
   - Q4 = 로컬 docker 볼륨 백업만 (디스크 장애 시 데이터 손실 수용)
 - **2026-05-20**: status = draft → **ready** (Spec 합의 완료)
+- **2026-05-20**: prod 적용 완료
+  - PR #396 머지 후 `infra/monitoring/docker-compose.yml`을 prod의 `/home/ubuntu/monitoring/`에 scp 동기화. `.env`에 `MYSQL_ROOT_PASSWORD` (openssl rand -hex 24) + `MYSQL_USER`/`MYSQL_PASSWORD` (backend의 `DB_USERNAME`/`DB_PASSWORD` 재사용) 추가
+  - `docker compose up -d mysql` → `ppiyaki-mysql` healthy 확인
+  - `dump-from-ncp.sh` → 1.9MB gzip 덤프 (NCP `pill_identifications` 25,515 rows 등 22 테이블)
+  - `restore-to-docker.sh` → 데이터 import
+  - `verify-counts.sh` + 정확 `SELECT COUNT(*)` 비교 → 22 테이블 모두 일치
+  - GitHub Secret `DB_URL` 갱신 (`jdbc:mysql://mysql:3306/ppiyaki`) + `workflow_dispatch`로 backend 재배포
+  - `ppiyaki-server` 로그 검증: HikariPool 정상 연결, MySQL 8.4.6 인식, JPA `validate` 통과, Tomcat 8080/8081 정상 기동
+- **2026-05-20**: ADR 0001 → superseded by ADR 0011 (self-hosted MySQL docker)
+- **2026-05-20**: status = ready → **done**


### PR DESCRIPTION
## AS-IS
- ADR 0001 (NCP 매니지드 MySQL) 는 여전히 accepted 상태로 표시
- spec `db-self-hosted-migration`은 ready 상태 (prod 적용 완료 미반영)

## TO-BE
- ADR 0011 추가 (self-hosted MySQL docker, accepted)
- ADR 0001 status: accepted → **superseded by 0011**
- spec status: ready → **done**
- spec §9 결정 로그에 prod 적용 단계와 검증 결과 기록

## 변경 파일
- `docs/decisions/0011-self-hosted-mysql-docker.md` — 신규 ADR
- `docs/decisions/0001-mysql-on-ncp-8.4.6.md` — status + supersede 노트
- `docs/features/db-self-hosted-migration.md` — status=done, 결정 로그 보강

## prod 적용 검증 (이번 PR 머지 전에 이미 완료)
- 22 테이블 row count 100% 일치 (`SELECT COUNT(*)` 정확 비교)
- backend `ppiyaki-server` 로그: HikariPool 정상, MySQL 8.4.6 인식, JPA validate 통과, Tomcat 8080/8081 정상

## 후속 사용자 액션
- **NCP 매니지드 DB 해지** (NCP 콘솔에서 직접). 백업/스냅샷 마지막 1회 확보 권장 후 진행.

## 관련
- 마일스톤 이슈: #395
- 선행 PR: #396 (spec + docker-compose), #398 (migration scripts)
- 본 PR로 마일스톤 #395 종료

## AI 체크리스트
- [x] Feature Spec status 갱신 완료
- [x] ADR 작성 + 0001 supersede
- [x] 도메인 문서 갱신 불필요 (인프라 변경, 도메인 모델 동일)
- [x] Notion API 명세 갱신 불필요 (API 변경 없음)
- [x] 보호 영역 미변경 (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 데이터베이스 마이그레이션 완료에 따른 아키텍처 결정 기록 업데이트
  * 자체 호스팅 MySQL Docker 환경 설정 및 운영 정책 문서화
  * 마이그레이션 실행 단계 및 검증 결과 기록

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->