### PR TITLE
 refactor(medication): 약 정보 / DUR 캐시를       Redis로 전환 (#404)        

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,15 @@ CLOVA_OCR_SECRET=your-clova-ocr-secret
 OPENAI_API_KEY=your-openai-api-key
 
 # -----------------------------------------------------------------------------
+# Redis — 캐시 / Rate Limiter 저장소
+# 로컬은 docker-compose의 Redis 사용 (비밀번호 없음).
+# prod는 docker 내부 네트워크의 ppiyaki-redis 컨테이너에 접속.
+# -----------------------------------------------------------------------------
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+
+# -----------------------------------------------------------------------------
 # Management / Observability port
 # Spring Boot Actuator + Micrometer는 메인(8080)과 별도 포트로 노출.
 # backend-cd.yml은 8081을 publish하지 않으므로 prod에서 외부 접근 불가

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -90,6 +90,9 @@ jobs:
               -e OPENAI_VISION_MODEL='gpt-5.4-mini' \
               -e FCM_PROJECT_ID='${{ secrets.FCM_PROJECT_ID }}' \
               -e FCM_CREDENTIALS_JSON_BASE64='${{ secrets.FCM_CREDENTIALS_JSON_BASE64 }}' \
+              -e REDIS_HOST='ppiyaki-redis' \
+              -e REDIS_PORT='6379' \
+              -e REDIS_PASSWORD='${{ secrets.REDIS_PASSWORD }}' \
               ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
             
             echo "Cleaning up old images..."

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation platform('software.amazon.awssdk:bom:2.28.29')
     implementation 'software.amazon.awssdk:s3'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  redis: # ← 추가
+  redis:
     image: redis:7
     container_name: ppiyaki-redis-local
     restart: unless-stopped
@@ -30,6 +30,11 @@ services:
       - "6379:6379"
     volumes:
       - ppiyaki-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 volumes:
   ppiyaki-mysql-data:
   ppiyaki-redis-data:             # ← 추가

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
+  redis: # ← 추가
+    image: redis:7
+    container_name: ppiyaki-redis-local
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - ppiyaki-redis-data:/data
 volumes:
   ppiyaki-mysql-data:
+  ppiyaki-redis-data:             # ← 추가
+

--- a/docs/features/redis-infra-setup.md
+++ b/docs/features/redis-infra-setup.md
@@ -1,0 +1,94 @@
+---
+feature: Redis 인프라 설정 및 Spring Boot 연동 구성
+slug: redis-infra-setup
+status: draft
+owner: @dohyeon
+scope: infra
+related_issues: [403]
+related_prs: []
+last_reviewed: 2026-05-22
+---
+
+# Redis 인프라 설정 및 Spring Boot 연동 구성
+
+## 1) 개요 (What / Why)
+프로젝트에 Redis를 도입하여 JVM 메모리 기반 캐시와 Rate Limiter를 Redis로 전환하기 위한 **기반 인프라**를 구성한다.
+
+현재 외부 API 응답 캐시(`DrugInfoClient`, `MfdsApiClient`)와 Rate Limiter(`InMemoryRateLimiter`)가 모두 `ConcurrentHashMap`으로 동작한다. 서버 재시작 시 캐시가 소실되고, 다중 인스턴스 환경에서 상태가 공유되지 않는 문제가 있다. 이 Feature Spec은 Redis 서버 자체와 Spring Boot 연동 설정만 다루며, 개별 캐시/Rate Limiter의 Redis 전환은 후속 이슈(#404, #405)에서 진행한다.
+
+## 2) 사용자 시나리오
+- (개발자) 로컬에서 `docker compose up -d`로 MySQL + Redis가 함께 기동되어 별도 설치 없이 개발 가능.
+- (운영자) prod 배포 시 Redis 컨테이너가 backend와 같은 docker network에서 동작하며, 외부 포트 노출 없이 내부 통신.
+- (개발자) `RedisTemplate` 또는 Spring Cache abstraction을 통해 Redis에 값을 저장/조회할 수 있다.
+
+## 3) 요구사항
+### 기능 요구사항
+- [ ] `build.gradle`에 `spring-boot-starter-data-redis` 의존성 추가
+- [ ] `application.yml`에 Redis 접속 설정 추가 (default 프로필: localhost:6379)
+- [ ] `application-prod.yml`에 prod Redis 접속 설정 추가 (환경변수 바인딩)
+- [ ] 로컬 `docker-compose.yml`에 Redis 7 컨테이너 추가
+- [ ] `StringRedisTemplate` 빈이 정상 주입되는지 확인하는 통합 테스트 작성
+- [ ] `.env.example`에 Redis 관련 환경변수 placeholder 추가
+
+### 비기능 요구사항
+- **보안**: prod Redis는 docker 내부 네트워크만 접근 가능 (외부 포트 노출 금지). 비밀번호 설정.
+- **관측성**: Actuator + Micrometer의 Redis 메트릭 자동 수집 활성화
+- **자원**: Redis 컨테이너 `maxmemory 256mb` + `maxmemory-policy allkeys-lru` 설정 (서버 OOM 방지)
+- **호환**: 기존 테스트(H2 기반)가 Redis 없이도 통과해야 함 (Redis 비활성 시 기존 동작 유지)
+
+## 4) 범위 / 비범위 (중요)
+### 포함
+- Redis 의존성 추가 및 Spring Boot auto-configuration 연동
+- 로컬/prod 환경 Redis 컨테이너 및 접속 설정
+- 연결 확인용 통합 테스트
+- `.env.example` 갱신
+
+### 제외 (Out of Scope)
+- **DrugInfoClient / MfdsApiClient 캐시의 Redis 전환**: 후속 이슈 #404에서 진행
+- **InMemoryRateLimiter의 Redis 전환**: 후속 이슈 #405에서 진행
+- **Redis Sentinel / Cluster 구성**: 단일 인스턴스. 베타 규모에서 HA 불필요
+- **Spring Session (세션 저장소)**: JWT 기반 인증이므로 세션 저장소 불필요
+- **prod 서버 docker-compose 수정**: CD 파이프라인 변경은 별도 작업
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+인프라 변경이며 도메인 엔티티/컨텍스트는 건드리지 않는다.
+
+### 5-2) API 엔드포인트
+변경 없음 (인프라 변경).
+
+### 5-3) 외부 연동
+- **Redis 7** (로컬: docker-compose, prod: 같은 서버의 docker 컨테이너)
+- 라이브러리: `spring-boot-starter-data-redis` (Lettuce 기본 드라이버)
+
+### 5-4) 데이터 흐름 / 시퀀스
+
+```
+[Spring Boot App]
+      │
+      ├── RedisTemplate / @Cacheable
+      │         │
+      └─────── Lettuce ──── Redis 7 (docker, port 6379 내부)
+```
+
+### 5-5) DB 마이그레이션
+없음. Redis는 별도 데이터 저장소이며 MySQL 스키마 변경 없음.
+
+## 6) 작업 분할 (예상 PR 리스트)
+- [ ] PR 1: `chore(infra): Redis 인프라 설정 및 Spring Boot 연동 구성 #403` — 의존성, 설정, docker-compose, 통합 테스트, .env.example
+
+## 7) 테스트 전략
+- **통합 테스트**: `StringRedisTemplate`으로 `SET` / `GET` / `EXPIRE` 동작 확인
+- **기존 테스트 호환**: Redis 미기동 환경(CI H2 테스트)에서 기존 테스트가 깨지지 않아야 함. `@ConditionalOnProperty` 또는 프로필 분리로 격리
+
+## 8) 오픈 질문
+
+| # | 질문 | 선택지 | 담당/기한 |
+|---|---|---|---|
+| Q1 | 로컬 테스트 시 embedded Redis vs docker Redis? | (a) Testcontainers로 Redis 컨테이너 기동 / (b) embedded-redis 라이브러리 / (c) docker-compose의 Redis 사용 | @dohyeon / 2026-05-23 |
+| Q2 | prod 배포 시 Redis 컨테이너를 backend-cd.yml에서 함께 관리할지, 별도 docker-compose로 분리할지 | (a) backend docker-compose에 포함 / (b) monitoring처럼 별도 compose | @dohyeon / 2026-05-23 |
+
+## 9) 결정 로그
+
+- 2026-05-22: 초안 작성 (status=draft)

--- a/docs/features/redis-infra-setup.md
+++ b/docs/features/redis-infra-setup.md
@@ -5,7 +5,7 @@ status: draft
 owner: @dohyeon
 scope: infra
 related_issues: [403]
-related_prs: []
+related_prs: [406]
 last_reviewed: 2026-05-22
 ---
 
@@ -64,7 +64,7 @@ last_reviewed: 2026-05-22
 
 ### 5-4) 데이터 흐름 / 시퀀스
 
-```
+```text
 [Spring Boot App]
       │
       ├── RedisTemplate / @Cacheable

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoCache.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoCache.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.infrastructure.druginfo;
+
+import java.util.Optional;
+
+public interface DrugInfoCache {
+
+    Optional<DrugInfoResponse> get(String itemName);
+
+    void put(String itemName, Optional<DrugInfoResponse> response);
+}

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoCacheConfig.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoCacheConfig.java
@@ -1,0 +1,29 @@
+package com.ppiyaki.infrastructure.druginfo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class DrugInfoCacheConfig {
+
+    @Bean
+    @Primary
+    @ConditionalOnBean(StringRedisTemplate.class)
+    public DrugInfoCache redisDrugInfoCache(
+            final StringRedisTemplate redisTemplate,
+            final ObjectMapper objectMapper
+    ) {
+        return new RedisDrugInfoCache(redisTemplate, objectMapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(DrugInfoCache.class)
+    public DrugInfoCache inMemoryDrugInfoCache() {
+        return new InMemoryDrugInfoCache();
+    }
+}

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoClient.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoClient.java
@@ -13,10 +13,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.Instant;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -30,7 +27,6 @@ public class DrugInfoClient {
 
     private static final Logger log = LoggerFactory.getLogger(DrugInfoClient.class);
     private static final String API_URL = "https://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList";
-    private static final Duration CACHE_TTL = Duration.ofHours(24);
 
     private static final String API = "drug_info";
     private static final String OPERATION = "search";
@@ -38,7 +34,7 @@ public class DrugInfoClient {
     private final String serviceKey;
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
-    private final Map<String, CachedDrugInfo> cache = new ConcurrentHashMap<>();
+    private final DrugInfoCache cache;
     private final MeterRegistry meterRegistry;
     private final Counter cacheHitCounter;
     private final Counter cacheMissCounter;
@@ -47,10 +43,12 @@ public class DrugInfoClient {
             final MfdsApiProperties properties,
             final RestClient.Builder restClientBuilder,
             final ObjectMapper objectMapper,
+            final DrugInfoCache cache,
             final MeterRegistry meterRegistry
     ) {
         this.serviceKey = properties.serviceKey();
         this.objectMapper = objectMapper;
+        this.cache = cache;
         this.meterRegistry = meterRegistry;
 
         final SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
@@ -70,11 +68,10 @@ public class DrugInfoClient {
     }
 
     public Optional<DrugInfoResponse> search(final String itemName) {
-        final String cacheKey = itemName.strip().toLowerCase();
-        final CachedDrugInfo cached = cache.get(cacheKey);
-        if (cached != null && cached.expiresAt().isAfter(Instant.now())) {
+        final Optional<DrugInfoResponse> cached = cache.get(itemName);
+        if (cached != null) {
             cacheHitCounter.increment();
-            return cached.response();
+            return cached;
         }
 
         cacheMissCounter.increment();
@@ -93,7 +90,7 @@ public class DrugInfoClient {
                     .body(String.class);
 
             final Optional<DrugInfoResponse> result = parseResponse(responseBody);
-            cache.put(cacheKey, new CachedDrugInfo(result, Instant.now().plus(CACHE_TTL)));
+            cache.put(itemName, result);
             ExternalApiMetrics.record(meterRegistry, API, OPERATION, ExternalApiMetrics.RESULT_SUCCESS, sample);
             return result;
 
@@ -142,11 +139,5 @@ public class DrugInfoClient {
             return null;
         }
         return text.replaceAll("<[^>]+>", "").strip();
-    }
-
-    private record CachedDrugInfo(
-            Optional<DrugInfoResponse> response,
-            Instant expiresAt
-    ) {
     }
 }

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/InMemoryDrugInfoCache.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/InMemoryDrugInfoCache.java
@@ -1,0 +1,40 @@
+package com.ppiyaki.infrastructure.druginfo;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryDrugInfoCache implements DrugInfoCache {
+
+    private static final Duration TTL = Duration.ofHours(24);
+
+    private final Map<String, CachedDrugInfo> cache = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<DrugInfoResponse> get(final String itemName) {
+        final String key = itemName.strip().toLowerCase();
+        final CachedDrugInfo cached = cache.get(key);
+        if (cached == null) {
+            return null;
+        }
+        if (cached.expiresAt().isBefore(Instant.now())) {
+            cache.remove(key);
+            return null;
+        }
+        return cached.response();
+    }
+
+    @Override
+    public void put(final String itemName, final Optional<DrugInfoResponse> response) {
+        final String key = itemName.strip().toLowerCase();
+        cache.put(key, new CachedDrugInfo(response, Instant.now().plus(TTL)));
+    }
+
+    private record CachedDrugInfo(
+            Optional<DrugInfoResponse> response,
+            Instant expiresAt
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/RedisDrugInfoCache.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/RedisDrugInfoCache.java
@@ -1,0 +1,64 @@
+package com.ppiyaki.infrastructure.druginfo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+public class RedisDrugInfoCache implements DrugInfoCache {
+
+    private static final Logger log = LoggerFactory.getLogger(RedisDrugInfoCache.class);
+    private static final Duration TTL = Duration.ofHours(24);
+    private static final String KEY_PREFIX = "drug-info:";
+    private static final String EMPTY_MARKER = "__EMPTY__";
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public RedisDrugInfoCache(
+            final StringRedisTemplate redisTemplate,
+            final ObjectMapper objectMapper
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Optional<DrugInfoResponse> get(final String itemName) {
+        final String redisKey = buildKey(itemName);
+        final String json = redisTemplate.opsForValue().get(redisKey);
+        if (json == null) {
+            return null;
+        }
+        if (EMPTY_MARKER.equals(json)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, DrugInfoResponse.class));
+        } catch (final JsonProcessingException e) {
+            log.warn("DrugInfo cache deserialize failed: key={}, error={}", redisKey, e.getMessage());
+            redisTemplate.delete(redisKey);
+            return null;
+        }
+    }
+
+    @Override
+    public void put(final String itemName, final Optional<DrugInfoResponse> response) {
+        final String redisKey = buildKey(itemName);
+        try {
+            final String json = response.isPresent()
+                    ? objectMapper.writeValueAsString(response.get())
+                    : EMPTY_MARKER;
+            redisTemplate.opsForValue().set(redisKey, json, TTL);
+        } catch (final JsonProcessingException e) {
+            log.warn("DrugInfo cache serialize failed: key={}, error={}", redisKey, e.getMessage());
+        }
+    }
+
+    private String buildKey(final String itemName) {
+        return KEY_PREFIX + itemName.strip().toLowerCase();
+    }
+}

--- a/src/main/java/com/ppiyaki/infrastructure/mfds/InMemoryMfdsResponseCache.java
+++ b/src/main/java/com/ppiyaki/infrastructure/mfds/InMemoryMfdsResponseCache.java
@@ -5,11 +5,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.stereotype.Component;
 
-@Component
-@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
 public class InMemoryMfdsResponseCache implements MfdsResponseCache {
 
     private static final Duration TTL = Duration.ofHours(24);

--- a/src/main/java/com/ppiyaki/infrastructure/mfds/MfdsResponseCacheConfig.java
+++ b/src/main/java/com/ppiyaki/infrastructure/mfds/MfdsResponseCacheConfig.java
@@ -1,0 +1,29 @@
+package com.ppiyaki.infrastructure.mfds;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class MfdsResponseCacheConfig {
+
+    @Bean
+    @Primary
+    @ConditionalOnBean(StringRedisTemplate.class)
+    public MfdsResponseCache redisMfdsResponseCache(
+            final StringRedisTemplate redisTemplate,
+            final ObjectMapper objectMapper
+    ) {
+        return new RedisMfdsResponseCache(redisTemplate, objectMapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(MfdsResponseCache.class)
+    public MfdsResponseCache inMemoryMfdsResponseCache() {
+        return new InMemoryMfdsResponseCache();
+    }
+}

--- a/src/main/java/com/ppiyaki/infrastructure/mfds/RedisMfdsResponseCache.java
+++ b/src/main/java/com/ppiyaki/infrastructure/mfds/RedisMfdsResponseCache.java
@@ -1,0 +1,63 @@
+package com.ppiyaki.infrastructure.mfds;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+public class RedisMfdsResponseCache implements MfdsResponseCache {
+
+    private static final Logger log = LoggerFactory.getLogger(RedisMfdsResponseCache.class);
+    private static final Duration TTL = Duration.ofHours(24);
+    private static final String KEY_PREFIX = "mfds-cache:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public RedisMfdsResponseCache(
+            final StringRedisTemplate redisTemplate,
+            final ObjectMapper objectMapper
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Optional<CachedMfdsResponse> get(final String operation, final String queryKey) {
+        final String redisKey = buildKey(operation, queryKey);
+        final String json = redisTemplate.opsForValue().get(redisKey);
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, CachedMfdsResponse.class));
+        } catch (final JsonProcessingException e) {
+            log.warn("MFDS cache deserialize failed: key={}, error={}", redisKey, e.getMessage());
+            redisTemplate.delete(redisKey);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void put(final String operation, final String queryKey, final CachedMfdsResponse response) {
+        final String redisKey = buildKey(operation, queryKey);
+        try {
+            final String json = objectMapper.writeValueAsString(response);
+            redisTemplate.opsForValue().set(redisKey, json, TTL);
+        } catch (final JsonProcessingException e) {
+            log.warn("MFDS cache serialize failed: key={}, error={}", redisKey, e.getMessage());
+        }
+    }
+
+    @Override
+    public void invalidate(final String operation, final String queryKey) {
+        redisTemplate.delete(buildKey(operation, queryKey));
+    }
+
+    private String buildKey(final String operation, final String queryKey) {
+        return KEY_PREFIX + operation + ":" + queryKey;
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,9 @@
 spring:
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,7 +3,7 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
-      password: ${REDIS_PASSWORD:}
+      password: ${REDIS_PASSWORD}
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
           options:
             model: whisper-1
             language: ko
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
   datasource:
     url: jdbc:h2:mem:ppiyaki;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,7 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
   datasource:
     url: jdbc:h2:mem:ppiyaki;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa


### PR DESCRIPTION
                            
                                                         
  ## AS-IS                                               
  - DrugInfoClient: 클래스 내부 private                  
  ConcurrentHashMap으로 약 정보 캐시 — 인터페이스 없이 
  강결합                                                 
  - MfdsApiClient:
  InMemoryMfdsResponseCache(ConcurrentHashMap)로 DUR 결과
   캐시                                   
  - 둘 다 서버 재시작 시 캐시 소실, 다중 인스턴스 시 공유
   불가                                                  
                                                       
  ## TO-BE                                               
  - DrugInfoClient: DrugInfoCache 인터페이스 분리 +      
  RedisDrugInfoCache 구현 (TTL 24h)                    
  - MfdsApiClient: RedisMfdsResponseCache 구현 (TTL 24h) 
  - Redis 미가용 환경(테스트/로컬)에서는 InMemory
  fallback 자동 선택                                     
  - 기존 Micrometer 캐시                  
  메트릭(ppiyaki.cache.hits/misses) 유지                 
                                                         
  ## 변경 파일                                           
  | 파일 | 변경 내용 |                                   
  |---|---|                                            
  | `DrugInfoCache.java` | 신규 — 약 정보 캐시 인터페이스
   |                                          
  | `RedisDrugInfoCache.java` | 신규 — Redis JSON 캐시   
  (TTL 24h, empty 결과도 캐시) |              
  | `InMemoryDrugInfoCache.java` | 신규 — Redis 없을 때  
  fallback |      
  | `DrugInfoCacheConfig.java` | 신규 — Redis/InMemory 빈
   자동 선택 |                                
  | `DrugInfoClient.java` | 내부 HashMap + CachedDrugInfo
   제거 → DrugInfoCache 주입 |                
  | `RedisMfdsResponseCache.java` | 신규 — Redis JSON    
  캐시 (TTL 24h) |                            
  | `MfdsResponseCacheConfig.java` | 신규 —              
  Redis/InMemory 빈 자동 선택 |
  | `InMemoryMfdsResponseCache.java` | `@Component` 제거 
  (Config에서 관리) |                         
                                                         
  ## 관련 이슈    
  - closes #404                                          
  - 참고: docs/features/redis-infra-setup.md
                                                         
  ## 리뷰어 참고 포인트                       
  - `DrugInfoCache.get()`은 cache miss 시 `null` 반환, 
  결과 없음 캐시 시 `Optional.empty()` 반환 — `null`과   
  empty를 구분하여 "결과 없음"도 24h 캐시 (불필요한 API  
  재호출 방지)                                           
  - Redis 직렬화는 Jackson ObjectMapper 사용.            
  `CachedMfdsResponse`는 record라 별도 설정 불필요     
  - `DrugInfoCacheConfig`와 `MfdsResponseCacheConfig`는  
  동일 패턴 — `@Primary` +                    
  `@ConditionalOnBean`/`@ConditionalOnMissingBean`       
   
  ## 라벨 부여 확인                                      
  - [x] `type:refactor` 라벨 1개 부여 완료
  - [x] `scope:medication` 라벨 1개 부여 완료            
  - [x] (AI 작성 시) `ai-generated` 라벨 부여 완료       
  - [ ] (보호 영역 변경 시) `needs-human-review` 라벨  
  부여 완료                                              
                                                         
  <details>                                              
  <summary>AI Agent 전용 체크리스트 (해당 시             
  작성)</summary>                                        
                                                         
  ## AI 작업 여부                                      
  - [ ] AI 작업 아님 (사람 작성 PR)                      
  - [x] AI 보조/생성 사용                     
                                                         
  ## 품질 게이트 체크 (AI 작성 시)            
  - [x] `./gradlew checkstyleMain spotlessCheck`         
  - [x] `./gradlew test`                                 
  - [x] 변경 범위의 회귀 가능 구간을 확인했다.           
  - [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를       
  작성했다.                                              
                                                       
  > 롤백: InMemoryMfdsResponseCache에 @Component 복원 +  
  DrugInfoClient에 내부 HashMap 캐시 복원. Redis 캐시    
  데이터는 TTL 만료로 자동 정리.                         
                                                         
  ## DDD/OOP 준수 체크 (AI 작성 시)                    
  - [x] 도메인 용어가 기존 컨텍스트와 일치한다.          
  - [x] 계층 침범(Controller -> Repository 직접 호출
  등)이 없다.                                            
  - [x] 객체 역할/책임이 명확하며, 과도한 God Object를
  만들지 않았다.                                         
                                                         
  ## 보안/민감정보 체크 (AI 작성 시)                     
  - [x] 시크릿(API 키/토큰/비밀번호) 하드코딩이 없다.    
  - [x] 복약 기록/건강 프로필 등 의료정보를            
  로그/스크린샷에 노출하지 않았다.                       
  - [x] 민감정보가 필요한 경우 마스킹 처리했다.
                                                         
  ## 예외 머지 여부 (AI 작성 시)                         
  - [x] 예외 머지 아님                                   
  - [ ] 예외 머지임                                      
                                                         
  ## AI 작업 기록                                      
  - 사용한 프롬프트/지시 요약: 약 정보(DrugInfoClient) / 
  DUR(MfdsApiClient) 캐시를 Redis로 전환 요청 
  - AI가 직접 수정한 파일/범위: DrugInfoCache,           
  RedisDrugInfoCache, InMemoryDrugInfoCache,  
  DrugInfoCacheConfig, DrugInfoClient,                   
  RedisMfdsResponseCache, MfdsResponseCacheConfig,
  InMemoryMfdsResponseCache                              
  - 사람이 수동 검증한 항목: NCP 서버 Redis 컨테이너 기동
   확인 (이전 PR에서 완료)                               
  - 잔여 리스크/추가 확인 필요사항: prod 배포 후 캐시
  hit/miss 메트릭으로 Redis 정상 동작 확인             
                                                         
  </details>
                                                         