### PR TITLE
feat(user): 안부 알림 (시니어→보호자) 발송 API 구현 (#412)

### DIFF
--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -80,6 +80,7 @@
 | 리포트 | Report | 보호자용 복약 리포트 (스키마 미정) |
 | 채팅 세션 | Chat Session | AI 챗봇과의 대화 단위. 마지막 메시지 후 5분 경과 시 만료 |
 | 채팅 메시지 | Chat Message | 세션 내 개별 메시지. 사용자(USER) 또는 AI 응답(ASSISTANT) |
+| 안부 알림 | Wellbeing Ping | 시니어가 보호자에게 1-tap으로 "잘 지내요" 신호를 보내는 능동적 알림. `NotificationCategory.WELLBEING_PING`. 푸시만 발송하며 `notifications` row를 만들지 않는다. Redis 기반 쿨다운 1분(보호자 수신자별 독립). 시스템 자동 발송인 가족 안전망 알림(`FAMILY_SAFETY`)과는 트리거 주체가 다르다 |
 
 ## 5) 엔티티 (코드 기준)
 

--- a/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
@@ -30,7 +30,11 @@ public class GlobalExceptionHandler {
         final ErrorResponse errorResponse = errorCode == ErrorCode.INTERNAL_SERVER_ERROR
                 ? ErrorResponse.of(errorCode)
                 : ErrorResponse.of(errorCode, exception.getMessage());
-        return ResponseEntity.status(errorCode.getStatus()).body(errorResponse);
+        final ResponseEntity.BodyBuilder builder = ResponseEntity.status(errorCode.getStatus());
+        if (exception instanceof final RetryAfterAware retryAfterAware) {
+            builder.header("Retry-After", String.valueOf(retryAfterAware.getRetryAfterSeconds()));
+        }
+        return builder.body(errorResponse);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/ppiyaki/common/exception/RetryAfterAware.java
+++ b/src/main/java/com/ppiyaki/common/exception/RetryAfterAware.java
@@ -1,0 +1,6 @@
+package com.ppiyaki.common.exception;
+
+public interface RetryAfterAware {
+
+    long getRetryAfterSeconds();
+}

--- a/src/main/java/com/ppiyaki/notification/NotificationCategory.java
+++ b/src/main/java/com/ppiyaki/notification/NotificationCategory.java
@@ -6,5 +6,6 @@ public enum NotificationCategory {
     MEDICATION_DELAY,
     DUR_WARNING,
     FAMILY_SAFETY,
-    MEDICATION_COMPLETE
+    MEDICATION_COMPLETE,
+    WELLBEING_PING
 }

--- a/src/main/java/com/ppiyaki/notification/controller/WellbeingPingController.java
+++ b/src/main/java/com/ppiyaki/notification/controller/WellbeingPingController.java
@@ -1,0 +1,31 @@
+package com.ppiyaki.notification.controller;
+
+import com.ppiyaki.notification.controller.dto.WellbeingPingCreateRequest;
+import com.ppiyaki.notification.service.WellbeingPingService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications/wellbeing-pings")
+public class WellbeingPingController {
+
+    private final WellbeingPingService wellbeingPingService;
+
+    public WellbeingPingController(final WellbeingPingService wellbeingPingService) {
+        this.wellbeingPingService = wellbeingPingService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> send(
+            @AuthenticationPrincipal final Long userId,
+            @Valid @RequestBody final WellbeingPingCreateRequest request
+    ) {
+        wellbeingPingService.send(userId, request.caregiverId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/controller/dto/WellbeingPingCreateRequest.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/WellbeingPingCreateRequest.java
@@ -1,0 +1,9 @@
+package com.ppiyaki.notification.controller.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record WellbeingPingCreateRequest(
+        @NotNull @Positive Long caregiverId
+) {
+}

--- a/src/main/java/com/ppiyaki/notification/service/WellbeingPingCooldownException.java
+++ b/src/main/java/com/ppiyaki/notification/service/WellbeingPingCooldownException.java
@@ -1,0 +1,20 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.exception.RetryAfterAware;
+
+public class WellbeingPingCooldownException extends BusinessException implements RetryAfterAware {
+
+    private final long retryAfterSeconds;
+
+    public WellbeingPingCooldownException(final long retryAfterSeconds) {
+        super(ErrorCode.RATE_LIMIT_EXCEEDED,
+                "Wellbeing ping cooldown active, retry after " + retryAfterSeconds + "s");
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+
+    public long getRetryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/service/WellbeingPingCooldownStore.java
+++ b/src/main/java/com/ppiyaki/notification/service/WellbeingPingCooldownStore.java
@@ -1,0 +1,39 @@
+package com.ppiyaki.notification.service;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WellbeingPingCooldownStore {
+
+    private static final String KEY_PREFIX = "wellbeing-ping:cooldown:";
+    private static final Duration COOLDOWN = Duration.ofSeconds(60);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public WellbeingPingCooldownStore(final StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public boolean tryAcquire(final long seniorId, final long caregiverId) {
+        final String key = buildKey(seniorId, caregiverId);
+        final Boolean acquired = redisTemplate.opsForValue()
+                .setIfAbsent(key, "1", COOLDOWN);
+        return Boolean.TRUE.equals(acquired);
+    }
+
+    public Optional<Long> getRetryAfterSeconds(final long seniorId, final long caregiverId) {
+        final String key = buildKey(seniorId, caregiverId);
+        final Long ttlSeconds = redisTemplate.getExpire(key);
+        if (ttlSeconds == null || ttlSeconds <= 0L) {
+            return Optional.empty();
+        }
+        return Optional.of(ttlSeconds);
+    }
+
+    private String buildKey(final long seniorId, final long caregiverId) {
+        return KEY_PREFIX + seniorId + ":" + caregiverId;
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/service/WellbeingPingService.java
+++ b/src/main/java/com/ppiyaki/notification/service/WellbeingPingService.java
@@ -1,0 +1,94 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.infrastructure.messaging.fcm.PushPayload;
+import com.ppiyaki.infrastructure.messaging.fcm.PushSendResult;
+import com.ppiyaki.infrastructure.messaging.fcm.PushSender;
+import com.ppiyaki.notification.DeviceToken;
+import com.ppiyaki.notification.NotificationCategory;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import com.ppiyaki.user.domain.User;
+import com.ppiyaki.user.domain.UserRole;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class WellbeingPingService {
+
+    private static final Logger log = LoggerFactory.getLogger(WellbeingPingService.class);
+    private static final String PUSH_TITLE = "안부 알림";
+    private static final String PUSH_BODY_FORMAT = "%s 어르신이 안부를 전했어요.";
+
+    private final UserRepository userRepository;
+    private final CareRelationRepository careRelationRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final WellbeingPingCooldownStore cooldownStore;
+    private final PushSender pushSender;
+
+    public WellbeingPingService(
+            final UserRepository userRepository,
+            final CareRelationRepository careRelationRepository,
+            final DeviceTokenRepository deviceTokenRepository,
+            final WellbeingPingCooldownStore cooldownStore,
+            final PushSender pushSender
+    ) {
+        this.userRepository = userRepository;
+        this.careRelationRepository = careRelationRepository;
+        this.deviceTokenRepository = deviceTokenRepository;
+        this.cooldownStore = cooldownStore;
+        this.pushSender = pushSender;
+    }
+
+    @Transactional
+    public void send(final Long seniorId, final Long caregiverId) {
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (senior.getRole() != UserRole.SENIOR) {
+            throw new BusinessException(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
+        }
+
+        final User caregiver = userRepository.findById(caregiverId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (caregiver.getRole() != UserRole.CAREGIVER) {
+            throw new BusinessException(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
+        }
+
+        if (careRelationRepository
+                .findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(caregiverId, seniorId)
+                .isEmpty()) {
+            throw new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND);
+        }
+
+        if (!cooldownStore.tryAcquire(seniorId, caregiverId)) {
+            final long retryAfterSeconds = cooldownStore
+                    .getRetryAfterSeconds(seniorId, caregiverId)
+                    .orElse(1L);
+            log.debug("WELLBEING_PING cooldown blocked (sender={}, receiver={}, retryAfter={}s)",
+                    seniorId, caregiverId, retryAfterSeconds);
+            throw new WellbeingPingCooldownException(retryAfterSeconds);
+        }
+
+        final List<DeviceToken> tokens = deviceTokenRepository.findByUserIdAndIsActiveTrue(caregiverId);
+        final String body = PUSH_BODY_FORMAT.formatted(senior.getNickname() == null ? "" : senior.getNickname());
+        final PushPayload payload = new PushPayload(PUSH_TITLE, body, Map.of(
+                "category", NotificationCategory.WELLBEING_PING.name(),
+                "seniorId", String.valueOf(seniorId)
+        ));
+
+        for (final DeviceToken token : tokens) {
+            final PushSendResult result = pushSender.send(token.getToken(), payload);
+            if (result.tokenInvalid()) {
+                token.deactivate();
+            }
+        }
+        log.info("WELLBEING_PING dispatched (sender={}, receiver={}, tokens={})",
+                seniorId, caregiverId, tokens.size());
+    }
+}

--- a/src/test/java/com/ppiyaki/notification/controller/WellbeingPingControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/WellbeingPingControllerE2ETest.java
@@ -1,0 +1,178 @@
+package com.ppiyaki.notification.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+import com.ppiyaki.common.auth.JwtProvider;
+import com.ppiyaki.notification.service.WellbeingPingCooldownStore;
+import com.ppiyaki.user.domain.User;
+import com.ppiyaki.user.domain.UserRole;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("POST /api/v1/notifications/wellbeing-pings E2E")
+class WellbeingPingControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private JwtProvider jwtProvider;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @MockBean
+    private WellbeingPingCooldownStore cooldownStore;
+
+    private static long userSequence = 900000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        Mockito.when(cooldownStore.tryAcquire(anyLong(), anyLong())).thenReturn(true);
+    }
+
+    @Test
+    @DisplayName("시니어가 CareRelation 있는 보호자에게 안부 발송 → 204")
+    void wellbeing_ping_success() {
+        final Long seniorId = seedSenior();
+        final Long caregiverId = seedCaregiver();
+        seedCareRelation(seniorId, caregiverId);
+        seedDeviceToken(caregiverId, "fcm-wp-" + caregiverId);
+
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"caregiverId": %d}
+                        """.formatted(caregiverId))
+                .when()
+                .post("/api/v1/notifications/wellbeing-pings")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    @DisplayName("쿨다운 차단 시 429 + Retry-After 헤더")
+    void wellbeing_ping_cooldown_blocked() {
+        final Long seniorId = seedSenior();
+        final Long caregiverId = seedCaregiver();
+        seedCareRelation(seniorId, caregiverId);
+
+        Mockito.when(cooldownStore.tryAcquire(seniorId, caregiverId)).thenReturn(false);
+        Mockito.when(cooldownStore.getRetryAfterSeconds(seniorId, caregiverId))
+                .thenReturn(Optional.of(42L));
+
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"caregiverId": %d}
+                        """.formatted(caregiverId))
+                .when()
+                .post("/api/v1/notifications/wellbeing-pings")
+                .then()
+                .statusCode(429)
+                .header("Retry-After", "42")
+                .body("error.code", is("COMMON_006"));
+    }
+
+    @Test
+    @DisplayName("CareRelation 없는 보호자에게 발송 → 403 CARE_001")
+    void wellbeing_ping_no_care_relation() {
+        final Long seniorId = seedSenior();
+        final Long caregiverId = seedCaregiver();
+        // No care_relations INSERT
+
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"caregiverId": %d}
+                        """.formatted(caregiverId))
+                .when()
+                .post("/api/v1/notifications/wellbeing-pings")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    @Test
+    @DisplayName("보호자 JWT로 호출 → 403 CARE_008 역할 mismatch")
+    void wellbeing_ping_caller_not_senior() {
+        final Long callerCaregiverId = seedCaregiver();
+        final Long targetCaregiverId = seedCaregiver();
+
+        final String caregiverToken = jwtProvider.createAccessToken(
+                callerCaregiverId, UserRole.CAREGIVER.name());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + caregiverToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"caregiverId": %d}
+                        """.formatted(targetCaregiverId))
+                .when()
+                .post("/api/v1/notifications/wellbeing-pings")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_008"));
+    }
+
+    // --- fixtures ---
+
+    private Long seedSenior() {
+        return transactionTemplate.execute(status -> {
+            final User senior = User.createSenior("WP시니어" + userSequence++, (LocalDate) null);
+            return userRepository.save(senior).getId();
+        });
+    }
+
+    private Long seedCaregiver() {
+        final long seq = userSequence++;
+        return transactionTemplate.execute(status -> {
+            final User caregiver = User.createSenior("WP보호자" + seq, (LocalDate) null);
+            caregiver.assignRole(UserRole.CAREGIVER);
+            return userRepository.save(caregiver).getId();
+        });
+    }
+
+    private void seedCareRelation(final Long seniorId, final Long caregiverId) {
+        jdbcTemplate.update(
+                "INSERT INTO care_relations (senior_id, caregiver_id, created_at, updated_at) "
+                        + "VALUES (?, ?, NOW(6), NOW(6))",
+                seniorId, caregiverId);
+    }
+
+    private void seedDeviceToken(final Long userId, final String token) {
+        jdbcTemplate.update(
+                "INSERT INTO device_tokens "
+                        + "(user_id, token, platform, is_active, created_at, updated_at) "
+                        + "VALUES (?, ?, 'ANDROID', TRUE, NOW(6), NOW(6))",
+                userId, token);
+    }
+}

--- a/src/test/java/com/ppiyaki/notification/service/WellbeingPingCooldownStoreTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/WellbeingPingCooldownStoreTest.java
@@ -1,0 +1,66 @@
+package com.ppiyaki.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+class WellbeingPingCooldownStoreTest {
+
+    private static final long SENIOR_ID = 1L;
+    private static final long CAREGIVER_ID = 2L;
+    private static final String KEY = "wellbeing-ping:cooldown:1:2";
+
+    private StringRedisTemplate redisTemplate;
+    private ValueOperations<String, String> valueOps;
+    private WellbeingPingCooldownStore store;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        redisTemplate = mock(StringRedisTemplate.class);
+        valueOps = mock(ValueOperations.class);
+        given(redisTemplate.opsForValue()).willReturn(valueOps);
+        store = new WellbeingPingCooldownStore(redisTemplate);
+    }
+
+    @Test
+    @DisplayName("setIfAbsent 성공 시 tryAcquire true")
+    void tryAcquire_success() {
+        given(valueOps.setIfAbsent(eq(KEY), eq("1"), any(Duration.class))).willReturn(true);
+
+        assertThat(store.tryAcquire(SENIOR_ID, CAREGIVER_ID)).isTrue();
+    }
+
+    @Test
+    @DisplayName("setIfAbsent 실패 시 tryAcquire false")
+    void tryAcquire_fails_when_key_exists() {
+        given(valueOps.setIfAbsent(eq(KEY), eq("1"), any(Duration.class))).willReturn(false);
+
+        assertThat(store.tryAcquire(SENIOR_ID, CAREGIVER_ID)).isFalse();
+    }
+
+    @Test
+    @DisplayName("getRetryAfterSeconds 가 TTL 양수면 Optional 반환")
+    void getRetryAfterSeconds_returns_positive_ttl() {
+        given(redisTemplate.getExpire(KEY)).willReturn(42L);
+
+        assertThat(store.getRetryAfterSeconds(SENIOR_ID, CAREGIVER_ID)).contains(42L);
+    }
+
+    @Test
+    @DisplayName("TTL 0 이하면 Optional.empty")
+    void getRetryAfterSeconds_empty_when_no_ttl() {
+        given(redisTemplate.getExpire(KEY)).willReturn(-1L);
+
+        assertThat(store.getRetryAfterSeconds(SENIOR_ID, CAREGIVER_ID)).isEmpty();
+    }
+}

--- a/src/test/java/com/ppiyaki/notification/service/WellbeingPingServiceTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/WellbeingPingServiceTest.java
@@ -1,0 +1,191 @@
+package com.ppiyaki.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.infrastructure.messaging.fcm.PushPayload;
+import com.ppiyaki.infrastructure.messaging.fcm.PushSendResult;
+import com.ppiyaki.infrastructure.messaging.fcm.PushSender;
+import com.ppiyaki.notification.DeviceToken;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import com.ppiyaki.user.domain.CareRelation;
+import com.ppiyaki.user.domain.User;
+import com.ppiyaki.user.domain.UserRole;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WellbeingPingServiceTest {
+
+    private static final long SENIOR_ID = 10L;
+    private static final long CAREGIVER_ID = 20L;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private CareRelationRepository careRelationRepository;
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+    @Mock
+    private WellbeingPingCooldownStore cooldownStore;
+    @Mock
+    private PushSender pushSender;
+
+    @InjectMocks
+    private WellbeingPingService wellbeingPingService;
+
+    @Test
+    @DisplayName("정상 발송 — 모든 활성 토큰에 push 호출")
+    void send_success_dispatches_to_all_tokens() {
+        // given
+        final User senior = mockUser(UserRole.SENIOR);
+        given(senior.getNickname()).willReturn("김장군");
+        final User caregiver = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(caregiver));
+        given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
+                CAREGIVER_ID, SENIOR_ID)).willReturn(Optional.of(mock(CareRelation.class)));
+        given(cooldownStore.tryAcquire(SENIOR_ID, CAREGIVER_ID)).willReturn(true);
+
+        final DeviceToken token1 = mock(DeviceToken.class);
+        final DeviceToken token2 = mock(DeviceToken.class);
+        given(token1.getToken()).willReturn("t1");
+        given(token2.getToken()).willReturn("t2");
+        given(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID))
+                .willReturn(List.of(token1, token2));
+        given(pushSender.send(anyString(), any(PushPayload.class))).willReturn(PushSendResult.ok());
+
+        // when
+        wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID);
+
+        // then
+        verify(pushSender, times(2)).send(anyString(), any(PushPayload.class));
+        verify(token1, never()).deactivate();
+        verify(token2, never()).deactivate();
+    }
+
+    @Test
+    @DisplayName("발신자가 시니어가 아니면 CARE_RELATION_ROLE_MISMATCH")
+    void send_caller_not_senior_throws() {
+        final User notSenior = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(notSenior));
+
+        assertThatThrownBy(() -> wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting(throwable -> ((BusinessException) throwable).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("수신자가 보호자가 아니면 CARE_RELATION_ROLE_MISMATCH")
+    void send_receiver_not_caregiver_throws() {
+        final User senior = mockUser(UserRole.SENIOR);
+        final User wrongRole = mockUser(UserRole.SENIOR);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(wrongRole));
+
+        assertThatThrownBy(() -> wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting(throwable -> ((BusinessException) throwable).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("CareRelation 없으면 CARE_RELATION_NOT_FOUND")
+    void send_no_care_relation_throws() {
+        final User senior = mockUser(UserRole.SENIOR);
+        final User caregiver = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(caregiver));
+        given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
+                CAREGIVER_ID, SENIOR_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting(throwable -> ((BusinessException) throwable).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("쿨다운 차단 시 WellbeingPingCooldownException + retryAfterSeconds 전달")
+    void send_cooldown_blocks_with_retry_after() {
+        final User senior = mockUser(UserRole.SENIOR);
+        final User caregiver = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(caregiver));
+        given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
+                CAREGIVER_ID, SENIOR_ID)).willReturn(Optional.of(mock(CareRelation.class)));
+        given(cooldownStore.tryAcquire(SENIOR_ID, CAREGIVER_ID)).willReturn(false);
+        given(cooldownStore.getRetryAfterSeconds(SENIOR_ID, CAREGIVER_ID))
+                .willReturn(Optional.of(33L));
+
+        assertThatThrownBy(() -> wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID))
+                .isInstanceOf(WellbeingPingCooldownException.class)
+                .extracting(throwable -> ((WellbeingPingCooldownException) throwable).getRetryAfterSeconds())
+                .isEqualTo(33L);
+    }
+
+    @Test
+    @DisplayName("tokenInvalid 결과 시 DeviceToken.deactivate 호출")
+    void send_invalid_token_deactivates() {
+        final User senior = mockUser(UserRole.SENIOR);
+        final User caregiver = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(caregiver));
+        given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
+                CAREGIVER_ID, SENIOR_ID)).willReturn(Optional.of(mock(CareRelation.class)));
+        given(cooldownStore.tryAcquire(SENIOR_ID, CAREGIVER_ID)).willReturn(true);
+
+        final DeviceToken token = mock(DeviceToken.class);
+        given(token.getToken()).willReturn("invalid-t");
+        given(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID))
+                .willReturn(List.of(token));
+        given(pushSender.send(eq("invalid-t"), any(PushPayload.class)))
+                .willReturn(PushSendResult.tokenInvalid("unregistered"));
+
+        wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID);
+
+        verify(token).deactivate();
+    }
+
+    @Test
+    @DisplayName("활성 토큰 0개여도 정상 종료")
+    void send_no_tokens_completes() {
+        final User senior = mockUser(UserRole.SENIOR);
+        final User caregiver = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(caregiver));
+        given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
+                CAREGIVER_ID, SENIOR_ID)).willReturn(Optional.of(mock(CareRelation.class)));
+        given(cooldownStore.tryAcquire(SENIOR_ID, CAREGIVER_ID)).willReturn(true);
+        given(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID))
+                .willReturn(List.of());
+
+        wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID);
+
+        verify(pushSender, never()).send(anyString(), any(PushPayload.class));
+    }
+
+    private User mockUser(final UserRole role) {
+        final User user = mock(User.class);
+        given(user.getRole()).willReturn(role);
+        return user;
+    }
+}


