### PR TITLE
feat(infra): docker MySQL을 host 127.0.0.1:13306으로 publish (#401)

### DIFF
--- a/infra/monitoring/docker-compose.yml
+++ b/infra/monitoring/docker-compose.yml
@@ -15,13 +15,18 @@ services:
     networks:
       - ppiyaki-monitoring
     mem_limit: 1g
+    ports:
+      # host loopback에만 13306으로 publish. DataGrip 등 운영자 도구가
+      # ssh tunnel(ppiyaki-prod) 후 127.0.0.1:13306으로 접근.
+      # 0.0.0.0이 아닌 127.0.0.1 bind라 prod host 외부에서는 도달 불가.
+      - "127.0.0.1:13306:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 30s
-    # 외부 포트 노출 안 함. backend는 같은 ppiyaki-monitoring 네트워크에서 mysql:3306 으로 접근.
+    # backend는 같은 ppiyaki-monitoring 네트워크에서 mysql:3306 으로 직접 접근(host port 거치지 않음).
     # 데이터는 mysql-data 영속 볼륨에 보관. 외부 백업 없음 (spec db-self-hosted-migration §4 결정).
 
   prometheus:


### PR DESCRIPTION
## AS-IS
- `ppiyaki-mysql` 컨테이너는 `ppiyaki-monitoring` 네트워크 내부에만 노출.
- 운영자가 DataGrip 등으로 직접 접근하려면 별도 우회 필요 (sidecar/수동 ssh tunnel).

## TO-BE
- `mysql` 서비스에 `ports: ["127.0.0.1:13306:3306"]` 추가.
- DataGrip → SSH tunnel(ppiyaki-prod) → prod host 127.0.0.1:13306 → docker mysql:3306.

## 보안
- **127.0.0.1 bind** (0.0.0.0 X) → prod host 외부에서는 도달 불가.
- backend는 변경 없이 docker 내부 네트워크의 `mysql:3306` 그대로 사용.

## 변경 파일
- `infra/monitoring/docker-compose.yml` — mysql 서비스에 ports 5줄 추가

## Test plan
- [x] `docker compose config` 파싱 검증 통과 (`host_ip: 127.0.0.1`, `published: 13306` 확인)
- [ ] (prod 적용) `docker compose up -d mysql` 후 host `127.0.0.1:13306` listen 확인 (`ss -tln | grep 13306`)
- [ ] DataGrip → `localhost:13306` 접근 확인

## 후속 (사용자 액션)
1. PR 머지
2. prod monitoring 디렉터리에 새 docker-compose.yml scp 동기화
3. `sudo docker compose up -d mysql` (또는 `--force-recreate mysql`로 포트 적용)
4. DataGrip dataSources.xml의 `ppiyaki-prod` jdbc-url 변경 (제가 직접 편집 예정)

## 관련
- 마일스톤: #401 (DB 이전 #395 후속)

## AI 체크리스트
- [x] Feature Spec 불필요 (단일 옵션 추가)
- [x] 도메인 문서 갱신 불필요
- [x] Notion API 명세 갱신 불필요
- [ ] **보호 영역(`docker-compose*.yml`) 변경 → `needs-human-review` 라벨 부여**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 데이터베이스 서비스의 네트워크 접근 제어를 강화하여 로컬 환경에서만 연결 가능하도록 제한되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->