### PR TITLE
feat(medication): 복약 지연 알림 슬롯 단위 묶음 발송 (#409)

### DIFF
--- a/src/main/java/com/ppiyaki/notification/Notification.java
+++ b/src/main/java/com/ppiyaki/notification/Notification.java
@@ -115,8 +115,7 @@ public class Notification extends BaseTimeEntity {
             final String title,
             final String body,
             final LocalDate targetDate,
-            final String mealSlot,
-            final Long scheduleId
+            final String mealSlot
     ) {
         return new Notification(
                 caregiverId,
@@ -127,7 +126,7 @@ public class Notification extends BaseTimeEntity {
                 null,
                 targetDate,
                 mealSlot,
-                scheduleId
+                null
         );
     }
 

--- a/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
@@ -70,6 +70,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             final Long scheduleId
     );
 
+    boolean existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot(
+            final Long userId,
+            final NotificationCategory category,
+            final Long seniorId,
+            final java.time.LocalDate targetDate,
+            final String mealSlot
+    );
+
     java.util.Optional<Notification> findFirstByUserIdAndCategoryAndSeniorIdOrderByCreatedAtDesc(
             final Long userId,
             final NotificationCategory category,

--- a/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
@@ -26,10 +26,12 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -109,6 +111,15 @@ public class MedicationDelayDispatcher {
                     takenScheduleIds.add(logRow.getScheduleId());
                 }
             }
+            final List<MedicationSchedule> unsentSchedules = new ArrayList<>();
+            for (final MedicationSchedule schedule : slotSchedules) {
+                if (!takenScheduleIds.contains(schedule.getId())) {
+                    unsentSchedules.add(schedule);
+                }
+            }
+            if (unsentSchedules.isEmpty()) {
+                continue;
+            }
 
             for (final CareRelation relation : relations) {
                 final Long caregiverId = relation.getCaregiverId();
@@ -123,18 +134,12 @@ public class MedicationDelayDispatcher {
                 if (now.isBefore(mealDateTime.plusMinutes(thresholdMinutes))) {
                     continue;
                 }
-                for (final MedicationSchedule schedule : slotSchedules) {
-                    if (takenScheduleIds.contains(schedule.getId())) {
-                        continue;
-                    }
-                    if (notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
-                            caregiverId, NotificationCategory.MEDICATION_DELAY, senior.getId(), today,
-                            schedule.getId())) {
-                        continue;
-                    }
-                    sendDelayNotification(caregiverId, senior, slot, today, schedule, thresholdMinutes);
-                    dispatched++;
+                if (notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot(
+                        caregiverId, NotificationCategory.MEDICATION_DELAY, senior.getId(), today, slot.name())) {
+                    continue;
                 }
+                sendDelayNotification(caregiverId, senior, slot, today, unsentSchedules, thresholdMinutes);
+                dispatched++;
             }
         }
         return dispatched;
@@ -145,21 +150,30 @@ public class MedicationDelayDispatcher {
             final User senior,
             final MealSlot slot,
             final LocalDate today,
-            final MedicationSchedule schedule,
+            final List<MedicationSchedule> schedules,
             final long thresholdMinutes
     ) {
         final String slotLabel = SLOT_LABELS.getOrDefault(slot, slot.name());
         final String title = "복약 지연 알림";
         final String seniorName = senior.getNickname() == null ? "" : senior.getNickname();
-        final String medicineLabel = resolveMedicineLabel(schedule);
-        final String body = String.format(
-                "%s 어르신이 %s에 %s을 아직 복용하지 않았어요. (%d분 경과)",
-                seniorName, slotLabel, medicineLabel, thresholdMinutes);
+        final StringBuilder bodyBuilder = new StringBuilder();
+        bodyBuilder.append(String.format(
+                "%s 어르신이 %s에 약 %d개를 아직 복용하지 않았어요. (%d분 경과)",
+                seniorName, slotLabel, schedules.size(), thresholdMinutes));
+        for (final MedicationSchedule schedule : schedules) {
+            bodyBuilder.append("\n• ").append(resolveMedicineLabel(schedule));
+        }
+        final String body = bodyBuilder.toString();
+        final String scheduleIdsJson = schedules.stream()
+                .map(MedicationSchedule::getId)
+                .map(String::valueOf)
+                .collect(Collectors.joining(",", "[", "]"));
+
         final Notification saved = notificationRepository.save(
                 Notification.createForMedicationDelay(
-                        caregiverId, senior.getId(), title, body, today, slot.name(), schedule.getId()));
-        log.info("MEDICATION_DELAY notification created (id={}, caregiver={}, senior={}, slot={}, schedule={})",
-                saved.getId(), caregiverId, senior.getId(), slot, schedule.getId());
+                        caregiverId, senior.getId(), title, body, today, slot.name()));
+        log.info("MEDICATION_DELAY notification created (id={}, caregiver={}, senior={}, slot={}, scheduleCount={})",
+                saved.getId(), caregiverId, senior.getId(), slot, schedules.size());
 
         final List<DeviceToken> tokens = deviceTokenRepository.findByUserIdAndIsActiveTrue(caregiverId);
         for (final DeviceToken token : tokens) {
@@ -167,7 +181,7 @@ public class MedicationDelayDispatcher {
                     new PushPayload(title, body, Map.of(
                             "category", "MEDICATION_DELAY",
                             "seniorId", String.valueOf(senior.getId()),
-                            "scheduleId", String.valueOf(schedule.getId()),
+                            "scheduleIds", scheduleIdsJson,
                             "mealSlot", slot.name()
                     )));
             if (result.tokenInvalid()) {

--- a/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
@@ -3,17 +3,26 @@ package com.ppiyaki.notification.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.ppiyaki.infrastructure.messaging.fcm.PushPayload;
+import com.ppiyaki.infrastructure.messaging.fcm.PushSendResult;
 import com.ppiyaki.infrastructure.messaging.fcm.PushSender;
+import com.ppiyaki.medication.domain.LogStatus;
 import com.ppiyaki.medication.domain.MealSlot;
+import com.ppiyaki.medication.domain.MedicationLog;
 import com.ppiyaki.medication.domain.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.notification.DeviceToken;
 import com.ppiyaki.notification.Notification;
 import com.ppiyaki.notification.repository.DeviceTokenRepository;
 import com.ppiyaki.notification.repository.NotificationRepository;
@@ -43,7 +52,7 @@ import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@DisplayName("MedicationDelayDispatcher 메시지 빌더")
+@DisplayName("MedicationDelayDispatcher 슬롯 단위 묶음 발송")
 class MedicationDelayDispatcherTest {
 
     @Mock
@@ -77,88 +86,171 @@ class MedicationDelayDispatcherTest {
     private static final LocalDate TODAY = LocalDate.of(2026, 5, 13);
 
     @Test
-    @DisplayName("발송 메시지 본문에 약 이름 + 복용량 포함 (issue #345)")
-    void body_includes_medicine_name_and_dosage() throws Exception {
-        givenSenior();
+    @DisplayName("미인증 약 1개도 묶음 포맷으로 발송 (issue #409)")
+    void single_unsent_uses_grouped_format() throws Exception {
         givenCareRelation();
         givenSettingsDefault();
         final MedicationSchedule schedule = buildSchedule(46L, 100L, "1정");
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
-                .thenReturn(List.of(schedule));
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
-                .thenReturn(List.of());
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
-                .thenReturn(List.of());
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(schedule));
+        givenEmptyOtherSlots();
         when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
         when(medicineRepository.findById(100L)).thenReturn(Optional.of(buildMedicine(100L, "록스펜씨알정")));
-        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
-                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        givenNoExistingDelayNotification();
         when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
         when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
 
-        dispatcher.dispatchForSenior(seniorUser(), TODAY);
+        final int dispatched = dispatcher.dispatchForSenior(seniorUser(), TODAY);
 
+        assertThat(dispatched).isEqualTo(1);
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
-        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
-        final Notification saved = captor.getValue();
-        assertThat(saved.getBody())
-                .isEqualTo("김철수 어르신이 아침에 록스펜씨알정 1정을 아직 복용하지 않았어요. (60분 경과)");
+        verify(notificationRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getBody())
+                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정 1정");
     }
 
     @Test
-    @DisplayName("medicine 조회 실패 시 fallback \"약\"")
+    @DisplayName("medicine 조회 실패 시 fallback \"약\" + 묶음 포맷")
     void body_fallback_when_medicine_not_found() throws Exception {
-        givenSenior();
         givenCareRelation();
         givenSettingsDefault();
         final MedicationSchedule schedule = buildSchedule(46L, 999L, "2캡슐");
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
-                .thenReturn(List.of(schedule));
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
-                .thenReturn(List.of());
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
-                .thenReturn(List.of());
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(schedule));
+        givenEmptyOtherSlots();
         when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
         when(medicineRepository.findById(999L)).thenReturn(Optional.empty());
-        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
-                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        givenNoExistingDelayNotification();
         when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
         when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
 
         dispatcher.dispatchForSenior(seniorUser(), TODAY);
 
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
-        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
+        verify(notificationRepository).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 2캡슐을 아직 복용하지 않았어요. (60분 경과)");
+                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 약 2캡슐");
     }
 
     @Test
     @DisplayName("dosage가 null이면 약 이름만 표시")
     void body_omits_dosage_when_null() throws Exception {
-        givenSenior();
         givenCareRelation();
         givenSettingsDefault();
         final MedicationSchedule schedule = buildSchedule(46L, 100L, null);
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
-                .thenReturn(List.of(schedule));
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
-                .thenReturn(List.of());
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
-                .thenReturn(List.of());
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(schedule));
+        givenEmptyOtherSlots();
         when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
         when(medicineRepository.findById(100L)).thenReturn(Optional.of(buildMedicine(100L, "록스펜씨알정")));
-        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
-                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        givenNoExistingDelayNotification();
         when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
         when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
 
         dispatcher.dispatchForSenior(seniorUser(), TODAY);
 
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
-        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
+        verify(notificationRepository).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 록스펜씨알정을 아직 복용하지 않았어요. (60분 경과)");
+                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정");
+    }
+
+    @Test
+    @DisplayName("한 슬롯 미인증 3개 → 알림 1건 묶음 발송 + payload scheduleIds JSON 배열")
+    void groups_multiple_unsent_into_single_notification() throws Exception {
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule s1 = buildScheduleWithId(101L, 1001L, "1정");
+        final MedicationSchedule s2 = buildScheduleWithId(102L, 1002L, "2캡슐");
+        final MedicationSchedule s3 = buildScheduleWithId(103L, 1003L, null);
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(s1, s2, s3));
+        givenEmptyOtherSlots();
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
+        when(medicineRepository.findById(1001L)).thenReturn(Optional.of(buildMedicine(1001L, "타이레놀500mg")));
+        when(medicineRepository.findById(1002L)).thenReturn(Optional.of(buildMedicine(1002L, "비타민C")));
+        when(medicineRepository.findById(1003L)).thenReturn(Optional.of(buildMedicine(1003L, "위장약")));
+        givenNoExistingDelayNotification();
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID))
+                .thenReturn(List.of(buildDeviceToken("token-xyz")));
+        when(pushSender.send(anyString(), any(PushPayload.class)))
+                .thenReturn(new PushSendResult(true, false, null));
+
+        final int dispatched = dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        assertThat(dispatched).isEqualTo(1);
+        final ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository, times(1)).save(notificationCaptor.capture());
+        assertThat(notificationCaptor.getValue().getBody())
+                .isEqualTo("김철수 어르신이 아침에 약 3개를 아직 복용하지 않았어요. (60분 경과)"
+                        + "\n• 타이레놀500mg 1정"
+                        + "\n• 비타민C 2캡슐"
+                        + "\n• 위장약");
+        assertThat(notificationCaptor.getValue().getScheduleId()).isNull();
+
+        final ArgumentCaptor<PushPayload> payloadCaptor = ArgumentCaptor.forClass(PushPayload.class);
+        verify(pushSender, times(1)).send(eq("token-xyz"), payloadCaptor.capture());
+        assertThat(payloadCaptor.getValue().data())
+                .containsEntry("category", "MEDICATION_DELAY")
+                .containsEntry("seniorId", String.valueOf(SENIOR_ID))
+                .containsEntry("mealSlot", MealSlot.BREAKFAST.name())
+                .containsEntry("scheduleIds", "[101,102,103]");
+    }
+
+    @Test
+    @DisplayName("일부만 인증된 경우 미인증 schedule만 본문에 포함")
+    void excludes_taken_schedules_from_body() throws Exception {
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule s1 = buildScheduleWithId(101L, 1001L, "1정");
+        final MedicationSchedule s2 = buildScheduleWithId(102L, 1002L, "2캡슐");
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(s1, s2));
+        givenEmptyOtherSlots();
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY))
+                .thenReturn(List.of(buildTakenLog(101L)));
+        when(medicineRepository.findById(1002L)).thenReturn(Optional.of(buildMedicine(1002L, "비타민C")));
+        givenNoExistingDelayNotification();
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
+
+        dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getBody())
+                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 비타민C 2캡슐");
+    }
+
+    @Test
+    @DisplayName("슬롯의 모든 schedule이 인증된 경우 알림 발송 없음")
+    void no_notification_when_all_taken() throws Exception {
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule s1 = buildScheduleWithId(101L, 1001L, "1정");
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(s1));
+        givenEmptyOtherSlots();
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY))
+                .thenReturn(List.of(buildTakenLog(101L)));
+
+        final int dispatched = dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        assertThat(dispatched).isZero();
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("같은 slot+date에 이미 발송된 경우 재발송 안 함 (멱등)")
+    void idempotent_per_slot_and_date() throws Exception {
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule s1 = buildScheduleWithId(101L, 1001L, "1정");
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(s1));
+        givenEmptyOtherSlots();
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
+        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot(
+                anyLong(), any(), anyLong(), any(), anyString())).thenReturn(true);
+
+        final int dispatched = dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        assertThat(dispatched).isZero();
+        verify(notificationRepository, never()).save(any(Notification.class));
     }
 
     // --- fixtures ---