### PR DESCRIPTION
## AS-IS
- 시니어가 보호자에게 1-tap 안부 신호를 보낼 수 있는 수단이 없다.
- spec(`docs/features/wellbeing-ping.md`)은 PR #413으로 머지된 상태 (status=draft).

## TO-BE
- `POST /api/v1/notifications/wellbeing-pings` endpoint 신설.
- 시니어 JWT → CareRelation 검증 → Redis 쿨다운 SETNX(60s) → 보호자 활성 토큰 전부에 FCM 푸시.
- `NotificationCategory.WELLBEING_PING` enum 추가 (푸시 식별자 — 알림함 row 미생성).
- `RetryAfterAware` 인터페이스로 GlobalExceptionHandler에서 Retry-After 헤더 부착.
- 도메인 모델 §4 유비쿼터스 랭귀지 "안부 알림" 등재.
- Notion API 명세 DB에 "안부 알림 발송" 페이지 생성.

## 관련 이슈
- closes #412
- 관련 spec PR: #413

## 변경 요약

**프로덕션 코드 (8개)**
- `NotificationCategory` enum에 `WELLBEING_PING` 추가
- `WellbeingPingController` — POST endpoint
- `WellbeingPingCreateRequest` — `{ caregiverId }` DTO
- `WellbeingPingService` — 역할/CareRelation 검증 + 쿨다운 + 푸시 발송
- `WellbeingPingCooldownStore` — Redis SETNX 기반 60초 쿨다운
- `WellbeingPingCooldownException` — `RetryAfterAware` 구현 (RATE_LIMIT_EXCEEDED 재사용)
- `RetryAfterAware` — common 모듈 인터페이스
- `GlobalExceptionHandler` — Retry-After 헤더 부착 분기

