### PR TITLE
feat(user): 시니어 본인의 보호자 목록 조회 API 구현 (#419)

### DIFF
--- a/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
+++ b/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
@@ -1,5 +1,6 @@
 package com.ppiyaki.user.controller;
 
+import com.ppiyaki.user.controller.dto.CaregiverSummaryResponse;
 import com.ppiyaki.user.controller.dto.CodeLoginRequest;
 import com.ppiyaki.user.controller.dto.InviteCodeRequest;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
@@ -37,6 +38,15 @@ public class CareRelationController {
             @AuthenticationPrincipal final Long userId
     ) {
         final List<SeniorSummaryResponse> responses = careRelationService.readSeniors(userId);
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/care-relations/caregivers")
+    @PreAuthorize("hasRole('SENIOR')")
+    public ResponseEntity<List<CaregiverSummaryResponse>> readCaregivers(
+            @AuthenticationPrincipal final Long userId
+    ) {
+        final List<CaregiverSummaryResponse> responses = careRelationService.readCaregivers(userId);
         return ResponseEntity.ok(responses);
     }
 

--- a/src/main/java/com/ppiyaki/user/controller/dto/CaregiverSummaryResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/CaregiverSummaryResponse.java
@@ -1,0 +1,16 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.ppiyaki.user.domain.User;
+
+public record CaregiverSummaryResponse(
+        Long id,
+        String nickname
+) {
+
+    public static CaregiverSummaryResponse from(final User user) {
+        return new CaregiverSummaryResponse(
+                user.getId(),
+                user.getNickname()
+        );
+    }
+}

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -4,6 +4,7 @@ import com.ppiyaki.common.auth.JwtProvider;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.common.ratelimit.RateLimiter;
+import com.ppiyaki.user.controller.dto.CaregiverSummaryResponse;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
 import com.ppiyaki.user.controller.dto.SeniorSummaryResponse;
@@ -66,6 +67,24 @@ public class CareRelationService {
         return careRelations.stream()
                 .map(relation -> seniorsById.get(relation.getSeniorId()))
                 .map(SeniorSummaryResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CaregiverSummaryResponse> readCaregivers(final Long seniorId) {
+        final List<CareRelation> careRelations = careRelationRepository.findBySeniorIdAndDeletedAtIsNull(
+                seniorId);
+
+        final List<Long> caregiverIds = careRelations.stream()
+                .map(CareRelation::getCaregiverId)
+                .toList();
+
+        final Map<Long, User> caregiversById = userRepository.findAllById(caregiverIds).stream()
+                .collect(Collectors.toMap(User::getId, user -> user));
+
+        return careRelations.stream()
+                .map(relation -> caregiversById.get(relation.getCaregiverId()))
+                .map(CaregiverSummaryResponse::from)
                 .toList();
     }
 

--- a/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
@@ -156,4 +156,100 @@ class CareRelationControllerE2ETest {
                 .body("$", hasSize(1))
                 .body("[0].nickname", is("시니어코드E2E"));
     }
+
+    @Test
+    @DisplayName("시니어가 본인의 보호자 목록을 조회한다")
+    void readCaregivers_success() {
+        // given — 보호자 회원가입 + 시니어 대리 생성 + 초대 코드 + 코드 로그인 → 시니어 토큰
+        final String caregiverToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "cg_code_e2e",
+                            "password": "pass1234!",
+                            "nickname": "보호자코드E2E"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("accessToken");
+
+        final Integer seniorId = RestAssured.given()
+                .header("Authorization", "Bearer " + caregiverToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "nickname": "시니어코드E2E",
+                            "birthDate": "1945-03-15"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/seniors")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("seniorId");
+
+        final String inviteCode = RestAssured.given()
+                .header("Authorization", "Bearer " + caregiverToken)
+                .contentType(ContentType.JSON)
+                .body("{\"seniorId\": " + seniorId + "}")
+                .when()
+                .post("/api/v1/care-relations/invite")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("inviteCode");
+
+        final String seniorToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("{\"code\": \"" + inviteCode + "\"}")
+                .when()
+                .post("/api/v1/auth/code-login")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("accessToken");
+
+        // when & then — 시니어가 본인의 보호자 목록 조회
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorToken)
+                .when()
+                .get("/api/v1/care-relations/caregivers")
+                .then()
+                .statusCode(200)
+                .body("$", hasSize(1))
+                .body("[0].nickname", is("보호자코드E2E"))
+                .body("[0].id", notNullValue());
+    }
+
+    @Test
+    @DisplayName("보호자가 시니어 전용 endpoint(/care-relations/caregivers) 호출 시 403")
+    void readCaregivers_caregiver_forbidden() {
+        final String caregiverToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "cg_code_e2e",
+                            "password": "pass1234!",
+                            "nickname": "보호자코드E2E"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("accessToken");
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + caregiverToken)
+                .when()
+                .get("/api/v1/care-relations/caregivers")
+                .then()
+                .statusCode(403);
+    }
 }

--- a/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
@@ -12,6 +12,7 @@ import com.ppiyaki.common.auth.JwtProvider;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.common.ratelimit.RateLimiter;
+import com.ppiyaki.user.controller.dto.CaregiverSummaryResponse;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
 import com.ppiyaki.user.domain.CareRelation;
@@ -23,6 +24,7 @@ import com.ppiyaki.user.repository.InviteCodeRepository;
 import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -173,10 +175,61 @@ class CareRelationServiceTest {
         verify(inviteCodeRepository, org.mockito.Mockito.never()).findByCodeHashAndUsedAtIsNull(any());
     }
 
+    @Test
+    @DisplayName("시니어가 본인의 보호자 목록을 조회하면 활성 care_relation의 보호자가 DTO로 변환된다")
+    void readCaregivers_returnsActiveCaregivers() {
+        // given
+        final Long seniorId = 1L;
+        final Long caregiverA = 10L;
+        final Long caregiverB = 11L;
+
+        final CareRelation relationA = mock(CareRelation.class);
+        given(relationA.getCaregiverId()).willReturn(caregiverA);
+        final CareRelation relationB = mock(CareRelation.class);
+        given(relationB.getCaregiverId()).willReturn(caregiverB);
+        given(careRelationRepository.findBySeniorIdAndDeletedAtIsNull(seniorId))
+                .willReturn(List.of(relationA, relationB));
+
+        final User userA = mockUserWithNickname(caregiverA, "보호자A");
+        final User userB = mockUserWithNickname(caregiverB, "보호자B");
+        given(userRepository.findAllById(List.of(caregiverA, caregiverB)))
+                .willReturn(List.of(userA, userB));
+
+        // when
+        final List<CaregiverSummaryResponse> responses = careRelationService.readCaregivers(seniorId);
+
+        // then
+        assertThat(responses).hasSize(2);
+        assertThat(responses).extracting(CaregiverSummaryResponse::id).containsExactly(caregiverA, caregiverB);
+        assertThat(responses).extracting(CaregiverSummaryResponse::nickname).containsExactly("보호자A", "보호자B");
+    }
+
+    @Test
+    @DisplayName("연동된 보호자가 없으면 빈 리스트를 반환한다")
+    void readCaregivers_returnsEmptyWhenNoRelations() {
+        // given
+        given(careRelationRepository.findBySeniorIdAndDeletedAtIsNull(1L))
+                .willReturn(List.of());
+        given(userRepository.findAllById(List.of())).willReturn(List.of());
+
+        // when
+        final List<CaregiverSummaryResponse> responses = careRelationService.readCaregivers(1L);
+
+        // then
+        assertThat(responses).isEmpty();
+    }
+
     private User mockUser(final Long id, final UserRole role) {
         final User user = mock(User.class);
         lenient().when(user.getId()).thenReturn(id);
         lenient().when(user.getRole()).thenReturn(role);
+        return user;
+    }
+
+    private User mockUserWithNickname(final Long id, final String nickname) {
+        final User user = mock(User.class);
+        lenient().when(user.getId()).thenReturn(id);
+        lenient().when(user.getNickname()).thenReturn(nickname);
         return user;
     }
 }


### PR DESCRIPTION
## AS-IS
- `CareRelationController`에 보호자 → 시니어 방향 endpoint(`GET /api/v1/care-relations/seniors`)만 존재.
- 시니어가 본인의 보호자 목록을 가져올 endpoint가 없어, 안부 알림(PR #414) UI에서 "어느 보호자에게 보낼지" 목록을 그릴 수단이 없음.

## TO-BE
- `GET /api/v1/care-relations/caregivers` 신설 — 시니어 JWT로 호출, `hasRole('SENIOR')`.
- 응답: `List<CaregiverSummaryResponse>` — `{ id, nickname }`.
- 보호자는 가입 시 birthDate/gender를 받지 않으므로 응답에서 제외 (null 노이즈 회피).

## 관련 이슈
- closes #419

## 변경 요약
- `CaregiverSummaryResponse` DTO 신설
- `CareRelationService.readCaregivers(seniorId)` — `findBySeniorIdAndDeletedAtIsNull` + `findAllById` (기존 `readSeniors` 패턴 그대로 대칭)
- `CareRelationController.readCaregivers` — `@PreAuthorize("hasRole('SENIOR')")`
- E2E 2건: 성공 케이스(invite+code-login 흐름으로 시니어 토큰 발급) / CAREGIVER 호출 시 403
- 단위 테스트 2건: 활성 관계 → DTO 매핑 / 빈 리스트

## 리뷰어 참고 포인트
- 도메인 모델 문서(`docs/ai-harness/06-domain-model.md`) 변경 없음 — 새 용어/엔티티 없이 기존 `CareRelation` 조회 방향만 추가.
- Notion API 명세 페이지 추가 — https://www.notion.so/36e55690fbc781a7ad18cba0dfbb54b7

## 라벨 부여 확인
- [x] `type:feat`
- [x] `scope:user`
- [x] `ai-generated`
- [ ] `needs-human-review` — 해당 없음 (코드/테스트만, 보호 영역 미변경)

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크 (AI 작성 시)
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test` — 신규 4건 + 회귀 전 영역 통과 (로컬 docker mysql + redis 띄운 상태)
- [x] 변경 범위의 회귀 가능 구간 확인 — `CareRelationController` 라우팅 + `readSeniors` 흐름 무변경 검증.

## DDD/OOP 준수 체크 (AI 작성 시)
- [x] 기존 `CareRelation` 도메인 어휘 그대로 사용
- [x] 계층 침범 없음 (Controller → Service → Repository)
- [x] DTO/Service 책임 분리 — DTO에 `from(User)` 변환만 둠

## 보안/민감정보 체크 (AI 작성 시)
- [x] 시크릿 하드코딩 없음
- [x] 의료정보 노출 없음
- [x] 응답 필드를 id/nickname으로 한정해 불필요한 노출 회피

## 예외 머지 여부
- [x] 예외 머지 아님

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 시니어 사용자가 자신과 연동된 보호자들의 목록을 조회할 수 있는 새로운 기능이 추가되었습니다. 조회 결과에는 각 보호자의 고유 ID와 닉네임 정보가 표시됩니다. 이 기능은 시니어 권한을 가진 사용자만 접근할 수 있으며, 보호자 권한을 가진 사용자는 이 기능에 접근할 수 없도록 제한됩니다. 이를 통해 시니어가 자신의 케어팀을 체계적이고 효율적으로 관리할 수 있게 됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->