### PR TITLE
feat(user): Rate Limiter Redis 전환 및 초대코드 횟수 제한 추가 (#405)       

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,15 @@ CLOVA_OCR_SECRET=your-clova-ocr-secret
 OPENAI_API_KEY=your-openai-api-key
 
 # -----------------------------------------------------------------------------
+# Redis — 캐시 / Rate Limiter 저장소
+# 로컬은 docker-compose의 Redis 사용 (비밀번호 없음).
+# prod는 docker 내부 네트워크의 ppiyaki-redis 컨테이너에 접속.
+# -----------------------------------------------------------------------------
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+
+# -----------------------------------------------------------------------------
 # Management / Observability port
 # Spring Boot Actuator + Micrometer는 메인(8080)과 별도 포트로 노출.
 # backend-cd.yml은 8081을 publish하지 않으므로 prod에서 외부 접근 불가

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -90,6 +90,9 @@ jobs:
               -e OPENAI_VISION_MODEL='gpt-5.4-mini' \
               -e FCM_PROJECT_ID='${{ secrets.FCM_PROJECT_ID }}' \
               -e FCM_CREDENTIALS_JSON_BASE64='${{ secrets.FCM_CREDENTIALS_JSON_BASE64 }}' \
+              -e REDIS_HOST='ppiyaki-redis' \
+              -e REDIS_PORT='6379' \
+              -e REDIS_PASSWORD='${{ secrets.REDIS_PASSWORD }}' \
               ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
             
             echo "Cleaning up old images..."

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation platform('software.amazon.awssdk:bom:2.28.29')
     implementation 'software.amazon.awssdk:s3'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  redis: # ← 추가
+  redis:
     image: redis:7
     container_name: ppiyaki-redis-local
     restart: unless-stopped
@@ -30,6 +30,11 @@ services:
       - "6379:6379"
     volumes:
       - ppiyaki-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 volumes:
   ppiyaki-mysql-data:
   ppiyaki-redis-data:             # ← 추가

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
+  redis: # ← 추가
+    image: redis:7
+    container_name: ppiyaki-redis-local
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - ppiyaki-redis-data:/data
 volumes:
   ppiyaki-mysql-data:
+  ppiyaki-redis-data:             # ← 추가
+

--- a/docs/features/redis-infra-setup.md
+++ b/docs/features/redis-infra-setup.md
@@ -5,7 +5,7 @@ status: draft
 owner: @dohyeon
 scope: infra
 related_issues: [403]
-related_prs: [406]
+related_prs: [406, 407]
 last_reviewed: 2026-05-22
 ---
 
@@ -44,8 +44,8 @@ last_reviewed: 2026-05-22
 - `.env.example` 갱신
 
 ### 제외 (Out of Scope)
-- **DrugInfoClient / MfdsApiClient 캐시의 Redis 전환**: 후속 이슈 #404에서 진행
-- **InMemoryRateLimiter의 Redis 전환**: 후속 이슈 #405에서 진행
+- **DrugInfoClient / MfdsApiClient 캐시의 Redis 전환**: PR #408에서 진행
+- **InMemoryRateLimiter의 Redis 전환 + 초대코드 횟수 제한**: PR #407에서 진행
 - **Redis Sentinel / Cluster 구성**: 단일 인스턴스. 베타 규모에서 HA 불필요
 - **Spring Session (세션 저장소)**: JWT 기반 인증이므로 세션 저장소 불필요
 - **prod 서버 docker-compose 수정**: CD 파이프라인 변경은 별도 작업
@@ -84,11 +84,12 @@ last_reviewed: 2026-05-22
 
 ## 8) 오픈 질문
 
-| # | 질문 | 선택지 | 담당/기한 |
-|---|---|---|---|
-| Q1 | 로컬 테스트 시 embedded Redis vs docker Redis? | (a) Testcontainers로 Redis 컨테이너 기동 / (b) embedded-redis 라이브러리 / (c) docker-compose의 Redis 사용 | @dohyeon / 2026-05-23 |
-| Q2 | prod 배포 시 Redis 컨테이너를 backend-cd.yml에서 함께 관리할지, 별도 docker-compose로 분리할지 | (a) backend docker-compose에 포함 / (b) monitoring처럼 별도 compose | @dohyeon / 2026-05-23 |
+모두 해소됨 → §9 결정 로그로 이동.
 
 ## 9) 결정 로그
 
 - 2026-05-22: 초안 작성 (status=draft)
+- 2026-05-22: Q1 → (c) docker-compose의 Redis 사용. 테스트 환경에서는 Redis 없이 InMemory fallback으로 동작 / @dohyeon
+- 2026-05-22: Q2 → (a) backend docker-compose에 포함. Redis는 backend 앱이 직접 의존하는 저장소이므로 MySQL과 같이 관리 / @dohyeon
+- 2026-05-22: prod NCP 서버에 Redis 7 컨테이너 기동 완료, 비밀번호 설정 완료
+- 2026-05-24: 초대코드(invite_codes) 저장소를 MySQL → Redis로 이전하는 후속 작업 식별. 별도 이슈로 분리 예정

--- a/docs/features/redis-infra-setup.md
+++ b/docs/features/redis-infra-setup.md
@@ -1,0 +1,94 @@
+---
+feature: Redis 인프라 설정 및 Spring Boot 연동 구성
+slug: redis-infra-setup
+status: draft
+owner: @dohyeon
+scope: infra
+related_issues: [403]
+related_prs: []
+last_reviewed: 2026-05-22
+---
+
+# Redis 인프라 설정 및 Spring Boot 연동 구성
+
+## 1) 개요 (What / Why)
+프로젝트에 Redis를 도입하여 JVM 메모리 기반 캐시와 Rate Limiter를 Redis로 전환하기 위한 **기반 인프라**를 구성한다.
+
+현재 외부 API 응답 캐시(`DrugInfoClient`, `MfdsApiClient`)와 Rate Limiter(`InMemoryRateLimiter`)가 모두 `ConcurrentHashMap`으로 동작한다. 서버 재시작 시 캐시가 소실되고, 다중 인스턴스 환경에서 상태가 공유되지 않는 문제가 있다. 이 Feature Spec은 Redis 서버 자체와 Spring Boot 연동 설정만 다루며, 개별 캐시/Rate Limiter의 Redis 전환은 후속 이슈(#404, #405)에서 진행한다.
+
+## 2) 사용자 시나리오
+- (개발자) 로컬에서 `docker compose up -d`로 MySQL + Redis가 함께 기동되어 별도 설치 없이 개발 가능.
+- (운영자) prod 배포 시 Redis 컨테이너가 backend와 같은 docker network에서 동작하며, 외부 포트 노출 없이 내부 통신.
+- (개발자) `RedisTemplate` 또는 Spring Cache abstraction을 통해 Redis에 값을 저장/조회할 수 있다.
+
+## 3) 요구사항
+### 기능 요구사항
+- [ ] `build.gradle`에 `spring-boot-starter-data-redis` 의존성 추가
+- [ ] `application.yml`에 Redis 접속 설정 추가 (default 프로필: localhost:6379)
+- [ ] `application-prod.yml`에 prod Redis 접속 설정 추가 (환경변수 바인딩)
+- [ ] 로컬 `docker-compose.yml`에 Redis 7 컨테이너 추가
+- [ ] `StringRedisTemplate` 빈이 정상 주입되는지 확인하는 통합 테스트 작성
+- [ ] `.env.example`에 Redis 관련 환경변수 placeholder 추가
+
+### 비기능 요구사항
+- **보안**: prod Redis는 docker 내부 네트워크만 접근 가능 (외부 포트 노출 금지). 비밀번호 설정.
+- **관측성**: Actuator + Micrometer의 Redis 메트릭 자동 수집 활성화
+- **자원**: Redis 컨테이너 `maxmemory 256mb` + `maxmemory-policy allkeys-lru` 설정 (서버 OOM 방지)
+- **호환**: 기존 테스트(H2 기반)가 Redis 없이도 통과해야 함 (Redis 비활성 시 기존 동작 유지)
+
+## 4) 범위 / 비범위 (중요)
+### 포함
+- Redis 의존성 추가 및 Spring Boot auto-configuration 연동
+- 로컬/prod 환경 Redis 컨테이너 및 접속 설정
+- 연결 확인용 통합 테스트
+- `.env.example` 갱신
+
+### 제외 (Out of Scope)
+- **DrugInfoClient / MfdsApiClient 캐시의 Redis 전환**: 후속 이슈 #404에서 진행
+- **InMemoryRateLimiter의 Redis 전환**: 후속 이슈 #405에서 진행
+- **Redis Sentinel / Cluster 구성**: 단일 인스턴스. 베타 규모에서 HA 불필요
+- **Spring Session (세션 저장소)**: JWT 기반 인증이므로 세션 저장소 불필요
+- **prod 서버 docker-compose 수정**: CD 파이프라인 변경은 별도 작업
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+인프라 변경이며 도메인 엔티티/컨텍스트는 건드리지 않는다.
+
+### 5-2) API 엔드포인트
+변경 없음 (인프라 변경).
+
+### 5-3) 외부 연동
+- **Redis 7** (로컬: docker-compose, prod: 같은 서버의 docker 컨테이너)
+- 라이브러리: `spring-boot-starter-data-redis` (Lettuce 기본 드라이버)
+
+### 5-4) 데이터 흐름 / 시퀀스
+
+```
+[Spring Boot App]
+      │
+      ├── RedisTemplate / @Cacheable
+      │         │
+      └─────── Lettuce ──── Redis 7 (docker, port 6379 내부)
+```
+
+### 5-5) DB 마이그레이션
+없음. Redis는 별도 데이터 저장소이며 MySQL 스키마 변경 없음.
+
+## 6) 작업 분할 (예상 PR 리스트)
+- [ ] PR 1: `chore(infra): Redis 인프라 설정 및 Spring Boot 연동 구성 #403` — 의존성, 설정, docker-compose, 통합 테스트, .env.example
+
+## 7) 테스트 전략
+- **통합 테스트**: `StringRedisTemplate`으로 `SET` / `GET` / `EXPIRE` 동작 확인
+- **기존 테스트 호환**: Redis 미기동 환경(CI H2 테스트)에서 기존 테스트가 깨지지 않아야 함. `@ConditionalOnProperty` 또는 프로필 분리로 격리
+
+## 8) 오픈 질문
+
+| # | 질문 | 선택지 | 담당/기한 |
+|---|---|---|---|
+| Q1 | 로컬 테스트 시 embedded Redis vs docker Redis? | (a) Testcontainers로 Redis 컨테이너 기동 / (b) embedded-redis 라이브러리 / (c) docker-compose의 Redis 사용 | @dohyeon / 2026-05-23 |
+| Q2 | prod 배포 시 Redis 컨테이너를 backend-cd.yml에서 함께 관리할지, 별도 docker-compose로 분리할지 | (a) backend docker-compose에 포함 / (b) monitoring처럼 별도 compose | @dohyeon / 2026-05-23 |
+
+## 9) 결정 로그
+
+- 2026-05-22: 초안 작성 (status=draft)

--- a/docs/features/redis-infra-setup.md
+++ b/docs/features/redis-infra-setup.md
@@ -5,7 +5,7 @@ status: draft
 owner: @dohyeon
 scope: infra
 related_issues: [403]
-related_prs: []
+related_prs: [406]
 last_reviewed: 2026-05-22
 ---
 
@@ -64,7 +64,7 @@ last_reviewed: 2026-05-22
 
 ### 5-4) 데이터 흐름 / 시퀀스
 
-```
+```text
 [Spring Boot App]
       │
       ├── RedisTemplate / @Cacheable

--- a/src/main/java/com/ppiyaki/common/ratelimit/AttemptLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/AttemptLimiter.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.common.ratelimit;
+
+public interface AttemptLimiter {
+
+    void checkAllowed(final String key);
+
+    void recordAttempt(final String key);
+
+    void clear(final String key);
+}

--- a/src/main/java/com/ppiyaki/common/ratelimit/InMemoryAttemptLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/InMemoryAttemptLimiter.java
@@ -21,7 +21,10 @@ public class InMemoryAttemptLimiter implements AttemptLimiter {
 
     @Override
     public void recordAttempt(final String key) {
-        attempts.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+        final int newCount = attempts.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+        if (newCount > MAX_ATTEMPTS) {
+            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
     }
 
     @Override

--- a/src/main/java/com/ppiyaki/common/ratelimit/InMemoryAttemptLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/InMemoryAttemptLimiter.java
@@ -1,0 +1,31 @@
+package com.ppiyaki.common.ratelimit;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class InMemoryAttemptLimiter implements AttemptLimiter {
+
+    private static final int MAX_ATTEMPTS = 5;
+
+    private final ConcurrentHashMap<String, AtomicInteger> attempts = new ConcurrentHashMap<>();
+
+    @Override
+    public void checkAllowed(final String key) {
+        final AtomicInteger count = attempts.get(key);
+        if (count != null && count.get() >= MAX_ATTEMPTS) {
+            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
+    }
+
+    @Override
+    public void recordAttempt(final String key) {
+        attempts.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+    }
+
+    @Override
+    public void clear(final String key) {
+        attempts.remove(key);
+    }
+}

--- a/src/main/java/com/ppiyaki/common/ratelimit/InMemoryRateLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/InMemoryRateLimiter.java
@@ -5,9 +5,7 @@ import com.ppiyaki.common.exception.ErrorCode;
 import java.time.LocalDateTime;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import org.springframework.stereotype.Component;
 
-@Component
 public class InMemoryRateLimiter implements RateLimiter {
 
     private static final int MAX_ATTEMPTS_PER_MINUTE = 10;

--- a/src/main/java/com/ppiyaki/common/ratelimit/RateLimiterConfig.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/RateLimiterConfig.java
@@ -1,0 +1,38 @@
+package com.ppiyaki.common.ratelimit;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RateLimiterConfig {
+
+    @Bean
+    @Primary
+    @ConditionalOnBean(StringRedisTemplate.class)
+    public RateLimiter redisRateLimiter(final StringRedisTemplate redisTemplate) {
+        return new RedisRateLimiter(redisTemplate);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(RateLimiter.class)
+    public RateLimiter inMemoryRateLimiter() {
+        return new InMemoryRateLimiter();
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnBean(StringRedisTemplate.class)
+    public AttemptLimiter redisAttemptLimiter(final StringRedisTemplate redisTemplate) {
+        return new RedisAttemptLimiter(redisTemplate);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(AttemptLimiter.class)
+    public AttemptLimiter inMemoryAttemptLimiter() {
+        return new InMemoryAttemptLimiter();
+    }
+}

--- a/src/main/java/com/ppiyaki/common/ratelimit/RedisAttemptLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/RedisAttemptLimiter.java
@@ -1,0 +1,43 @@
+package com.ppiyaki.common.ratelimit;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import java.time.Duration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+public class RedisAttemptLimiter implements AttemptLimiter {
+
+    private static final int MAX_ATTEMPTS = 5;
+    private static final Duration TTL = Duration.ofMinutes(5);
+    private static final String KEY_PREFIX = "attempt-limit:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisAttemptLimiter(final StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void checkAllowed(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        final String value = redisTemplate.opsForValue().get(redisKey);
+        if (value != null && Integer.parseInt(value) >= MAX_ATTEMPTS) {
+            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
+    }
+
+    @Override
+    public void recordAttempt(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        final Long count = redisTemplate.opsForValue().increment(redisKey);
+        if (count != null && count == 1L) {
+            redisTemplate.expire(redisKey, TTL);
+        }
+    }
+
+    @Override
+    public void clear(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        redisTemplate.delete(redisKey);
+    }
+}

--- a/src/main/java/com/ppiyaki/common/ratelimit/RedisAttemptLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/RedisAttemptLimiter.java
@@ -3,10 +3,13 @@ package com.ppiyaki.common.ratelimit;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 public class RedisAttemptLimiter implements AttemptLimiter {
 
+    private static final Logger log = LoggerFactory.getLogger(RedisAttemptLimiter.class);
     private static final int MAX_ATTEMPTS = 5;
     private static final Duration TTL = Duration.ofMinutes(5);
     private static final String KEY_PREFIX = "attempt-limit:";
@@ -21,8 +24,15 @@ public class RedisAttemptLimiter implements AttemptLimiter {
     public void checkAllowed(final String key) {
         final String redisKey = KEY_PREFIX + key;
         final String value = redisTemplate.opsForValue().get(redisKey);
-        if (value != null && Integer.parseInt(value) >= MAX_ATTEMPTS) {
-            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        if (value != null) {
+            try {
+                if (Integer.parseInt(value) >= MAX_ATTEMPTS) {
+                    throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+                }
+            } catch (final NumberFormatException e) {
+                log.warn("Attempt limit key has invalid value: key={}, value={}", redisKey, value);
+                redisTemplate.delete(redisKey);
+            }
         }
     }
 

--- a/src/main/java/com/ppiyaki/common/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/RedisRateLimiter.java
@@ -1,0 +1,57 @@
+package com.ppiyaki.common.ratelimit;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+public class RedisRateLimiter implements RateLimiter {
+
+    private static final int MAX_ATTEMPTS_PER_MINUTE = 10;
+    private static final Duration WINDOW = Duration.ofMinutes(1);
+    private static final String KEY_PREFIX = "rate-limit:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisRateLimiter(final StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void checkAllowed(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        final long windowStart = Instant.now().minus(WINDOW).toEpochMilli();
+
+        pruneOldEntries(redisKey, windowStart);
+
+        final Long count = redisTemplate.opsForZSet().zCard(redisKey);
+        if (count != null && count >= MAX_ATTEMPTS_PER_MINUTE) {
+            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
+    }
+
+    @Override
+    public void recordFailure(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        final long now = Instant.now().toEpochMilli();
+
+        pruneOldEntries(redisKey, now - WINDOW.toMillis());
+
+        final ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        zSetOps.add(redisKey, UUID.randomUUID().toString(), now);
+        redisTemplate.expire(redisKey, WINDOW);
+    }
+
+    @Override
+    public void clearFailures(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        redisTemplate.delete(redisKey);
+    }
+
+    private void pruneOldEntries(final String redisKey, final long windowStart) {
+        redisTemplate.opsForZSet().removeRangeByScore(redisKey, 0, windowStart);
+    }
+}

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -3,6 +3,7 @@ package com.ppiyaki.user.service;
 import com.ppiyaki.common.auth.JwtProvider;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.ratelimit.AttemptLimiter;
 import com.ppiyaki.common.ratelimit.RateLimiter;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
@@ -32,6 +33,7 @@ public class CareRelationService {
     private final JwtProvider jwtProvider;
     private final AuthService authService;
     private final RateLimiter rateLimiter;
+    private final AttemptLimiter attemptLimiter;
 
     public CareRelationService(
             final CareRelationRepository careRelationRepository,
@@ -40,7 +42,8 @@ public class CareRelationService {
             final UserRepository userRepository,
             final JwtProvider jwtProvider,
             final AuthService authService,
-            final RateLimiter rateLimiter
+            final RateLimiter rateLimiter,
+            final AttemptLimiter attemptLimiter
     ) {
         this.careRelationRepository = careRelationRepository;
         this.inviteCodeRepository = inviteCodeRepository;
@@ -49,6 +52,7 @@ public class CareRelationService {
         this.jwtProvider = jwtProvider;
         this.authService = authService;
         this.rateLimiter = rateLimiter;
+        this.attemptLimiter = attemptLimiter;
     }
 
     @Transactional(readOnly = true)
@@ -86,22 +90,28 @@ public class CareRelationService {
         rateLimiter.checkAllowed(rateLimitKey);
 
         final String codeHash = InviteCode.sha256(code);
+        final String attemptKey = "code:" + codeHash;
+        attemptLimiter.checkAllowed(attemptKey);
+
         final InviteCode inviteCode = inviteCodeRepository.findByCodeHashAndUsedAtIsNull(codeHash)
                 .orElse(null);
 
         if (inviteCode == null) {
             rateLimiter.recordFailure(rateLimitKey);
+            attemptLimiter.recordAttempt(attemptKey);
             throw new BusinessException(ErrorCode.CARE_RELATION_INVITE_INVALID);
         }
 
         final LocalDateTime now = LocalDateTime.now();
         if (inviteCode.isExpired(now)) {
             rateLimiter.recordFailure(rateLimitKey);
+            attemptLimiter.recordAttempt(attemptKey);
             throw new BusinessException(ErrorCode.CARE_RELATION_INVITE_INVALID);
         }
 
         inviteCode.markUsed(now);
         rateLimiter.clearFailures(rateLimitKey);
+        attemptLimiter.clear(attemptKey);
 
         final Long seniorId = inviteCode.getSeniorId();
         final User senior = findUserById(seniorId);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,9 @@
 spring:
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,7 +3,7 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
-      password: ${REDIS_PASSWORD:}
+      password: ${REDIS_PASSWORD}
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
           options:
             model: whisper-1
             language: ko
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
   datasource:
     url: jdbc:h2:mem:ppiyaki;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,7 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
   datasource:
     url: jdbc:h2:mem:ppiyaki;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa

--- a/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
@@ -119,6 +119,8 @@ class CareRelationServiceTest {
         assertThat(response.refreshToken()).isEqualTo("refresh-token");
         assertThat(inviteCodeWithRaw.inviteCode().isUsed()).isTrue();
         verify(rateLimiter).clearFailures("code-login:127.0.0.1");
+        verify(attemptLimiter).checkAllowed("code:" + codeHash);
+        verify(attemptLimiter).clear("code:" + codeHash);
     }
 
     @Test
@@ -137,6 +139,8 @@ class CareRelationServiceTest {
                     assertThat(be.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_INVITE_INVALID);
                 });
         verify(rateLimiter).recordFailure("code-login:127.0.0.1");
+        verify(attemptLimiter).checkAllowed("code:" + InviteCode.sha256("BADCOD"));
+        verify(attemptLimiter).recordAttempt("code:" + InviteCode.sha256("BADCOD"));
     }
 
     @Test
@@ -158,6 +162,8 @@ class CareRelationServiceTest {
                     assertThat(be.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_INVITE_INVALID);
                 });
         verify(rateLimiter).recordFailure("code-login:127.0.0.1");
+        verify(attemptLimiter).checkAllowed("code:" + codeHash);
+        verify(attemptLimiter).recordAttempt("code:" + codeHash);
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import com.ppiyaki.common.auth.JwtProvider;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.ratelimit.AttemptLimiter;
 import com.ppiyaki.common.ratelimit.RateLimiter;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
@@ -54,6 +55,9 @@ class CareRelationServiceTest {
 
     @Mock
     private RateLimiter rateLimiter;
+
+    @Mock
+    private AttemptLimiter attemptLimiter;
 
     @InjectMocks
     private CareRelationService careRelationService;


### PR DESCRIPTION
                                                   
  ## AS-IS                                               
  - Rate Limiter가 JVM 메모리(ConcurrentHashMap) 기반으로
   동작 — 서버 재시작 시 초기화, 다중 인스턴스 시 우회   
  가능                                    
  - 초대코드 시도 횟수 제한 없음 — 동일 코드에 대해      
  무제한 시도 가능                                       
                                                       
  ## TO-BE                                               
  - Rate Limiter가 Redis Sorted Set 기반 Sliding Window  
  Log로 동작 — 인스턴스 간 공유, 재시작에도 유지       
  - 초대코드별 5회 시도 제한 추가 (Redis INCR + TTL 5분, 
  코드 만료와 동일)                           
  - Redis 미가용 환경(테스트/로컬)에서는 InMemory        
  fallback으로 기존 동작 유지                 
                                                         
  ## 변경 파일    
  | 파일 | 변경 내용 |                                   
  |---|---|                                   
  | `RedisRateLimiter.java` | 신규 — Sliding Window Log  
  (Sorted Set) 기반 IP rate limiter |
  | `AttemptLimiter.java` | 신규 — 코드별 횟수 제한      
  인터페이스 |                                
  | `RedisAttemptLimiter.java` | 신규 — Redis INCR 기반  
  코드당 5회 제한 (TTL 5분) |                 
  | `InMemoryAttemptLimiter.java` | 신규 — Redis 없을 때 
  fallback |
  | `RateLimiterConfig.java` | 신규 — Redis/InMemory 빈  
  자동 선택 Config |                          
  | `InMemoryRateLimiter.java` | `@Component` 제거       
  (Config에서 빈 등록으로 전환) |             
  | `CareRelationService.java` | `AttemptLimiter` 주입 + 
  codeLogin에 코드별 횟수 제한 적용 |         
  | `CareRelationServiceTest.java` | `AttemptLimiter`    
  mock 추가 |     
                                                         
  ## 관련 이슈                                
  - closes #405                                          
  - 참고: docs/features/redis-infra-setup.md
                                                         
  ## 리뷰어 참고 포인트                       
  - IP rate limit(RateLimiter)과 코드별 횟수             
  제한(AttemptLimiter)은 **이중 방어** — IP 변경 공격과  
  단일 코드 반복 시도를 각각 차단                        
  - `RateLimiterConfig`에서                              
  `@ConditionalOnBean(StringRedisTemplate.class)` +      
  `@ConditionalOnMissingBean`으로 Redis 유무에 따라 자동
  선택                                                   
  - 기존 `CareRelationServiceTest`는 Mockito mock으로    
  동작하므로 영향 없음                                 
                                                         
  ## 라벨 부여 확인                           
  - [x] `type:feat` 라벨 1개 부여 완료                   
  - [x] `scope:user` 라벨 1개 부여 완료       
  - [x] (AI 작성 시) `ai-generated` 라벨 부여 완료       
  - [ ] (보호 영역 변경 시) `needs-human-review` 라벨
  부여 완료                                              
                                          
  <details>                                              
  <summary>AI Agent 전용 체크리스트 (해당 시             
  작성)</summary>                                        
                                                         
  ## AI 작업 여부                                      
  - [ ] AI 작업 아님 (사람 작성 PR)                      
  - [x] AI 보조/생성 사용                     
                                                         
  ## 품질 게이트 체크 (AI 작성 시)            
  - [x] `./gradlew checkstyleMain spotlessCheck`         
  - [x] `./gradlew test`                                 
  - [x] 변경 범위의 회귀 가능 구간을 확인했다.           
  - [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를       
  작성했다.                                              
                                                         
  > 롤백: InMemoryRateLimiter에 @Component 복원 +        
  AttemptLimiter 관련 코드 revert. Redis 데이터는 TTL    
  만료로 자동 정리.                                      
                                                         
  ## DDD/OOP 준수 체크 (AI 작성 시)                    
  - [x] 도메인 용어가 기존 컨텍스트와 일치한다.          
  - [x] 계층 침범(Controller -> Repository 직접 호출
  등)이 없다.                                            
  - [x] 객체 역할/책임이 명확하며, 과도한 God Object를
  만들지 않았다.                                         
                                                         
  ## 보안/민감정보 체크 (AI 작성 시)                     
  - [x] 시크릿(API 키/토큰/비밀번호) 하드코딩이 없다.    
  - [x] 복약 기록/건강 프로필 등 의료정보를            
  로그/스크린샷에 노출하지 않았다.                       
  - [x] 민감정보가 필요한 경우 마스킹 처리했다.
                                                         
  ## 예외 머지 여부 (AI 작성 시)                         
  - [x] 예외 머지 아님                                   
  - [ ] 예외 머지임                                      
                                                       
  ## AI 작업 기록                                        
  - 사용한 프롬프트/지시 요약: Rate Limiter Redis 전환 + 
  초대코드 횟수 제한 추가 요청                         
  - AI가 직접 수정한 파일/범위: RedisRateLimiter,        
  AttemptLimiter, RedisAttemptLimiter,        
  InMemoryAttemptLimiter, RateLimiterConfig,             
  InMemoryRateLimiter, CareRelationService,
  CareRelationServiceTest                                
  - 사람이 수동 검증한 항목: NCP 서버 Redis 컨테이너 기동
   및 비밀번호 설정                                      
  - 잔여 리스크/추가 확인 필요사항: prod 배포 후 Redis
  연결 정상 동작 확인, 실제 rate limit 동작 검증       
                                                         
  </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Redis 캐시 및 레이트 제한 저장소 지원 추가
  * 초대 코드 기반 시도(attempt) 제한 도입으로 코드 로그인 시도 추적 강화

* **설정 변경**
  * Redis 환경 변수 추가: REDIS_HOST, REDIS_PORT, REDIS_PASSWORD
  * Docker Compose 및 프로덕션 설정에 Redis 연결 정보 반영
  * 배포 워크플로에 Redis 환경변수 전달 추가

* **문서**
  * Redis 인프라 설정 가이드 추가

* **테스트**
  * 관련 서비스 테스트에 시도 제한 동작 검증 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->