@@ -167,13 +259,8 @@ class MedicationDelayDispatcherTest {
         final User mockSenior = mock(User.class);
         when(mockSenior.getId()).thenReturn(SENIOR_ID);
         when(mockSenior.getNickname()).thenReturn("김철수");
-        // BREAKFAST만 설정 — LUNCH/DINNER는 null이라 dispatcher가 skip
         when(mockSenior.getBreakfastTime()).thenReturn(LocalTime.of(10, 0));
         return mockSenior;
-    }
-
-    private void givenSenior() {
-        // no-op (User mock에서 mealTimes 직접 stub)
     }
 
     private void givenCareRelation() {
@@ -185,10 +272,32 @@ class MedicationDelayDispatcherTest {
 
     private void givenSettingsDefault() {
         when(settingsRepository.findByCaregiverIdAndSeniorId(CAREGIVER_ID, SENIOR_ID))
-                .thenReturn(Optional.empty()); // default threshold 60
+                .thenReturn(Optional.empty());
+    }
+
+    private void givenSlotSchedules(final MealSlot slot, final List<MedicationSchedule> schedules) {
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(slot)))
+                .thenReturn(schedules);
+    }
+
+    private void givenEmptyOtherSlots() {
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
+                .thenReturn(List.of());
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
+                .thenReturn(List.of());
+    }
+
+    private void givenNoExistingDelayNotification() {
+        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot(
+                anyLong(), any(), anyLong(), any(), anyString())).thenReturn(false);
     }
 
     private MedicationSchedule buildSchedule(final Long id, final Long medicineId,
+            final String dosage) throws Exception {
+        return buildScheduleWithId(id, medicineId, dosage);
+    }
+
+    private MedicationSchedule buildScheduleWithId(final Long id, final Long medicineId,
             final String dosage) throws Exception {
         final java.lang.reflect.Constructor<MedicationSchedule> ctor = MedicationSchedule.class
                 .getDeclaredConstructor();
@@ -213,6 +322,24 @@ class MedicationDelayDispatcherTest {
         final Medicine m = new Medicine(SENIOR_ID, null, name, 30, 30, "ITEM-" + id, null);
         setField(m, "id", id);
         return m;
+    }
+
+    private MedicationLog buildTakenLog(final Long scheduleId) throws Exception {
+        final java.lang.reflect.Constructor<MedicationLog> ctor = MedicationLog.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final MedicationLog log = ctor.newInstance();
+        setField(log, "scheduleId", scheduleId);
+        setField(log, "status", LogStatus.TAKEN);
+        return log;
+    }
+
+    private DeviceToken buildDeviceToken(final String token) throws Exception {
+        final java.lang.reflect.Constructor<DeviceToken> ctor = DeviceToken.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final DeviceToken dt = ctor.newInstance();
+        setField(dt, "token", token);
+        setField(dt, "isActive", true);
+        return dt;
     }
 
     private static void setField(final Object target, final String fieldName, final Object value) throws Exception {


### PR DESCRIPTION
## AS-IS
- `MedicationDelayDispatcher.dispatchForSenior`가 슬롯의 미인증 schedule 개수만큼 푸시 N건 발송
- 시니어가 아침 약 3개 미복용 시 보호자 폰에 동일 슬롯·동일 시니어 알림이 3건 누적

## TO-BE
- 슬롯·시니어·날짜 단위로 1건 묶음 발송 (보호자당 1건)
- 본문에 미복용 약 목록 줄바꿈으로 전부 나열 (N≥1 동일 포맷)
- FCM data payload `scheduleIds`를 JSON 배열 문자열로 포함 (예: `"[101,102,103]"`)
- DB UNIQUE 인덱스 변경 없이 코드 레벨 멱등(`existsBy...MealSlot`)만 적용
- 다른 알림 카테고리(REMINDER/DUR/COMPLETE/FAMILY_SAFETY) 무변경

## 관련 이슈
- closes #409
- spec: `docs/features/medication-delay-grouped-notification.md` (PR #410 머지됨)

## 리뷰어 참고 포인트
- `MedicationDelayDispatcher.dispatchForSenior` 보호자 루프 안에 있던 schedule 루프를 **루프 밖**으로 끌어내 사전 집계. 그 다음 보호자별로 1회 호출.
- `Notification.createForMedicationDelay` 시그니처에서 `scheduleId` 파라미터 제거. row의 `schedule_id` 컬럼은 NULL 저장 (UNIQUE 인덱스에 포함되지만 NULL ≠ NULL 특성으로 충돌 없음).
- `NotificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId`는 **`DurWarningDispatcher` 사용 중**이라 제거하지 않고 신규 `existsBy...MealSlot` 메서드만 추가.
- 본 PR 머지 직후 프론트엔드 cut-over 필요 — FCM data key `scheduleId`(단수) → `scheduleIds`(JSON 배열 문자열). 진영에게 별도 디스코드 안내.

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료 (`type:feat`)
- [x] `scope:*` 라벨 1개 부여 완료 (`scope:medication`)
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 — DB 마이그레이션/yml/gradle 변경 없음, 해당 없음

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [ ] AI 작업 아님 (사람 작성 PR)
- [x] AI 보조/생성 사용

## 품질 게이트 체크 (AI 작성 시)
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 변경 범위의 회귀 가능 구간을 확인했다. (`existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId`의 다른 사용처는 DurWarningDispatcher 1곳이며, 시그니처 미변경으로 영향 없음 확인)
- [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다. — 백엔드 단독 revert로 즉시 롤백 가능. 프론트엔드 cut-over는 본 PR 머지 시점에 동시 진행 필요(별도 안내).

## DDD/OOP 준수 체크 (AI 작성 시)
- [x] 도메인 용어가 기존 컨텍스트와 일치한다. (`MEDICATION_DELAY`, `MealSlot`, `CareRelation`, `NotificationSettings`)
- [x] 계층 침범(Controller -> Repository 직접 호출 등)이 없다.
- [x] 객체 역할/책임이 명확하며, 과도한 God Object를 만들지 않았다.

## 보안/민감정보 체크 (AI 작성 시)
- [x] 시크릿(API 키/토큰/비밀번호) 하드코딩이 없다.
- [x] 복약 기록/건강 프로필 등 의료정보를 로그/스크린샷에 노출하지 않았다. — 로그에는 `scheduleCount`만 남기고 약 이름은 본문에만 포함(보호자 push 본문은 의도된 노출).
- [x] 민감정보가 필요한 경우 마스킹 처리했다.

## 예외 머지 여부 (AI 작성 시)
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 사용자 백로그 3번 항목(#409, 진영 요청) 구현. spec PR #410 머지 후 같은 브랜치에서 진행.
- AI가 직접 수정한 파일/범위:
  - `src/main/java/com/ppiyaki/notification/Notification.java` — `createForMedicationDelay` 시그니처 변경
  - `src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java` — `existsBy...MealSlot` 메서드 추가
  - `src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java` — 슬롯 단위 집계 + 본문 빌더 + payload 변경
  - `src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java` — 기존 3개 갱신 + 신규 4개 추가 (묶음, 일부 인증, 전부 인증, 멱등)
- 사람이 수동 검증한 항목: spec §9 Q1~Q4 결정 4건 사용자 확정. Q5(프론트 cut-over)는 보류 → 본 PR 머지 직후 진영 안내.
- 잔여 리스크/추가 확인 필요사항: ① Notion API 명세 FCM payload 섹션(보호자 미복약 알림 항목) 갱신 필요. ② 진영 프론트 cut-over 합의·반영.

</details>