### PR TITLE
chore(infra): CI workflow에 redis 서비스 추가 (#412)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -31,6 +31,11 @@ jobs:
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=5
 
     steps:
       - name: Checkout
@@ -57,6 +62,8 @@ jobs:
           SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3306/ppiyaki_test?useSSL=false&allowPublicKeyRetrieval=true
           SPRING_DATASOURCE_USERNAME: root
           SPRING_DATASOURCE_PASSWORD: root
+          SPRING_DATA_REDIS_HOST: localhost
+          SPRING_DATA_REDIS_PORT: 6379
 
       - name: BootJar with Gradle
         run: ./gradlew bootJar -x test


### PR DESCRIPTION
## AS-IS
- `backend-ci.yml`의 `services`에 mysql만 있고 redis가 없다.
- PR #414에서 추가된 `WellbeingPingCooldownStore`가 `StringRedisTemplate`에 의존하지만, 본 PR 이전에는 통합 테스트에서 `@MockBean`으로 Redis 의존을 회피해야만 했다 (실제 SETNX/TTL 동작 미검증).

## TO-BE
- `services.redis` 컨테이너(`redis:7`) 추가 + healthcheck.
- `Test with Gradle` 단계의 env에 `SPRING_DATA_REDIS_HOST/PORT` 명시.

## 관련 이슈
- closes 없음 (PR #414 후속 인프라 정비)

## 리뷰어 참고 포인트
- **보호 영역 변경**: `.github/workflows/backend-ci.yml`. 사람 리뷰 필수.
- Spring 자동설정 기본값이 localhost:6379라 env 없이도 동작은 하지만 명시적으로 두어 의도를 드러냄.
- 본 PR 머지 후 `WellbeingPingControllerE2ETest`의 `@MockBean WellbeingPingCooldownStore`를 제거하고 실제 Redis 통합으로 전환하는 후속 PR이 가능.

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료 (`type:chore`)
- [x] `scope:*` 라벨 1개 부여 완료 (`scope:infra`)
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [x] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크 (AI 작성 시)
- [x] 코드 변경 없음 (CI yml만). 본 PR의 CI run이 곧 검증.

## 보안/민감정보 체크 (AI 작성 시)
- [x] 시크릿 하드코딩 없음
- [x] redis 서비스에 password 없음 — 운영 redis와 별개의 CI 컨테이너이므로 OK

## 예외 머지 여부
- [x] 예외 머지 아님

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)