**테스트 (3개)**
- `WellbeingPingServiceTest` — 7건 (정상/역할 mismatch x2/관계 없음/쿨다운/tokenInvalid/토큰 0개)
- `WellbeingPingCooldownStoreTest` — 4건 (SETNX 성공/실패, TTL 조회)
- `WellbeingPingControllerE2ETest` — 4건 (성공 204 / 쿨다운 429+Retry-After / CARE_001 / CARE_008)

**문서**
- `docs/ai-harness/06-domain-model.md` §4 유비쿼터스 랭귀지에 "안부 알림" 등재
- Notion API 명세 DB에 페이지 생성 — https://www.notion.so/36e55690fbc781d68b06c6247f49c3b3

## 리뷰어 참고 포인트
- **CI에 Redis 서비스가 없습니다.** 본 PR E2E는 `@MockBean WellbeingPingCooldownStore`로 Redis 의존을 회피. 후속 chore PR로 `backend-ci.yml`의 `services`에 redis 컨테이너 추가가 필요합니다 (보호 영역).
- `RetryAfterAware` 인터페이스는 common 모듈에 두고 도메인 누설을 피했습니다. cooldown 응답에 Retry-After 헤더만 동적으로 부착하기 위함.
- spec 작성 당시 `@Transactional 불필요`로 적었으나 `DeviceToken.deactivate()` dirty checking이 update SQL을 만들기 때문에 service에 `@Transactional` 부착. spec과 차이는 다음 spec 갱신 PR에서 정리 예정.
- 시니어 닉네임이 NULL일 경우 본문은 `" 어르신이 안부를 전했어요."` 처럼 앞이 비게 됩니다 (Spec에 닉네임 NULL 처리 미명세 — 시니어는 닉네임 필수가 아닌가요? 후속에서 결정).

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료 (`type:feat`)
- [x] `scope:*` 라벨 1개 부여 완료 (`scope:user`)
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료 — 해당 없음

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크 (AI 작성 시)
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` — 로컬 docker redis 띄운 상태에서 359건+신규 15건 통과
- [x] 변경 범위의 회귀 가능 구간을 확인했다. `NotificationCategory` enum 사용처(`Notification.@Enumerated(STRING)` + `FcmPushSender` metrics 라벨) 영향 검증. 다른 dispatcher 흐름 무변경.
- [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다. 신규 endpoint + enum 값 추가 — 코드 revert로 충분. DB 마이그레이션 없음.

## DDD/OOP 준수 체크 (AI 작성 시)
- [x] 도메인 용어가 기존 컨텍스트와 일치한다 (FAMILY_SAFETY와 분리, 유비쿼터스 랭귀지 등재 완료)
- [x] 계층 침범 없음 (Controller → Service → Repository)
- [x] 객체 역할/책임 명확 (Cooldown store는 Redis 통신만 담당)

## 보안/민감정보 체크 (AI 작성 시)
- [x] 시크릿 하드코딩 없음
- [x] 의료정보 노출 없음 (안부 알림은 의료 데이터를 포함하지 않음)
- [x] 민감정보 마스킹 해당 없음

## 예외 머지 여부 (AI 작성 시)
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 디스코드 백로그 4번 콕찌르기 기능 구현. spec PR #413 머지 후 구현 진행 — 사용자 직접 명시.
- AI가 직접 수정한 파일/범위: 본 PR diff 전체. spec/Notion 명세 + 도메인 모델 문서 + 코드.
- 사람이 수동 검증한 항목: spec 단계 합의 9건 (방향/쿨다운/영속화/본문 + 오픈 질문 5건 추천값) 모두 사용자 직접 확인.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 안부 알림(Wellbeing Ping) 기능 추가: 보호자가 시니어에게 안부 확인을 요청할 수 있습니다.
  * 1분 쿨다운 레이트 제한으로 과도한 요청을 방지합니다.
  * 요청 제한 시 Retry-After 헤더로 재시도 시간을 안내합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->