### PR TITLE
release: v0.14.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,15 @@ CLOVA_OCR_SECRET=your-clova-ocr-secret
 OPENAI_API_KEY=your-openai-api-key
 
 # -----------------------------------------------------------------------------
+# Redis — 캐시 / Rate Limiter 저장소
+# 로컬은 docker-compose의 Redis 사용 (비밀번호 없음).
+# prod는 docker 내부 네트워크의 ppiyaki-redis 컨테이너에 접속.
+# -----------------------------------------------------------------------------
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+
+# -----------------------------------------------------------------------------
 # Management / Observability port
 # Spring Boot Actuator + Micrometer는 메인(8080)과 별도 포트로 노출.
 # backend-cd.yml은 8081을 publish하지 않으므로 prod에서 외부 접근 불가

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -90,6 +90,9 @@ jobs:
               -e OPENAI_VISION_MODEL='gpt-5.4-mini' \
               -e FCM_PROJECT_ID='${{ secrets.FCM_PROJECT_ID }}' \
               -e FCM_CREDENTIALS_JSON_BASE64='${{ secrets.FCM_CREDENTIALS_JSON_BASE64 }}' \
+              -e REDIS_HOST='ppiyaki-redis' \
+              -e REDIS_PORT='6379' \
+              -e REDIS_PASSWORD='${{ secrets.REDIS_PASSWORD }}' \
               ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
             
             echo "Cleaning up old images..."

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -31,6 +31,11 @@ jobs:
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=5
 
     steps:
       - name: Checkout
@@ -57,6 +62,8 @@ jobs:
           SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3306/ppiyaki_test?useSSL=false&allowPublicKeyRetrieval=true
           SPRING_DATASOURCE_USERNAME: root
           SPRING_DATASOURCE_PASSWORD: root
+          SPRING_DATA_REDIS_HOST: localhost
+          SPRING_DATA_REDIS_PORT: 6379
 
       - name: BootJar with Gradle
         run: ./gradlew bootJar -x test

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation platform('software.amazon.awssdk:bom:2.28.29')
     implementation 'software.amazon.awssdk:s3'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  redis: # ← 추가
+  redis:
     image: redis:7
     container_name: ppiyaki-redis-local
     restart: unless-stopped
@@ -30,6 +30,11 @@ services:
       - "6379:6379"
     volumes:
       - ppiyaki-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 volumes:
   ppiyaki-mysql-data:
   ppiyaki-redis-data:             # ← 추가

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
+  redis: # ← 추가
+    image: redis:7
+    container_name: ppiyaki-redis-local
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - ppiyaki-redis-data:/data
 volumes:
   ppiyaki-mysql-data:
+  ppiyaki-redis-data:             # ← 추가
+

--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -73,7 +73,7 @@
 | 알약 개수 검증 상태 | Log Pill Count Status | 복약 인증 사진 약 개수 AI 검증 결과. `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED`. `medication_logs.pill_count_status`에 enum 매핑 (Phase 2). 사진 + status=TAKEN일 때만 채워짐. Phase 3(낱알 식별) 진입 시 `pill_identification_status` 컬럼 분리 예정 |
 | 복약 이행률 | Adherence Rate | 기간 내 성공 복약 / 예정 복약 |
 | 대리 처리 | Proxy Confirmation | 보호자가 시니어 대신 복용 상태를 확정 (`is_proxy=true`, `confirmed_by_user_id != senior_id`) |
-| 보호자 승인 모드 | Care Mode | 시니어의 처방전 변경 권한 정책. `MANAGED`(보호자 검증 강제, 0~72h 보호자 전용 + 72h 후 시니어 fallback) / `AUTONOMOUS`(시니어 즉시 변경 허용). `users.care_mode`에 저장. 변경은 보호자만 가능 |
+| 보호자 승인 모드 | Care Mode | 시니어의 처방전 변경 권한 + 복약 인증 사진 정책. `MANAGED`(보호자 검증 강제, 0~72h 보호자 전용 + 72h 후 시니어 fallback. 복약 인증 `status=TAKEN` 시 `photo_object_key` **필수**) / `AUTONOMOUS`(시니어 즉시 변경 허용, 복약 인증 사진 선택). `users.care_mode`에 저장. 변경은 보호자만 가능 |
 | DUR 점검 | Drug Utilization Review | 약물 상호작용/중복/금기 검증. 결과는 `dur_checks`에 immutable 로그로 저장 |
 | 약 개수 인식 | Pill Count Recognition | 복약 확인용 비전 기반 약 개수 판정. 세부 구현 보류 |
 | 삐약이 | Ppiyaki / Pet Character | 복약 성공 시 성장하는 게이미피케이션 캐릭터 |
@@ -252,7 +252,7 @@ OCR + LLM 파싱으로 추출된 약물 후보. 처방전 1건당 N행. 보호�
 | target_date | date (`LocalDate`) | 예정 복약 일자 |
 | taken_at | datetime (`LocalDateTime`) nullable | 실제 확인 시각 |
 | status | varchar | 사용자 확정 상태. Java는 `LogStatus` enum(`TAKEN`/`MISSED`/`PENDING`) |
-| photo_object_key | varchar nullable | 복약 인증 사진의 NCP Object Storage `objectKey` (예: `medication-log/{userId}/{uuid}.jpg`). 응답 시 서버가 endpoint·bucket을 조립해 full URL(`photoUrl`)로 반환 |
+| photo_object_key | varchar nullable | 복약 인증 사진의 NCP Object Storage `objectKey` (예: `medication-log/{userId}/{uuid}.jpg`). 응답 시 서버가 endpoint·bucket을 조립해 full URL(`photoUrl`)로 반환. **시니어 `care_mode=MANAGED`이면 `status=TAKEN` 시 필수** (없으면 400 `LOG_001 MEDICATION_LOG_PHOTO_REQUIRED`). `care_mode=AUTONOMOUS`이면 선택 |
 | pill_count_status | varchar nullable | Vision LLM 약 개수 검증 결과. Java `LogPillCountStatus` enum: `COUNT_MATCH` / `COUNT_MISMATCH` / `COUNT_UNKNOWN` / `COUNT_FAILED` (Phase 2). 사진 + status=TAKEN일 때만 채워짐. Phase 3(낱알 식별) 진입 시 `pill_identification_status` 컬럼 분리 예정 |
 | is_proxy | boolean | 보호자 대리 처리 여부 (= `confirmed_by_user_id != senior_id`의 캐시) |
 | confirmed_by_user_id | bigint nullable | 실제로 상태를 확정한 사용자(`users.id` 참조). 시니어 본인일 수도, 보호자일 수도 있음 |

--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -105,7 +105,7 @@
 | birth_date | date | 생년월일 |
 | pet_id | bigint | `pets.id` PK 참조 (FK 제약 선언 여부는 §7-12) |
 | care_mode | varchar | DB는 varchar, Java는 `CareMode` enum(`MANAGED` default / `AUTONOMOUS`). 시니어 회원에 적용. 보호자 회원도 컬럼은 갖지만 처방전 흐름에서는 `prescription.owner_id`로 참조하는 시니어 측 값만 사용 |
-| breakfast_time | time nullable | 시니어 식사 시간대(아침). Java는 `LocalTime`. 미설정 가능. Phase 1: 클라이언트가 schedule 등록 시 활용. Phase 2~3: 슬롯 매핑/자동 생성 (별도 spec) |
+| breakfast_time | time nullable | 시니어 식사 시간대(아침). Java는 `LocalTime`. 미설정 가능. Phase 1: 클라이언트가 schedule 등록 시 활용. Phase 2~3: 슬롯 매핑/자동 생성 (별도 spec). 변경 권한: 시니어 본인(`PUT /api/v1/users/me/meal-times`) 또는 연결된 보호자(`PUT /api/v1/users/{seniorId}/meal-times`, CareRelation 검증) |
 | lunch_time | time nullable | 시니어 식사 시간대(점심). 동일 |
 | dinner_time | time nullable | 시니어 식사 시간대(저녁). 동일 |
 | notification_mode | varchar nullable | 알림 프리셋. Java는 `NotificationMode` enum(`BASIC_ALERT`/`INTENSIVE_CARE`). 시니어에만 적용. 온보딩 시 설정, 이후 개별 조정 가능 |

--- a/docs/ai-harness/06-domain-model.md
+++ b/docs/ai-harness/06-domain-model.md
@@ -80,6 +80,7 @@
 | 리포트 | Report | 보호자용 복약 리포트 (스키마 미정) |
 | 채팅 세션 | Chat Session | AI 챗봇과의 대화 단위. 마지막 메시지 후 5분 경과 시 만료 |
 | 채팅 메시지 | Chat Message | 세션 내 개별 메시지. 사용자(USER) 또는 AI 응답(ASSISTANT) |
+| 안부 알림 | Wellbeing Ping | 시니어가 보호자에게 1-tap으로 "잘 지내요" 신호를 보내는 능동적 알림. `NotificationCategory.WELLBEING_PING`. 푸시만 발송하며 `notifications` row를 만들지 않는다. Redis 기반 쿨다운 1분(보호자 수신자별 독립). 시스템 자동 발송인 가족 안전망 알림(`FAMILY_SAFETY`)과는 트리거 주체가 다르다 |
 
 ## 5) 엔티티 (코드 기준)
 

--- a/docs/decisions/0001-mysql-on-ncp-8.4.6.md
+++ b/docs/decisions/0001-mysql-on-ncp-8.4.6.md
@@ -1,10 +1,12 @@
 ---
 id: 0001
 title: 운영 DB는 NCP 매니지드 MySQL 8.4.6
-status: accepted
+status: superseded by 0011
 date: 2026-04-08
 deciders: [@goohong]
 ---
+
+> **2026-05-20 supersede**: 비용 절감 목적으로 운영 DB를 backend 서버 docker MySQL로 이전 (ADR 0011). MySQL 8.4.6 버전 선택과 로컬 docker-compose 정렬 결정은 ADR 0011에서도 유지된다.
 
 # 0001. 운영 DB는 NCP 매니지드 MySQL 8.4.6
 

--- a/docs/decisions/0011-self-hosted-mysql-docker.md
+++ b/docs/decisions/0011-self-hosted-mysql-docker.md
@@ -1,0 +1,46 @@
+---
+id: 0011
+title: 운영 DB를 backend 서버 docker MySQL로 자체 호스팅
+status: accepted
+date: 2026-05-20
+deciders: [@goohong]
+---
+
+# 0011. 운영 DB를 backend 서버 docker MySQL로 자체 호스팅
+
+## Context
+ADR 0001로 NCP 매니지드 MySQL 8.4.6을 도입했으나, 베타 사용자 < 100명 규모에서는 매니지드 백업·HA 기능이 비용 대비 과잉이다. 운영 데이터 사이즈도 22.84MB로 매우 작고(`pill_identifications` 캐시 21.59MB가 대부분), 다운타임 허용폭이 넓어 단일 인스턴스로 충분하다. 매니지드 월 구독료를 줄이는 것이 우선순위가 됐다.
+
+## Decision
+운영 DB를 **backend 서버(211.188.48.217) 의 docker MySQL 8.4.6** 으로 이전한다.
+- `ppiyaki-monitoring` docker network 내부에만 노출, 외부 포트 미공개
+- `mysql-data` 영속 볼륨에만 데이터 보관 (외부/오프사이트 백업 없음)
+- backend는 `jdbc:mysql://mysql:3306/ppiyaki` (network DNS)로 접속
+- credential은 backend 컨테이너 env(`DB_USERNAME`/`DB_PASSWORD`)와 동일하게 .env에 주입
+- 메모리 1GB 제한, healthcheck로 기동 검증
+
+ADR 0001은 superseded.
+
+## Consequences
+### 긍정적
+- 매니지드 월 구독료 제거 (가장 큰 비용 절감 효과)
+- backend ↔ DB 간 네트워크 hop이 사라져 평균 latency 감소
+- 모니터링 stack과 동일한 docker compose로 통합 관리
+
+### 부정적
+- **단일 장애점**: backend 서버 디스크/하드웨어 장애 시 데이터 손실 (외부 백업 없음 — 결정 시 명시적으로 수용)
+- **HA 없음**: 매니지드의 자동 fail-over 기능 상실
+- **자원 경합 위험**: backend + monitoring 5종 + MySQL이 같은 서버(2 vCPU / 3.8GB RAM)에서 공존 — 트래픽 증가 시 분리 필요
+- 백업·복구 운영 부담이 운영자에게 이전됨 (현재는 자동 cron 백업 없음)
+
+## Alternatives (considered)
+- (A) **별도 저렴한 VM에 docker MySQL** — 자원 분리는 안전하지만 VM 고정 비용이 다시 발생 → 비용 절감 효과 절반 이하
+- (B) **다른 클라우드의 저렴한 매니지드** (AWS RDS 등) — NCP Object Storage·CD 와 분리되어 운영 복잡도 증가
+- (C) **현 상태 유지** — 비용 절감 목표 미달성
+
+## References
+- Spec: `docs/features/db-self-hosted-migration.md`
+- Supersedes: ADR 0001
+- 마일스톤: 이슈 #395
+- 관련 PR: #396 (spec + docker-compose), #398 (migration scripts), #399 (마무리)
+- 마이그레이션 일시: 2026-05-20

--- a/docs/features/db-self-hosted-migration.md
+++ b/docs/features/db-self-hosted-migration.md
@@ -1,0 +1,133 @@
+---
+feature: DB 자체 호스팅 이전 (NCP 매니지드 MySQL → backend 서버 docker MySQL)
+slug: db-self-hosted-migration
+status: ready
+owner: @goohong
+scope: infra
+related_issues: []
+related_prs: []
+last_reviewed: 2026-05-20
+---
+
+# DB 자체 호스팅 이전
+
+## 1) 개요 (What / Why)
+NCP 매니지드 MySQL을 해지하고, 동일한 backend 서버(211.188.48.217)의 docker MySQL로 운영 DB를 이전한다. **유일한 목적은 비용 절감**이다 — NCP 매니지드 MySQL 월 구독료를 제거하고 동일 서버의 잉여 자원에 DB를 띄운다.
+
+대상: 시니어 사용자 수가 베타 규모(< 100명)인 현 시점에서 매니지드 백업·HA 기능을 사용할 만한 트래픽이 아니며, 비용 vs 안정성 트레이드오프에서 **비용을 택한 결정**.
+
+## 2) 사용자 시나리오
+- (운영자) 매니지드 DB 해지 후에도 시니어/보호자가 평소처럼 모든 기능을 사용 — 외부에서 보이는 동작 변화 없음.
+- (운영자) 서버 장애 시 docker 볼륨의 데이터만으로 복구. **단일 서버 장애 시 데이터 손실 가능성을 수용한다.**
+
+## 3) 요구사항
+### 기능 요구사항
+- [ ] backend 서버에 MySQL 8.4.6 컨테이너 신설 (NCP 매니지드와 동일 메이저 버전)
+- [ ] `ppiyaki-monitoring` 도커 네트워크 안에서만 접근 (localhost-bind, 외부 포트 노출 금지)
+- [ ] 영속 볼륨으로 `/var/lib/mysql` 데이터 보존 (서버 재부팅 후에도 유지)
+- [ ] NCP 매니지드 DB 데이터를 mysqldump로 일괄 이전
+- [ ] backend Spring Boot가 `DB_URL=jdbc:mysql://mysql:3306/ppiyaki`로 연결
+- [ ] CD 배포가 정상 동작 (Github Secrets만 갱신)
+
+### 비기능 요구사항
+- **성능**: 단일 서버에서 backend + DB 공존 시 OOM 발생하지 않을 것 (서버 메모리 사용량 < 80%)
+- **보안**: DB 외부 노출 금지 (3306 포트는 docker 내부 네트워크만)
+- **백업**: 로컬 docker 볼륨 보존만 (사용자 결정, [§9](#9-결정-로그) 참조)
+- **관측성**: prometheus mysqld_exporter 추가 (기존 monitoring stack에 결합)
+- **자원**: MySQL 컨테이너에 메모리 제한 설정 (예: 1GB) — 서버 OOM 방지
+
+## 4) 범위 / 비범위
+### 포함
+- backend 서버에 MySQL docker 컨테이너 신설
+- 데이터 일괄 이전 (mysqldump → restore)
+- backend-cd.yml의 DB 연결 정보 갱신
+- monitoring stack에 mysqld_exporter 통합
+- NCP 매니지드 DB 해지
+
+### 제외 (Out of Scope)
+- **외부(Object Storage 등) 백업**: 사용자가 명시적으로 로컬 볼륨만 선택 ([§9](#9-결정-로그))
+- **자동 백업 cron**: 로컬 볼륨만 보관하므로 별도 cron 없음. 추후 별도 PR로 추가 가능
+- **HA / replication**: 단일 인스턴스. master-slave 구성 없음
+- **다운타임 최소화 (replication 기반 cutover)**: 사용자가 다운타임 무제한 허용 → mysqldump 기반 단순 마이그레이션
+- **로컬 개발용 `docker-compose.yml`**: 이미 MySQL 컨테이너 정의되어 있음 — 변경 불필요
+- **데이터 스키마 변경**: Flyway/migration 없이 raw dump → restore
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+DB 이전은 인프라 변경이며 도메인 엔티티/컨텍스트는 건드리지 않는다. `docs/ai-harness/06-domain-model.md` §5 엔티티 정의 그대로 유지.
+
+### 5-2) API 엔드포인트
+변경 없음 (인프라 변경).
+
+### 5-3) 외부 연동
+- **이전**: NCP 매니지드 MySQL (외부 endpoint)
+- **이후**: 같은 서버의 docker MySQL (`ppiyaki-monitoring` 네트워크 내부 DNS `mysql:3306`)
+- **NCP 매니지드 DB는 마이그레이션 검증 후 해지**
+
+### 5-4) 데이터 흐름 / 마이그레이션 시퀀스
+
+```mermaid
+sequenceDiagram
+    actor admin as "운영자"
+    participant ncp as "NCP 매니지드 MySQL"
+    participant server as "backend 서버"
+    participant docker as "docker MySQL (신설)"
+    participant app as "ppiyaki-server"
+
+    admin->>server: ssh 접속
+    admin->>server: docker-compose up -d mysql (Step A)
+    server->>docker: 컨테이너 기동, 빈 DB
+    admin->>ncp: mysqldump (스키마+데이터) (Step B)
+    ncp-->>admin: dump.sql.gz
+    admin->>server: scp dump.sql.gz
+    admin->>docker: gunzip | mysql 로 import (Step C)
+    docker-->>admin: row count 검증
+    admin->>app: docker stop ppiyaki-server (다운타임 시작)
+    admin->>app: DB_URL 환경변수 변경 + 재기동 (Step D)
+    app->>docker: 정상 연결 검증
+    admin->>ncp: 매니지드 DB 해지 (Step E, 일정 기간 후)
+```
+
+### 5-5) DB 마이그레이션
+- 스키마 변경 없음. 기존 NCP DB의 스키마+데이터를 통째로 dump → restore
+- AUTO_INCREMENT 값, FK, 인덱스 모두 dump에 포함되도록 `mysqldump --triggers --routines --events --single-transaction --quick`
+- 마이그레이션 검증 쿼리: 주요 테이블의 row count, 최신 created_at 비교
+
+## 6) 작업 분할 (예상 PR 리스트)
+
+- [ ] **PR 1**: docker-compose에 prod MySQL 서비스 정의 (`infra/monitoring/docker-compose.yml`에 추가) + mysqld_exporter — 로컬에서 기동 검증
+- [ ] **PR 2**: prod 마이그레이션 실행 — **사용자 위임 작업** (AI는 스크립트만 작성, 운영 명령은 사용자가 직접 실행). 다음 산출물:
+  - `scripts/db-migration/dump-from-ncp.sh`
+  - `scripts/db-migration/restore-to-docker.sh`
+  - `scripts/db-migration/verify-counts.sh`
+- [ ] **PR 3**: backend-cd.yml의 `DB_URL` 환경변수 주입 방식 검토 (값은 GitHub Secrets에서 변경, 코드 변경 불필요 가능)
+- [ ] **PR 4**: NCP 매니지드 DB 해지 (운영자 콘솔 작업) + 도메인 문서 인프라 섹션 갱신
+
+## 7) 테스트 전략
+- **로컬 검증** (PR 1): `docker-compose up`으로 MySQL 기동 → backend 연결 → 기존 테스트 suite 통과
+- **prod dump 검증**: mysqldump → import 후 row count, 최신 row, 핵심 FK 검증 (verify-counts.sh)
+- **연결 검증**: backend 재기동 후 health check (`/actuator/health`) 200 확인
+- **롤백 시나리오**: PR 3 적용 후 문제 발생 시 GitHub Secrets의 `DB_URL`을 NCP 매니지드로 되돌리고 backend 재기동 → 매니지드 DB가 살아있는 한 즉시 복구
+
+## 8) 오픈 질문
+
+| # | 질문 | 선택지 | 담당/기한 |
+|---|---|---|---|
+| Q1 | 서버 메모리 여유 확인 (MySQL + backend + monitoring stack 공존 가능?) | (a) ssh로 점검 (b) 메모리 부족하면 swap 추가 | @goohong / PR1 전 |
+| Q2 | 데이터 사이즈 (dump 크기 예상) | (a) 작음(<100MB) → 즉시 (b) 큼 → 압축 전송 시간 산정 | @goohong / PR2 전 |
+| Q3 | NCP 매니지드 DB 해지 시점 | (a) 마이그레이션 직후 (b) 1주일 후 (롤백 여지 확보) | @goohong / PR4 전 |
+| Q4 | 로컬 볼륨 백업 안 함 — 서버 디스크 장애 시 데이터 손실 OK? | (a) OK (비용 우선) (b) 추후 cron + Object Storage 추가 | @goohong / 명시 결정 필요 |
+
+## 9) 결정 로그
+- **2026-05-20**: 초안 작성. 사용자 결정 반영:
+  - 이전 위치 = backend 서버 docker (Option A, 비용 절감 최대화)
+  - 다운타임 = 무제한 허용 (mysqldump 기반 단순 마이그레이션)
+  - 백업 = 로컬 docker 볼륨만 (외부 백업 X) — **데이터 손실 위험은 비용 절감을 위해 수용**
+- **2026-05-20**: 진행 방식 = Spec 먼저 합의 후 PR 분리하여 구현
+- **2026-05-20**: 오픈 질문 해소
+  - Q1 = 서버 메모리 2.5GB 가용 (총 3.8GB, 현 사용 1.1GB) → MySQL 1GB 할당 OK
+  - Q2 = 데이터 사이즈 22.84MB (대부분은 `pill_identifications` 21.59MB/25,992rows 식약처 캐시). 마이그레이션 예상 시간 < 1분
+  - Q3 = NCP 매니지드 DB 해지 시점 = 마이그레이션 직후 (롤백 여지 미확보 — 단순/빠른 정리 우선)
+  - Q4 = 로컬 docker 볼륨 백업만 (디스크 장애 시 데이터 손실 수용)
+- **2026-05-20**: status = draft → **ready** (Spec 합의 완료)

--- a/docs/features/db-self-hosted-migration.md
+++ b/docs/features/db-self-hosted-migration.md
@@ -1,7 +1,7 @@
 ---
 feature: DB 자체 호스팅 이전 (NCP 매니지드 MySQL → backend 서버 docker MySQL)
 slug: db-self-hosted-migration
-status: ready
+status: done
 owner: @goohong
 scope: infra
 related_issues: []
@@ -131,3 +131,13 @@ sequenceDiagram
   - Q3 = NCP 매니지드 DB 해지 시점 = 마이그레이션 직후 (롤백 여지 미확보 — 단순/빠른 정리 우선)
   - Q4 = 로컬 docker 볼륨 백업만 (디스크 장애 시 데이터 손실 수용)
 - **2026-05-20**: status = draft → **ready** (Spec 합의 완료)
+- **2026-05-20**: prod 적용 완료
+  - PR #396 머지 후 `infra/monitoring/docker-compose.yml`을 prod의 `/home/ubuntu/monitoring/`에 scp 동기화. `.env`에 `MYSQL_ROOT_PASSWORD` (openssl rand -hex 24) + `MYSQL_USER`/`MYSQL_PASSWORD` (backend의 `DB_USERNAME`/`DB_PASSWORD` 재사용) 추가
+  - `docker compose up -d mysql` → `ppiyaki-mysql` healthy 확인
+  - `dump-from-ncp.sh` → 1.9MB gzip 덤프 (NCP `pill_identifications` 25,515 rows 등 22 테이블)
+  - `restore-to-docker.sh` → 데이터 import
+  - `verify-counts.sh` + 정확 `SELECT COUNT(*)` 비교 → 22 테이블 모두 일치
+  - GitHub Secret `DB_URL` 갱신 (`jdbc:mysql://mysql:3306/ppiyaki`) + `workflow_dispatch`로 backend 재배포
+  - `ppiyaki-server` 로그 검증: HikariPool 정상 연결, MySQL 8.4.6 인식, JPA `validate` 통과, Tomcat 8080/8081 정상 기동
+- **2026-05-20**: ADR 0001 → superseded by ADR 0011 (self-hosted MySQL docker)
+- **2026-05-20**: status = ready → **done**

--- a/docs/features/medication-delay-grouped-notification.md
+++ b/docs/features/medication-delay-grouped-notification.md
@@ -1,0 +1,172 @@
+---
+feature: 복약 지연 알림 슬롯 단위 묶기
+slug: medication-delay-grouped-notification
+status: draft
+owner: @goohong
+scope: medication
+related_issues: [409]
+related_prs: []
+last_reviewed: 2026-05-28
+---
+
+# 복약 지연 알림 슬롯 단위 묶기
+
+> 부모 spec: `docs/features/medication-notification.md` (§5-4 보호자 미복약/지연 알림 흐름의 개선).
+> 본 spec은 `MEDICATION_DELAY` 카테고리만 다룬다. 다른 카테고리(REMINDER/DUR/COMPLETE/FAMILY_SAFETY)는 변경 없음.
+
+## 1) 개요 (What / Why)
+
+현재 `MedicationDelayDispatcher.dispatchForSenior`는 한 슬롯(BREAKFAST/LUNCH/DINNER)에 미인증된 schedule이 N개면 보호자에게 푸시 N건을 발송한다. 시니어가 아침에 약 3개를 안 먹으면 보호자 폰 알림 영역에 같은 슬롯·같은 시니어 알림이 3건 쌓여 시각적 노이즈가 발생한다.
+
+본 기능은 **슬롯·시니어·날짜 단위로 1건 묶어 발송**한다. 본문에 미복용 약 목록을 줄바꿈으로 나열하고, 데이터 페이로드에 `scheduleIds` 배열을 포함한다.
+
+대상 액터: 보호자.
+해결 문제: 슬롯당 N건의 중복 알림 → 1건 묶음 알림.
+
+## 2) 사용자 시나리오
+
+- 시니어 김장군이 아침에 타이레놀500mg / 비타민C / 위장약 3개를 60분 넘게 인증하지 않는다. 보호자는 **1건의 알림**을 받아 "김장군 어르신이 아침에 약 3개를 아직 복용하지 않았어요. (60분 경과)\n• 타이레놀500mg\n• 비타민C\n• 위장약"을 본다.
+- 시니어가 약 1개만 안 먹은 경우도 동일 흐름으로 1건. 본문은 약 개수 표현 없이 단일 약 형식으로 (§8 Q1).
+- 같은 슬롯에 추후 약을 일부만 인증해도 이미 발송된 알림은 갱신하지 않는다 (slot+date 단위 멱등 1회).
+
+## 3) 요구사항
+
+### 기능 요구사항
+- [ ] **슬롯 단위 1건 발송**: 한 슬롯의 미인증 schedule이 N개여도 보호자에게 푸시 1건 + 알림함 row 1건만 생성한다.
+- [ ] **본문 약 목록 나열**: N≥1 모두 동일한 묶음 포맷. 본문에 미복용 약 라벨을 `\n• `로 구분해 **전부 나열**한다. 라벨 형식은 기존 `resolveMedicineLabel`과 동일 (`{약이름} {복용량}`).
+- [ ] **payload `scheduleIds` JSON 배열 문자열**: FCM data에 `scheduleIds`를 JSON 배열 문자열로 포함 (예: `"[123,456,789]"`). FCM data는 String 값만 허용하므로 프론트가 `JSON.parse` 적용.
+- [ ] **slot+date 단위 멱등**: 같은 `(caregiver_id, senior_id, target_date, meal_slot)`에 대해 1회만 발송. 이후 추가 미복용이 생겨도 재발송하지 않는다. 코드 레벨 `existsBy` 체크만 사용 (DB UNIQUE 인덱스 변경 없음 — §5-5 옵션 A 확정).
+- [ ] **다른 카테고리 미변경**: REMINDER/DUR/COMPLETE/FAMILY_SAFETY 코드 경로와 메시지 포맷 무변경.
+
+### 비기능 요구사항
+- **호환성**: FCM data payload key 변경 (`scheduleId` 단수 → `scheduleIds` JSON 배열 문자열). 프론트엔드 cut-over 필요 — Notion API 명세 갱신 + 진영에게 디스코드 안내.
+- **관측성**: 기존 `MEDICATION_DELAY notification created` INFO 로그 유지. schedule 개수를 로그에 포함.
+- **메시지 길이**: FCM body 4KB 제한. 운영상 슬롯당 미인증 약 ≤10개로 추정, 상한 두지 않음.
+
+## 4) 범위 / 비범위
+
+### 포함
+- `MedicationDelayDispatcher.dispatchForSenior` 슬롯 단위 집계 로직
+- `Notification.createForMedicationDelay` 시그니처 변경 (`scheduleId` 단수 → schedule_id 컬럼 NULL 처리)
+- `NotificationRepository` 멱등 체크 메서드 교체 (`existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId` → slot+date 단위)
+- DB UNIQUE 인덱스 검토 (§5-5)
+- 본문 포맷 변경
+- 단위 + E2E 테스트 갱신
+
+### 제외 (Out of Scope)
+- 시니어 본인의 `MEDICATION_REMINDER`도 마찬가지로 묶을지 — 시니어 측 알림은 이미 슬롯 단위 1건이므로 무변경 (`medication-notification.md` §5-4)
+- "추가 미복용 발생 시 갱신 알림" — 첫 발송 1회로 충분, 추가 noise 회피
+- 슬롯 외 시간대(임의 schedule time) 처리 — 현재 dispatcher 자체가 mealTime 단위라 N/A
+- DUR/COMPLETE 알림 본문/payload 변경
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+
+**`Notification` 엔티티 변경**:
+- `createForMedicationDelay` 시그니처에서 `scheduleId` 파라미터 제거. `MEDICATION_DELAY` row의 `schedule_id` 컬럼은 NULL로 저장.
+- 미복용 schedule 목록은 본문 텍스트(보호자 가독)와 FCM payload(클라이언트 라우팅)에만 노출. 알림함 row에 schedule ids를 영속할 필요는 현재 사용처 없음.
+
+**`MedicationDelayDispatcher` 변경**:
+- 슬롯 루프 내부에서 미복용 schedule 리스트를 먼저 집계 → 빈 리스트면 skip, 비어있지 않으면 1회 `sendDelayNotification(caregiverId, senior, slot, today, schedules, thresholdMinutes)` 호출.
+- 보호자 루프 안에서 멱등 체크 → 미발송 시 발송. 멱등 키 = `(caregiverId, MEDICATION_DELAY, seniorId, today, slot)`.
+
+**`NotificationRepository` 변경**:
+- `existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(...)` 메서드 제거 (현재 MEDICATION_DELAY 외 사용처 없음 — verify 필요).
+- `existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot(...)` 신설.
+
+**`docs/ai-harness/06-domain-model.md` 갱신**: 알림 카테고리별 멱등 키 설명을 보유한 섹션이 있다면 갱신. (스펙 갱신 시 확인)
+
+### 5-2) API 엔드포인트
+
+외부 노출 API 명세 무변경. FCM data payload key만 변경:
+
+| Before | After |
+|---|---|
+| `scheduleId: "123"` (단일 schedule) | `scheduleIds: "[123,456,789]"` (JSON 배열 문자열) |
+
+→ Notion API 명세에서 FCM payload 섹션 갱신 (보호자 미복약 알림 항목).
+
+### 5-3) 외부 연동
+
+FCM payload data 필드:
+```json
+{
+  "category": "MEDICATION_DELAY",
+  "seniorId": "16",
+  "mealSlot": "BREAKFAST",
+  "scheduleIds": "[123,456,789]"
+}
+```
+
+본문 포맷 — N≥1 동일:
+```
+{시니어} 어르신이 {슬롯}에 약 {N}개를 아직 복용하지 않았어요. ({임계}분 경과)
+• {약1}
+• {약2}
+• {약3}
+```
+
+### 5-4) 데이터 흐름 / 시퀀스
+
+```
+slot 루프
+  ├─ mealTime 미설정/미경과 → skip
+  ├─ slotSchedules 조회 → 빈 set이면 skip
+  ├─ takenScheduleIds 집계
+  └─ 보호자 루프
+       ├─ settings.medicationDelayEnabled=false → skip
+       ├─ thresholdMinutes 미경과 → skip
+       ├─ unsentSchedules = slotSchedules - takenScheduleIds  ← 신규: 사전 집계
+       ├─ unsentSchedules 빈 set → skip                       ← 신규: 전부 인증된 경우
+       ├─ 멱등 체크 (slot+date 단위)                          ← 변경
+       └─ 미발송 시 sendDelayNotification(unsentSchedules)    ← 변경: 리스트 전달
+```
+
+### 5-5) DB 마이그레이션
+
+**없음** — 옵션 A 확정 (§9 결정 로그). `notifications.uk_notifications_dedup` UNIQUE 인덱스 변경하지 않고 코드 레벨 멱등(`existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot`)만 적용. MEDICATION_DELAY row의 `schedule_id` 컬럼은 NULL로 저장.
+
+근거:
+- cron tick은 1분 간격, 동일 분 내 race는 ppiyaki 운영 규모(보호자 수십 명)에서 무시 가능.
+- 코드 `existsBy` 체크가 사실상 멱등 보장.
+- MySQL 8 partial unique index 미지원 → 카테고리별 분리는 over-engineering.
+
+⚠️ 보호 영역 변경 없음 → PR에 `needs-human-review` 라벨 불필요.
+
+## 6) 작업 분할 (예상 PR 리스트)
+
+- [ ] **PR 1: spec 초안 머지** (this PR, `type:docs`, `scope:medication`, `ai-generated`)
+- [ ] **PR 2: 구현** — `MedicationDelayDispatcher` 슬롯 단위 집계 + `Notification.createForMedicationDelay` 시그니처 변경 + `NotificationRepository` 메서드 교체 + 단위/E2E 테스트 갱신 + Notion API 명세 갱신. **라벨**: `type:refactor`, `scope:medication`, `ai-generated`. DB 마이그레이션 옵션 A 채택 시 보호 영역 변경 없음.
+
+## 7) 테스트 전략
+
+- **단위 (`MedicationDelayDispatcherTest`)**:
+  - 슬롯에 미인증 schedule 3개 → 알림 1건만 생성, 본문에 약 3개 나열, payload `scheduleIds`에 3개 ID 포함.
+  - 슬롯에 미인증 schedule 1개 → 알림 1건, 본문은 단일 약 포맷.
+  - 슬롯의 모든 schedule이 인증됨 → 알림 0건.
+  - 같은 slot+date에 두 번째 tick → 알림 0건 (멱등).
+  - 보호자 `medicationDelayEnabled=false` → 알림 0건.
+  - 임계 미경과 → 알림 0건.
+- **E2E**: 기존 보호자 미복약 알림 E2E 테스트가 있다면 본문/payload 형식 검증 추가. 없으면 신규 1건 (CLAUDE.md §4 — 신규 엔드포인트 E2E 필수이지만 이번엔 신규 엔드포인트 X. 그러나 dispatcher 통합 테스트 권장).
+- **FCM mock**: `PushSender` mock으로 `PushPayload.data.scheduleIds`가 콤마 구분 String인지 검증.
+
+## 8) 오픈 질문
+
+> 모든 질문 2026-05-28 해소 (§9 참조).
+
+| # | 질문 | 결정 |
+|---|---|---|
+| ~~Q1~~ | N==1 본문 포맷 | (b) 묶음 형식 통일 ✅ |
+| ~~Q2~~ | payload `scheduleIds` 직렬화 | (b) JSON 배열 문자열 ✅ |
+| ~~Q3~~ | 본문 약 목록 표시 개수 상한 | (a) 전부 나열, 상한 없음 ✅ |
+| ~~Q4~~ | DB UNIQUE 인덱스 변경 | (a) 옵션 A — 코드 멱등만 ✅ |
+| Q5 | FCM data key 변경의 프론트엔드 cut-over 시점 | 백엔드 머지 직후 동시 cut-over (호환 윈도 미제공). 진영에게 디스코드로 별도 안내. — 사용자 합의 보류 |
+
+## 9) 결정 로그
+
+- 2026-05-28: 초안 작성 (status=draft). 이슈 #409, 사용자 백로그 3번 항목. 부모 spec `medication-notification.md`의 §5-4 동작 개선. 단일 PR 예상.
+- 2026-05-28: **Q1 해소** — N==1도 묶음 포맷 통일. 이유: 코드 단순(분기 제거), 본문 일관성, N==1은 운영상 빈도 낮음. 본문 예시: "김장군 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 타이레놀500mg".
+- 2026-05-28: **Q2 해소** — payload `scheduleIds`는 JSON 배열 문자열 (`"[123,456,789]"`). 이유: 약 ID에 콤마 없음이 보장됨, 프론트 `JSON.parse` 단일 호출로 깔끔, 확장성(향후 객체 추가 가능).
+- 2026-05-28: **Q3 해소** — 약 목록 상한 없음, 전부 나열. 이유: 운영상 슬롯당 미인증 ≤10개 추정 → FCM body 4KB 한도 내, 상한 로직 도입 시 "외 N개" UX 추가 결정 필요해 단순화.
+- 2026-05-28: **Q4 해소** — 옵션 A 채택. 인덱스 변경 없이 코드 레벨 멱등(`existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot`)만 적용. 이유: §5-5 권장안. 보호 영역 변경 없음.

--- a/docs/features/redis-infra-setup.md
+++ b/docs/features/redis-infra-setup.md
@@ -5,7 +5,7 @@ status: draft
 owner: @dohyeon
 scope: infra
 related_issues: [403]
-related_prs: [406]
+related_prs: [406, 407]
 last_reviewed: 2026-05-22
 ---
 
@@ -44,8 +44,8 @@ last_reviewed: 2026-05-22
 - `.env.example` 갱신
 
 ### 제외 (Out of Scope)
-- **DrugInfoClient / MfdsApiClient 캐시의 Redis 전환**: 후속 이슈 #404에서 진행
-- **InMemoryRateLimiter의 Redis 전환**: 후속 이슈 #405에서 진행
+- **DrugInfoClient / MfdsApiClient 캐시의 Redis 전환**: PR #408에서 진행
+- **InMemoryRateLimiter의 Redis 전환 + 초대코드 횟수 제한**: PR #407에서 진행
 - **Redis Sentinel / Cluster 구성**: 단일 인스턴스. 베타 규모에서 HA 불필요
 - **Spring Session (세션 저장소)**: JWT 기반 인증이므로 세션 저장소 불필요
 - **prod 서버 docker-compose 수정**: CD 파이프라인 변경은 별도 작업
@@ -84,11 +84,12 @@ last_reviewed: 2026-05-22
 
 ## 8) 오픈 질문
 
-| # | 질문 | 선택지 | 담당/기한 |
-|---|---|---|---|
-| Q1 | 로컬 테스트 시 embedded Redis vs docker Redis? | (a) Testcontainers로 Redis 컨테이너 기동 / (b) embedded-redis 라이브러리 / (c) docker-compose의 Redis 사용 | @dohyeon / 2026-05-23 |
-| Q2 | prod 배포 시 Redis 컨테이너를 backend-cd.yml에서 함께 관리할지, 별도 docker-compose로 분리할지 | (a) backend docker-compose에 포함 / (b) monitoring처럼 별도 compose | @dohyeon / 2026-05-23 |
+모두 해소됨 → §9 결정 로그로 이동.
 
 ## 9) 결정 로그
 
 - 2026-05-22: 초안 작성 (status=draft)
+- 2026-05-22: Q1 → (c) docker-compose의 Redis 사용. 테스트 환경에서는 Redis 없이 InMemory fallback으로 동작 / @dohyeon
+- 2026-05-22: Q2 → (a) backend docker-compose에 포함. Redis는 backend 앱이 직접 의존하는 저장소이므로 MySQL과 같이 관리 / @dohyeon
+- 2026-05-22: prod NCP 서버에 Redis 7 컨테이너 기동 완료, 비밀번호 설정 완료
+- 2026-05-24: 초대코드(invite_codes) 저장소를 MySQL → Redis로 이전하는 후속 작업 식별. 별도 이슈로 분리 예정

--- a/docs/features/redis-infra-setup.md
+++ b/docs/features/redis-infra-setup.md
@@ -1,0 +1,94 @@
+---
+feature: Redis 인프라 설정 및 Spring Boot 연동 구성
+slug: redis-infra-setup
+status: draft
+owner: @dohyeon
+scope: infra
+related_issues: [403]
+related_prs: []
+last_reviewed: 2026-05-22
+---
+
+# Redis 인프라 설정 및 Spring Boot 연동 구성
+
+## 1) 개요 (What / Why)
+프로젝트에 Redis를 도입하여 JVM 메모리 기반 캐시와 Rate Limiter를 Redis로 전환하기 위한 **기반 인프라**를 구성한다.
+
+현재 외부 API 응답 캐시(`DrugInfoClient`, `MfdsApiClient`)와 Rate Limiter(`InMemoryRateLimiter`)가 모두 `ConcurrentHashMap`으로 동작한다. 서버 재시작 시 캐시가 소실되고, 다중 인스턴스 환경에서 상태가 공유되지 않는 문제가 있다. 이 Feature Spec은 Redis 서버 자체와 Spring Boot 연동 설정만 다루며, 개별 캐시/Rate Limiter의 Redis 전환은 후속 이슈(#404, #405)에서 진행한다.
+
+## 2) 사용자 시나리오
+- (개발자) 로컬에서 `docker compose up -d`로 MySQL + Redis가 함께 기동되어 별도 설치 없이 개발 가능.
+- (운영자) prod 배포 시 Redis 컨테이너가 backend와 같은 docker network에서 동작하며, 외부 포트 노출 없이 내부 통신.
+- (개발자) `RedisTemplate` 또는 Spring Cache abstraction을 통해 Redis에 값을 저장/조회할 수 있다.
+
+## 3) 요구사항
+### 기능 요구사항
+- [ ] `build.gradle`에 `spring-boot-starter-data-redis` 의존성 추가
+- [ ] `application.yml`에 Redis 접속 설정 추가 (default 프로필: localhost:6379)
+- [ ] `application-prod.yml`에 prod Redis 접속 설정 추가 (환경변수 바인딩)
+- [ ] 로컬 `docker-compose.yml`에 Redis 7 컨테이너 추가
+- [ ] `StringRedisTemplate` 빈이 정상 주입되는지 확인하는 통합 테스트 작성
+- [ ] `.env.example`에 Redis 관련 환경변수 placeholder 추가
+
+### 비기능 요구사항
+- **보안**: prod Redis는 docker 내부 네트워크만 접근 가능 (외부 포트 노출 금지). 비밀번호 설정.
+- **관측성**: Actuator + Micrometer의 Redis 메트릭 자동 수집 활성화
+- **자원**: Redis 컨테이너 `maxmemory 256mb` + `maxmemory-policy allkeys-lru` 설정 (서버 OOM 방지)
+- **호환**: 기존 테스트(H2 기반)가 Redis 없이도 통과해야 함 (Redis 비활성 시 기존 동작 유지)
+
+## 4) 범위 / 비범위 (중요)
+### 포함
+- Redis 의존성 추가 및 Spring Boot auto-configuration 연동
+- 로컬/prod 환경 Redis 컨테이너 및 접속 설정
+- 연결 확인용 통합 테스트
+- `.env.example` 갱신
+
+### 제외 (Out of Scope)
+- **DrugInfoClient / MfdsApiClient 캐시의 Redis 전환**: 후속 이슈 #404에서 진행
+- **InMemoryRateLimiter의 Redis 전환**: 후속 이슈 #405에서 진행
+- **Redis Sentinel / Cluster 구성**: 단일 인스턴스. 베타 규모에서 HA 불필요
+- **Spring Session (세션 저장소)**: JWT 기반 인증이므로 세션 저장소 불필요
+- **prod 서버 docker-compose 수정**: CD 파이프라인 변경은 별도 작업
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+인프라 변경이며 도메인 엔티티/컨텍스트는 건드리지 않는다.
+
+### 5-2) API 엔드포인트
+변경 없음 (인프라 변경).
+
+### 5-3) 외부 연동
+- **Redis 7** (로컬: docker-compose, prod: 같은 서버의 docker 컨테이너)
+- 라이브러리: `spring-boot-starter-data-redis` (Lettuce 기본 드라이버)
+
+### 5-4) 데이터 흐름 / 시퀀스
+
+```
+[Spring Boot App]
+      │
+      ├── RedisTemplate / @Cacheable
+      │         │
+      └─────── Lettuce ──── Redis 7 (docker, port 6379 내부)
+```
+
+### 5-5) DB 마이그레이션
+없음. Redis는 별도 데이터 저장소이며 MySQL 스키마 변경 없음.
+
+## 6) 작업 분할 (예상 PR 리스트)
+- [ ] PR 1: `chore(infra): Redis 인프라 설정 및 Spring Boot 연동 구성 #403` — 의존성, 설정, docker-compose, 통합 테스트, .env.example
+
+## 7) 테스트 전략
+- **통합 테스트**: `StringRedisTemplate`으로 `SET` / `GET` / `EXPIRE` 동작 확인
+- **기존 테스트 호환**: Redis 미기동 환경(CI H2 테스트)에서 기존 테스트가 깨지지 않아야 함. `@ConditionalOnProperty` 또는 프로필 분리로 격리
+
+## 8) 오픈 질문
+
+| # | 질문 | 선택지 | 담당/기한 |
+|---|---|---|---|
+| Q1 | 로컬 테스트 시 embedded Redis vs docker Redis? | (a) Testcontainers로 Redis 컨테이너 기동 / (b) embedded-redis 라이브러리 / (c) docker-compose의 Redis 사용 | @dohyeon / 2026-05-23 |
+| Q2 | prod 배포 시 Redis 컨테이너를 backend-cd.yml에서 함께 관리할지, 별도 docker-compose로 분리할지 | (a) backend docker-compose에 포함 / (b) monitoring처럼 별도 compose | @dohyeon / 2026-05-23 |
+
+## 9) 결정 로그
+
+- 2026-05-22: 초안 작성 (status=draft)

--- a/docs/features/redis-infra-setup.md
+++ b/docs/features/redis-infra-setup.md
@@ -5,7 +5,7 @@ status: draft
 owner: @dohyeon
 scope: infra
 related_issues: [403]
-related_prs: []
+related_prs: [406]
 last_reviewed: 2026-05-22
 ---
 
@@ -64,7 +64,7 @@ last_reviewed: 2026-05-22
 
 ### 5-4) 데이터 흐름 / 시퀀스
 
-```
+```text
 [Spring Boot App]
       │
       ├── RedisTemplate / @Cacheable

--- a/docs/features/user-nickname-not-null.md
+++ b/docs/features/user-nickname-not-null.md
@@ -1,0 +1,134 @@
+---
+feature: User.nickname NOT NULL 강제
+slug: user-nickname-not-null
+status: draft
+owner: @goohong
+scope: user
+related_issues: [417]
+related_prs: []
+last_reviewed: 2026-05-28
+---
+
+# User.nickname NOT NULL 강제
+
+> 발단: PR #414 (안부 알림) 구현 중 시니어 닉네임 NULL 가능성이 드러나 `WellbeingPingService`에 `nickname == null ? "" : nickname` 방어 코드가 들어갔다. 이 가드를 service에 두는 것은 [[feedback-no-service-null-guards]] 룰과 충돌하고, 본질적으로 도메인 불변식을 service에 누설한 것이다.
+
+## 1) 개요 (What / Why)
+
+`users.nickname`은 현재 코드/DB 양쪽에서 nullable로 선언되어 있다 (`@Column(name = "nickname")` + `nickname varchar(255)`). 그러나 모든 가입 경로(`signup`, `onboarding`, `senior add`)의 DTO는 `@NotBlank` 검증을 적용하고 있어 사실상 NULL이 들어올 수 없다.
+
+**예외 한 곳**: 카카오 로그인 흐름(`AuthService.createNewUser(payload, ...)`)이 `KakaoIdTokenPayload.nickname`을 그대로 저장하는데, 카카오 OIDC profile 스코프는 nickname 미동의 가능 → null로 들어올 수 있다.
+
+본 spec은 코드/DB/도메인 팩토리 전체에서 `User.nickname`을 NOT NULL로 강제하고, 카카오 흐름의 null 가능성을 명시적으로 메우는 것을 목표로 한다.
+
+대상 액터: 백엔드.
+해결 문제: 도메인 불변식 누설 + 코드/DB 선언과 실제 정책 불일치.
+
+## 2) 사용자 시나리오 (개발자 관점)
+
+- 카카오 로그인 사용자가 닉네임 동의를 거부 → 회원 가입은 성공하되 default 닉네임(예: `회원{userId}`)이 부여된다. 사용자는 가입 후 닉네임을 변경할 수 있다 (기존 `updateNickname` API).
+- `User.createSenior(...)`로 시니어를 만들 때 nickname이 null이면 컴파일 흐름이 아닌 런타임에 `NullPointerException` 발생 → 코드 작성자가 즉시 인지.
+- `WellbeingPingService`는 더 이상 `senior.getNickname() == null ? "" : senior.getNickname()`을 하지 않고 `senior.getNickname()` 그대로 사용한다.
+
+## 3) 요구사항
+
+### 기능 요구사항
+- [ ] **DB 컬럼 NOT NULL**: `users.nickname`을 `VARCHAR(255) NOT NULL`로 변경. 마이그레이션 PR 별도.
+- [ ] **운영 DB 사전 보강**: 운영 DB에 `nickname IS NULL`인 row가 존재하면 마이그레이션 직전 채워 넣어야 한다. 사용자 직접 확인 + 위임 (§8 Q1).
+- [ ] **카카오 흐름 default 닉네임**: `AuthService.createNewUser(payload, ...)`에서 `payload.nickname()`이 null이면 default 값으로 대체 (§8 Q2에서 default 형식 결정).
+- [ ] **User 생성자 가드**: `User` 생성자 (라인 80-96)에 `Objects.requireNonNull(nickname, ...)` 추가.
+- [ ] **createSenior 팩토리 일관성**: `User.createSenior(String, LocalDate)`에도 `Objects.requireNonNull(nickname, ...)` 추가 (다른 오버로드 `createSenior(String, Gender)`에는 이미 있음).
+- [ ] **schema.sql 갱신**: `nickname varchar(255) NOT NULL` 적용.
+- [ ] **WellbeingPingService 가드 제거**: `senior.getNickname() == null ? "" : senior.getNickname()` → `senior.getNickname()`.
+- [ ] **도메인 모델 문서 갱신**: `docs/ai-harness/06-domain-model.md` §5 users 표에 `nickname` 필드 NOT NULL 표기.
+
+### 비기능 요구사항
+- **호환성**: 운영 DB에 NULL row가 남아있는 상태로 마이그레이션 실행 시 실패. 사전 보강 필수.
+- **관측성**: 카카오 default 닉네임 부여 시 INFO 로그 1줄(`kakao signup with default nickname (userId={}, providerUserId={})`).
+
+## 4) 범위 / 비범위
+
+### 포함
+- DB 컬럼 NOT NULL + 마이그레이션
+- User 생성자/팩토리 가드 추가
+- 카카오 흐름 null fallback
+- WellbeingPingService 가드 제거
+- 도메인 모델 문서 갱신
+
+### 제외 (Out of Scope)
+- 다른 nullable 컬럼 (`login_id`, `gender`, `birth_date` 등) NOT NULL 강제 — 본 spec은 nickname 한정
+- 닉네임 길이/금칙어 검증 — 별도 spec
+- 닉네임 중복 방지 — 별도 spec
+- 기존 카카오 가입 사용자의 닉네임 일괄 재발부 — 사전 보강 SQL로 1회성 처리
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+
+**`User` 엔티티 변경**:
+- 생성자 (`User(...)`)에 `Objects.requireNonNull(nickname, "nickname must not be null")` 추가.
+- `createSenior(String, LocalDate)` 팩토리에 동일 가드 추가.
+- `@Column(name = "nickname", nullable = false, length = 255)` 으로 명시.
+
+**`AuthService.createNewUser` 변경 (카카오)**:
+```java
+final String nickname = payload.nickname() != null && !payload.nickname().isBlank()
+        ? payload.nickname()
+        : DEFAULT_KAKAO_NICKNAME_PREFIX + savedUserId; // 또는 sub 기반
+```
+default 형식은 §8 Q2.
+
+**`WellbeingPingService` 변경**:
+- `senior.getNickname() == null ? "" : senior.getNickname()` 가드 제거.
+- `senior.getNickname()` 직접 사용.
+
+**`docs/ai-harness/06-domain-model.md` §5 users 표**:
+- `nickname` 행을 `varchar(255) nullable` → `varchar(255) NOT NULL` 로 갱신.
+
+### 5-2) API 엔드포인트
+변경 없음.
+
+### 5-3) 외부 연동
+- **카카오 OIDC**: nickname 미제공 케이스 처리 명시화.
+
+### 5-4) DB 마이그레이션
+
+```sql
+-- 1) NULL row 보강 (운영에서 사전 실행)
+UPDATE users
+SET nickname = CONCAT('회원', id)
+WHERE nickname IS NULL;
+
+-- 2) NOT NULL 적용
+ALTER TABLE users
+MODIFY COLUMN nickname VARCHAR(255) NOT NULL;
+```
+
+`schema.sql`도 함께 갱신. 마이그레이션은 보호 영역(`**/db/migration/**` 또는 `src/main/resources/**`) — `needs-human-review` 라벨 필수.
+
+## 6) 작업 분할 (예상 PR 리스트)
+
+- [ ] PR 1: spec 초안 (본 문서)
+- [ ] PR 2: 카카오 흐름 default 닉네임 + User 생성자/팩토리 가드 + 도메인 모델 문서 갱신 (`scope:user`, 코드만)
+- [ ] PR 3: schema.sql NOT NULL 적용 + `WellbeingPingService` 가드 제거 (`scope:user`, **사전: 운영 DB NULL row 보강 완료 + PR 2 머지 완료**)
+- [ ] (사용자 위임) 운영 DB `UPDATE users SET nickname = ... WHERE nickname IS NULL` 실행
+
+## 7) 테스트 전략
+
+- **단위 테스트**:
+  - `User` 생성자 nickname null 입력 시 `NullPointerException`.
+  - `AuthService.createNewUser` 카카오 payload nickname null → default 적용.
+- **E2E**:
+  - 카카오 로그인 (mock된 verifier가 nickname null payload 반환) → 회원 생성 + default 닉네임 부여 검증.
+
+## 8) 오픈 질문
+
+| # | 질문 | 선택지 | 담당/기한 |
+|---|---|---|---|
+| Q1 | 운영 DB `users.nickname IS NULL` row가 실제로 존재하는가? | (a) 0건 — 마이그레이션 바로 가능 / (b) 존재 — 사전 UPDATE 후 진행 | @goohong (사용자 직접 SQL 확인) |
+| Q2 | 카카오 default 닉네임 형식 | (a) `회원{userId}` / (b) `회원{sub}` (Kakao provider user id) / (c) `사용자` (고정) / (d) 가입 거부 (400 응답) | @goohong / spec 합의 시점 |
+| Q3 | PR 2 머지와 PR 3 머지 사이 운영에 카카오 가입자가 nickname null로 들어올 위험 | (a) PR 2 머지 즉시 PR 3 머지 / (b) PR 2 머지 → 운영 배포 검증 → PR 3 머지 | @goohong / spec 합의 시점 |
+
+## 9) 결정 로그
+
+- 2026-05-28: 초안 작성 (status=draft). 발단은 PR #414 안부 알림 구현에서 노출된 `WellbeingPingService` nickname null 가드.

--- a/docs/features/wellbeing-ping.md
+++ b/docs/features/wellbeing-ping.md
@@ -1,0 +1,154 @@
+---
+feature: 안부 알림 (시니어 → 보호자 콕찌르기)
+slug: wellbeing-ping
+status: draft
+owner: @goohong
+scope: user
+related_issues: []
+related_prs: []
+last_reviewed: 2026-05-28
+---
+
+# 안부 알림 (시니어 → 보호자 콕찌르기)
+
+> 부모 spec: 없음. 신규 알림 카테고리(`WELLBEING_PING`)를 도입한다.
+> 비교 대상: `FAMILY_SAFETY` (시니어 48시간 미접속 시 자동 발송) — 본 기능은 **시니어 능동 트리거**라 카테고리를 분리한다.
+
+## 1) 개요 (What / Why)
+
+시니어가 보호자 정보 화면에서 가벼운 신호 하나로 "잘 지내고 있어요"를 전달하고 싶을 때 사용하는 1-tap 푸시. 페이스북 옛 "콕찌르기" UX의 한국형 변형으로, **의미 없는 신호 1개로 안부를 전한다**.
+
+대상 액터: 시니어.
+해결 문제: 메시지 작성/통화 진입장벽 없이 보호자에게 "잘 있음" 시그널을 전달.
+
+## 2) 사용자 시나리오
+
+- 시니어 김장군은 보호자 화면을 열어 본인을 돌보는 보호자 목록을 본다. 특정 보호자 카드의 "안부 전하기" 버튼을 누른다. 보호자는 폰에서 "김장군 어르신이 안부를 전했어요." 푸시를 받는다.
+- 시니어가 30초 뒤 같은 보호자에게 다시 안부를 보낸다 → 쿨다운 1분 미경과로 429 응답. 1분 뒤 재시도하면 성공.
+- 시니어가 보호자 A, B에게 동시에 안부를 보낸다 → 각자 쿨다운이 독립적이므로 둘 다 발송된다.
+
+## 3) 요구사항
+
+### 기능 요구사항
+- [ ] **단방향 발송**: 시니어 → 보호자 방향만 허용. 보호자가 시니어에게 보내는 endpoint는 만들지 않는다.
+- [ ] **CareRelation 검증**: 발신 시니어와 수신 보호자 사이에 활성 `CareRelation` (`deletedAt IS NULL`)이 있어야 한다. 없으면 403.
+- [ ] **쿨다운 1분**: 동일 `(seniorId, caregiverId)` 쌍에 대해 최근 60초 이내 발송 이력이 있으면 429 응답. Redis 기반.
+- [ ] **푸시 발송**: 보호자의 활성 `DeviceToken` 전부에 FCM 푸시 1회 발송. `PushSender.send` 결과 `tokenInvalid` 시 토큰 비활성화 (기존 dispatcher 동일 패턴).
+- [ ] **알림함 row 미생성**: `Notification` 테이블에 row를 만들지 않는다. 푸시만 전달 후 끝낸다.
+- [ ] **푸시 본문**: 제목 `"안부 알림"`, 본문 `"{시니어 닉네임} 어르신이 안부를 전했어요."`. payload data: `{ "category": "WELLBEING_PING", "seniorId": "<id>" }`.
+- [ ] **NotificationCategory enum 추가**: `WELLBEING_PING` 값을 `NotificationCategory` enum에 추가한다 (FCM payload의 `category` 식별자 일관성을 위해). 단, 본 카테고리는 알림함에 저장되지 않으므로 enum 추가는 푸시 식별자 + 향후 통계용 목적에 한정.
+
+### 비기능 요구사항
+- **응답 시간**: p95 ≤ 500ms. FCM 발송은 동기 호출이지만 토큰당 ~100ms 이내 예상.
+- **관측성**: `WELLBEING_PING dispatched (sender={seniorId}, receiver={caregiverId}, tokens={count})` INFO 로그 1줄.
+- **레이트리밋 관측성**: 쿨다운 컷오프 시 DEBUG 로그 1줄.
+- **인증**: JWT 필수. 발신 시니어는 토큰의 사용자 ID에서 추출 (path/body에서 받지 않음).
+
+## 4) 범위 / 비범위
+
+### 포함
+- 새 `WellbeingPingController` + `WellbeingPingService`
+- `NotificationCategory.WELLBEING_PING` enum 값 추가
+- Redis 기반 쿨다운 (TTL 60초)
+- 기존 `PushSender` / `DeviceTokenRepository` / `CareRelationRepository` 재사용
+- E2E 성공 케이스 + 쿨다운 차단 케이스
+
+### 제외 (Out of Scope)
+- 보호자 → 시니어 방향
+- 시니어 → 시니어 또는 보호자 → 보호자 (동일 역할 간)
+- 메시지 본문 사용자 입력 (고정 1종 본문만)
+- 메시지 본문 다양성 (랜덤 멘트 풀) — 추후 검토
+- 알림함 영속화 — `WELLBEING_PING` 카테고리는 `Notification` 테이블에 row 만들지 않음
+- 보호자가 직접 "안부 알림 받지 않기" 설정 끄기 (`NotificationSettings`에 토글 추가) — 1차에선 무조건 발송, 후속 spec에서 검토
+- 안부 발송 통계/이력 조회 API
+- 안부 받은 직후 보호자가 회신("나도 잘 있어요") 흐름 — 별도 spec
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+
+**`NotificationCategory` enum 변경**:
+- `WELLBEING_PING` 추가. 의미: 시니어가 보호자에게 보내는 능동적 안부 신호.
+- 알림함 영속화는 하지 않지만 FCM payload `category` 식별자 + 향후 발송 통계용으로 enum 등재.
+
+**신규 빈**:
+- `WellbeingPingService` — care relation 검증 + 쿨다운 체크 + 푸시 발송. `@Transactional` 불필요 (DB write 없음).
+- `WellbeingPingController` — endpoint 노출.
+- `WellbeingPingCooldownStore` (or 같은 책임의 컴포넌트) — Redis 기반 쿨다운 SETNX.
+
+**`docs/ai-harness/06-domain-model.md` 갱신 항목** (이번 PR과 동기):
+- §4 유비쿼터스 랭귀지: "안부 알림 / Wellbeing Ping" 용어 등재.
+- §알림 카테고리 표가 있다면 `WELLBEING_PING` 행 추가.
+
+### 5-2) API 엔드포인트
+
+| Method | Path | 설명 | 인증 | Req | Res |
+|---|---|---|---|---|---|
+| POST | /api/v1/notifications/wellbeing-pings | 시니어가 보호자에게 안부 신호 발송 | 필수 (SENIOR) | `WellbeingPingCreateRequest` | 204 No Content |
+
+**`WellbeingPingCreateRequest`**:
+```json
+{ "caregiverId": 123 }
+```
+
+**응답 코드**:
+- `204 No Content` — 발송 성공 (보호자 활성 토큰 0개인 경우도 204. 로그에 `tokens=0` 기록)
+- `400 Bad Request` — `caregiverId` 누락/형식 오류
+- `401 Unauthorized` — JWT 없음/만료
+- `403 Forbidden` — 발신자가 SENIOR 역할이 아니거나, 수신자와 CareRelation 없음
+- `404 Not Found` — `caregiverId`에 해당하는 사용자 없음
+- `429 Too Many Requests` — 쿨다운 미경과 (Retry-After 헤더에 남은 초)
+
+### 5-3) 외부 연동
+
+- **FCM (PushSender)**: 기존 인터페이스 그대로 사용. `PushPayload(title, body, data)` 생성 후 토큰별 `send`.
+- **Redis**: 쿨다운 키 `wellbeing-ping:cooldown:{seniorId}:{caregiverId}` TTL 60초. SETNX 패턴 (`SET key value NX EX 60`). 키 존재 시 TTL 조회해 Retry-After 계산.
+
+### 5-4) 데이터 흐름
+
+```
+[시니어] POST /api/v1/notifications/wellbeing-pings { caregiverId }
+   ↓
+[Controller] JWT에서 seniorId 추출
+   ↓
+[Service] 
+   1. 수신자 user 조회 (없으면 404)
+   2. CareRelation 존재 확인 (없으면 403)
+   3. Redis SETNX wellbeing-ping:cooldown:{seniorId}:{caregiverId} TTL=60
+      → 실패 시 TTL 조회 → 429 Retry-After
+   4. 보호자 활성 DeviceToken 조회
+   5. 각 토큰에 FCM 발송 (tokenInvalid 시 deactivate)
+   6. 204 응답
+```
+
+### 5-5) DB 마이그레이션
+
+**없음**. enum 값 추가만 코드 변경. `Notification` 테이블에 row 안 만들기 때문에 스키마 변경 불필요.
+
+## 6) 작업 분할 (예상 PR 리스트)
+
+- [ ] PR 1: spec 초안 (`docs/features/wellbeing-ping.md`) — 본 문서
+- [ ] PR 2: 구현 (`WellbeingPingController` + `WellbeingPingService` + Redis cooldown + enum 추가 + E2E)
+- [ ] (PR 2와 같은 PR에서) Notion API 명세 갱신 + `docs/ai-harness/06-domain-model.md` 유비쿼터스 랭귀지 등재
+
+## 7) 테스트 전략
+
+- **단위 테스트**:
+  - `WellbeingPingService`: care relation 없음 → `ForbiddenException`. 수신자 없음 → `NotFoundException`. 쿨다운 미경과 → `TooManyRequestsException` (또는 도메인 예외).
+  - 쿨다운 store: SETNX 성공/실패 분기.
+- **통합 테스트**: `@SpringBootTest` + embedded Redis(기존 redis-infra-setup이 어떤 구성이냐에 따라 결정 — verify 필요) + Mock FCM.
+- **E2E (RestAssured) 필수**:
+  - 성공 케이스: 시니어 JWT로 발송 → 204, 푸시 발송 횟수 = 토큰 수.
+  - 쿨다운 케이스: 즉시 2회 호출 → 두 번째 429.
+  - 권한 케이스: CareRelation 없는 보호자에게 발송 → 403.
+  - 역할 케이스: 보호자 JWT로 호출 → 403.
+
+## 8) 오픈 질문
+
+> 모든 항목 합의 완료. §9 결정 로그 참조.
+
+## 9) 결정 로그
+
+- 2026-05-28: 초안 작성 (status=draft). 디스코드 백로그 4번 기반 [[backlog-2026-05-27]].
+- 2026-05-28: 합의 완료 항목 — 방향=시니어→보호자, 쿨다운=1분, 영속화=푸시만(DB row X), 본문 톤=안부 알림.
+- 2026-05-28: 오픈 질문 5건 합의 — Q1 (a) 1차에는 무조건 받기, Q2 (a) 보호자(수신자)별 쿨다운, Q3 (a) 429 + Retry-After, Q4 (a) 토큰 0개여도 204, Q5 (a) `NotificationCategory.WELLBEING_PING` enum 추가.

--- a/docs/features/wellbeing-ping.md
+++ b/docs/features/wellbeing-ping.md
@@ -72,7 +72,7 @@ last_reviewed: 2026-05-28
 - 알림함 영속화는 하지 않지만 FCM payload `category` 식별자 + 향후 발송 통계용으로 enum 등재.
 
 **신규 빈**:
-- `WellbeingPingService` — care relation 검증 + 쿨다운 체크 + 푸시 발송. `@Transactional` 불필요 (DB write 없음).
+- `WellbeingPingService` — care relation 검증 + 쿨다운 체크 + 푸시 발송. `@Transactional` 부착 — `DeviceToken.deactivate()`가 JPA dirty checking으로 update SQL을 발생시키기 때문 (`notifications` row는 만들지 않지만 `device_tokens.is_active` 갱신은 발생).
 - `WellbeingPingController` — endpoint 노출.
 - `WellbeingPingCooldownStore` (or 같은 책임의 컴포넌트) — Redis 기반 쿨다운 SETNX.
 
@@ -152,3 +152,4 @@ last_reviewed: 2026-05-28
 - 2026-05-28: 초안 작성 (status=draft). 디스코드 백로그 4번 기반 [[backlog-2026-05-27]].
 - 2026-05-28: 합의 완료 항목 — 방향=시니어→보호자, 쿨다운=1분, 영속화=푸시만(DB row X), 본문 톤=안부 알림.
 - 2026-05-28: 오픈 질문 5건 합의 — Q1 (a) 1차에는 무조건 받기, Q2 (a) 보호자(수신자)별 쿨다운, Q3 (a) 429 + Retry-After, Q4 (a) 토큰 0개여도 204, Q5 (a) `NotificationCategory.WELLBEING_PING` enum 추가.
+- 2026-05-28: §5-1 `@Transactional 불필요` 문구를 구현 사실에 맞게 정정 — `DeviceToken.deactivate()` dirty checking으로 update SQL이 발생하므로 `@Transactional` 부착 (구현 PR #414 머지 직후 정정).

--- a/infra/monitoring/docker-compose.yml
+++ b/infra/monitoring/docker-compose.yml
@@ -1,6 +1,29 @@
 name: ppiyaki-monitoring
 
 services:
+  mysql:
+    image: mysql:8.4.6
+    container_name: ppiyaki-mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD must be set}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-ppiyaki}
+      MYSQL_USER: ${MYSQL_USER:?MYSQL_USER must be set}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:?MYSQL_PASSWORD must be set}
+    volumes:
+      - mysql-data:/var/lib/mysql
+    networks:
+      - ppiyaki-monitoring
+    mem_limit: 1g
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    # 외부 포트 노출 안 함. backend는 같은 ppiyaki-monitoring 네트워크에서 mysql:3306 으로 접근.
+    # 데이터는 mysql-data 영속 볼륨에 보관. 외부 백업 없음 (spec db-self-hosted-migration §4 결정).
+
   prometheus:
     image: prom/prometheus:v3.0.1
     container_name: ppiyaki-prometheus
@@ -73,6 +96,7 @@ volumes:
   grafana-data:
   loki-data:
   alloy-data:
+  mysql-data:
 
 networks:
   ppiyaki-monitoring:

--- a/infra/monitoring/docker-compose.yml
+++ b/infra/monitoring/docker-compose.yml
@@ -15,13 +15,18 @@ services:
     networks:
       - ppiyaki-monitoring
     mem_limit: 1g
+    ports:
+      # host loopback에만 13306으로 publish. DataGrip 등 운영자 도구가
+      # ssh tunnel(ppiyaki-prod) 후 127.0.0.1:13306으로 접근.
+      # 0.0.0.0이 아닌 127.0.0.1 bind라 prod host 외부에서는 도달 불가.
+      - "127.0.0.1:13306:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 30s
-    # 외부 포트 노출 안 함. backend는 같은 ppiyaki-monitoring 네트워크에서 mysql:3306 으로 접근.
+    # backend는 같은 ppiyaki-monitoring 네트워크에서 mysql:3306 으로 직접 접근(host port 거치지 않음).
     # 데이터는 mysql-data 영속 볼륨에 보관. 외부 백업 없음 (spec db-self-hosted-migration §4 결정).
 
   prometheus:

--- a/scripts/db-migration/README.md
+++ b/scripts/db-migration/README.md
@@ -1,0 +1,38 @@
+# DB Migration Scripts
+
+NCP 매니지드 MySQL → backend 서버 docker MySQL 데이터 이전용 스크립트.
+
+상세 spec: [`docs/features/db-self-hosted-migration.md`](../../docs/features/db-self-hosted-migration.md)
+
+## 사전 조건
+
+- backend 서버에 ssh 접속 가능 (`ssh ppiyaki-prod`)
+- `ppiyaki-server`, `ppiyaki-mysql` 두 컨테이너가 실행 중 (`docker compose up -d mysql`로 docker MySQL 미리 기동)
+- 서버에 mysql client 설치 (`apt install mysql-client-core-8.0` 또는 이미 설치되어 있을 가능성)
+
+## 실행 순서
+
+backend 서버에서 차례로 실행:
+
+```bash
+# 1. NCP 매니지드 DB → 압축 덤프
+./dump-from-ncp.sh
+# → /tmp/ppiyaki-ncp-dump-YYYYMMDD-HHMMSS.sql.gz 생성
+
+# 2. 덤프 → docker MySQL 복원
+./restore-to-docker.sh /tmp/ppiyaki-ncp-dump-YYYYMMDD-HHMMSS.sql.gz
+
+# 3. row count 검증
+./verify-counts.sh
+```
+
+## 주의사항
+
+- credential은 컨테이너 env에서 추출하며 임시 `.my.cnf` 파일에만 노출. EXIT trap으로 즉시 삭제.
+- `restore-to-docker.sh`는 기존 데이터를 덮어쓴다. docker MySQL이 빈 상태인지 확인 후 실행.
+- `verify-counts.sh`의 row count는 `information_schema.tables` 통계값이라 ±10% 오차 가능. 정확한 검증이 필요하면 각 테이블 `SELECT COUNT(*)`를 별도로 비교.
+- 다운타임 무제한 허용 (spec §9 결정). 마이그레이션 중 ppiyaki-server는 살아있어도 되지만, 사진 업로드/복약 인증 등 쓰기 트래픽이 발생하면 NCP에 남은 데이터와 docker MySQL 데이터가 어긋남. 가능하면 ppiyaki-server를 일시 중단 후 진행.
+
+## 롤백
+
+마이그레이션 후 backend 연결 변경 전이면 NCP DB는 그대로 살아있다. PR 3 머지 전 단계에서 문제 발견 시 docker MySQL만 정리하고 NCP를 계속 사용.

--- a/scripts/db-migration/dump-from-ncp.sh
+++ b/scripts/db-migration/dump-from-ncp.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# NCP 매니지드 MySQL → 압축된 sql.gz 덤프 생성.
+# backend 서버(ssh ppiyaki-prod)에서 실행할 것을 가정.
+#
+# 사용법:
+#   ./dump-from-ncp.sh [OUTPUT_PATH]
+#   기본 OUTPUT_PATH = /tmp/ppiyaki-ncp-dump-<timestamp>.sql.gz
+#
+# 동작:
+#   1) 실행 중인 ppiyaki-server 컨테이너의 env에서 DB_URL/USERNAME/PASSWORD 추출
+#   2) DB_URL을 jdbc:mysql://HOST:PORT/DB 패턴에서 분해
+#   3) mysqldump --single-transaction --triggers --routines --events --quick → gzip
+#   4) 결과 경로와 row count 요약 출력
+#
+# 보안: credential은 임시 .my.cnf로만 노출되며 EXIT trap으로 즉시 삭제.
+
+set -euo pipefail
+
+OUTPUT="${1:-/tmp/ppiyaki-ncp-dump-$(date +%Y%m%d-%H%M%S).sql.gz}"
+
+CID=$(sudo docker ps --filter name=ppiyaki-server -q | head -1)
+if [[ -z "$CID" ]]; then
+    echo "ERROR: ppiyaki-server 컨테이너를 찾을 수 없습니다." >&2
+    exit 1
+fi
+
+ENV_FILE=$(mktemp)
+CNF_FILE=$(mktemp)
+trap 'rm -f "$ENV_FILE" "$CNF_FILE"' EXIT
+
+sudo docker inspect "$CID" --format '{{range .Config.Env}}{{println .}}{{end}}' > "$ENV_FILE"
+
+URL=$(grep '^DB_URL=' "$ENV_FILE" | cut -d= -f2-)
+DBUSER=$(grep '^DB_USERNAME=' "$ENV_FILE" | cut -d= -f2-)
+DBPASS=$(grep '^DB_PASSWORD=' "$ENV_FILE" | cut -d= -f2-)
+
+if [[ -z "$URL" || -z "$DBUSER" || -z "$DBPASS" ]]; then
+    echo "ERROR: ppiyaki-server 컨테이너 env에서 DB_URL/USERNAME/PASSWORD 추출 실패." >&2
+    exit 1
+fi
+
+# jdbc:mysql://HOST:PORT/DB?params -> HOST, PORT, DB 분해
+HOST=$(echo "$URL" | sed -E 's|jdbc:mysql://([^:/]+).*|\1|')
+PORT=$(echo "$URL" | sed -nE 's|jdbc:mysql://[^:/]+:([0-9]+).*|\1|p')
+PORT="${PORT:-3306}"
+DBNAME=$(echo "$URL" | sed -nE 's|jdbc:mysql://[^/]+/([^?]+).*|\1|p')
+
+if [[ -z "$HOST" || -z "$DBNAME" ]]; then
+    echo "ERROR: DB_URL 파싱 실패: $URL" >&2
+    exit 1
+fi
+
+{
+    echo "[client]"
+    echo "host=$HOST"
+    echo "port=$PORT"
+    echo "user=$DBUSER"
+    echo "password=$DBPASS"
+} > "$CNF_FILE"
+chmod 600 "$CNF_FILE"
+
+echo "Source: $HOST:$PORT/$DBNAME"
+echo "Target: $OUTPUT"
+
+# Pre-dump row count snapshot
+echo "=== row counts before dump ==="
+mysql --defaults-extra-file="$CNF_FILE" "$DBNAME" -N -e "
+    SELECT table_name, table_rows
+    FROM information_schema.tables
+    WHERE table_schema = '$DBNAME'
+    ORDER BY table_name;
+"
+
+# Dump
+mysqldump --defaults-extra-file="$CNF_FILE" \
+    --single-transaction \
+    --triggers \
+    --routines \
+    --events \
+    --quick \
+    --set-gtid-purged=OFF \
+    --no-tablespaces \
+    "$DBNAME" \
+    | gzip -9 > "$OUTPUT"
+
+DUMP_SIZE=$(du -h "$OUTPUT" | cut -f1)
+echo
+echo "Dump 완료: $OUTPUT ($DUMP_SIZE)"
+echo "다음 단계: ./restore-to-docker.sh $OUTPUT"

--- a/scripts/db-migration/restore-to-docker.sh
+++ b/scripts/db-migration/restore-to-docker.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# 압축된 sql.gz 덤프를 backend 서버의 docker MySQL(ppiyaki-mysql)에 import.
+# backend 서버(ssh ppiyaki-prod)에서 실행할 것을 가정.
+#
+# 사용법:
+#   ./restore-to-docker.sh DUMP_PATH
+#
+# 동작:
+#   1) ppiyaki-mysql 컨테이너 healthy 상태 확인
+#   2) MYSQL_ROOT_PASSWORD를 컨테이너 env에서 추출 (혹은 외부 env에서 받음)
+#   3) gzip -dc | docker exec mysql 로 import (DROP TABLE → CREATE → INSERT 전체)
+#   4) import 직후 row count 출력
+#
+# 주의: import는 기존 데이터를 덮어쓴다. 빈 DB가 아니면 사전에 백업 필요.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "사용법: $0 DUMP_PATH" >&2
+    exit 1
+fi
+
+DUMP="$1"
+if [[ ! -f "$DUMP" ]]; then
+    echo "ERROR: 덤프 파일을 찾을 수 없음: $DUMP" >&2
+    exit 1
+fi
+
+CID=$(sudo docker ps --filter name=ppiyaki-mysql -q | head -1)
+if [[ -z "$CID" ]]; then
+    echo "ERROR: ppiyaki-mysql 컨테이너가 실행 중이 아닙니다." >&2
+    echo "먼저 'docker compose up -d mysql'을 실행하세요." >&2
+    exit 1
+fi
+
+# Healthcheck 통과 대기 (최대 60초)
+echo "ppiyaki-mysql healthy 대기 중..."
+for i in {1..30}; do
+    STATUS=$(sudo docker inspect "$CID" --format '{{.State.Health.Status}}' 2>/dev/null || echo "unknown")
+    if [[ "$STATUS" == "healthy" ]]; then
+        break
+    fi
+    sleep 2
+done
+
+if [[ "$STATUS" != "healthy" ]]; then
+    echo "ERROR: ppiyaki-mysql healthcheck 실패 (current=$STATUS). 컨테이너 로그 확인 필요." >&2
+    exit 1
+fi
+
+# 컨테이너 env에서 root password + db name 추출
+ROOT_PW=$(sudo docker inspect "$CID" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^MYSQL_ROOT_PASSWORD=' | cut -d= -f2-)
+DBNAME=$(sudo docker inspect "$CID" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^MYSQL_DATABASE=' | cut -d= -f2-)
+DBNAME="${DBNAME:-ppiyaki}"
+
+if [[ -z "$ROOT_PW" ]]; then
+    echo "ERROR: MYSQL_ROOT_PASSWORD를 컨테이너 env에서 추출 실패." >&2
+    exit 1
+fi
+
+echo "Source: $DUMP ($(du -h "$DUMP" | cut -f1))"
+echo "Target: ppiyaki-mysql / $DBNAME"
+
+# import
+gzip -dc "$DUMP" | sudo docker exec -i -e "MYSQL_PWD=$ROOT_PW" "$CID" mysql -u root "$DBNAME"
+
+echo
+echo "=== row counts after import ==="
+sudo docker exec -e "MYSQL_PWD=$ROOT_PW" "$CID" mysql -u root -N -e "
+    SELECT table_name, table_rows
+    FROM information_schema.tables
+    WHERE table_schema = '$DBNAME'
+    ORDER BY table_name;
+"
+
+echo
+echo "Restore 완료. 다음 단계: ./verify-counts.sh"

--- a/scripts/db-migration/verify-counts.sh
+++ b/scripts/db-migration/verify-counts.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# NCP 매니지드 MySQL과 backend 서버 docker MySQL의 row count를 비교 검증.
+# backend 서버(ssh ppiyaki-prod)에서 실행할 것을 가정.
+#
+# 사용법:
+#   ./verify-counts.sh
+#
+# 동작:
+#   1) ppiyaki-server env에서 NCP 접속 정보 추출
+#   2) ppiyaki-mysql env에서 local 접속 정보 추출
+#   3) 두 DB에서 information_schema.tables의 table_rows를 가져와 diff
+#   4) 차이가 있는 테이블만 표시 (없으면 OK 메시지)
+#
+# 참고: information_schema.tables.table_rows는 통계값이라 ±10% 오차 가능.
+#       정확한 검증이 필요하면 각 테이블 SELECT COUNT(*)를 별도로 비교할 것.
+
+set -euo pipefail
+
+# === NCP 접속 정보 추출 ===
+SERVER_CID=$(sudo docker ps --filter name=ppiyaki-server -q | head -1)
+if [[ -z "$SERVER_CID" ]]; then
+    echo "ERROR: ppiyaki-server 컨테이너를 찾을 수 없습니다." >&2
+    exit 1
+fi
+
+NCP_ENV=$(mktemp)
+NCP_CNF=$(mktemp)
+LOCAL_CNF=$(mktemp)
+trap 'rm -f "$NCP_ENV" "$NCP_CNF" "$LOCAL_CNF"' EXIT
+
+sudo docker inspect "$SERVER_CID" --format '{{range .Config.Env}}{{println .}}{{end}}' > "$NCP_ENV"
+NCP_URL=$(grep '^DB_URL=' "$NCP_ENV" | cut -d= -f2-)
+NCP_HOST=$(echo "$NCP_URL" | sed -E 's|jdbc:mysql://([^:/]+).*|\1|')
+NCP_PORT=$(echo "$NCP_URL" | sed -nE 's|jdbc:mysql://[^:/]+:([0-9]+).*|\1|p')
+NCP_PORT="${NCP_PORT:-3306}"
+NCP_DB=$(echo "$NCP_URL" | sed -nE 's|jdbc:mysql://[^/]+/([^?]+).*|\1|p')
+
+{
+    echo "[client]"
+    echo "host=$NCP_HOST"
+    echo "port=$NCP_PORT"
+    echo "user=$(grep '^DB_USERNAME=' "$NCP_ENV" | cut -d= -f2-)"
+    echo "password=$(grep '^DB_PASSWORD=' "$NCP_ENV" | cut -d= -f2-)"
+} > "$NCP_CNF"
+chmod 600 "$NCP_CNF"
+
+# === Local docker 접속 정보 추출 ===
+MYSQL_CID=$(sudo docker ps --filter name=ppiyaki-mysql -q | head -1)
+if [[ -z "$MYSQL_CID" ]]; then
+    echo "ERROR: ppiyaki-mysql 컨테이너를 찾을 수 없습니다." >&2
+    exit 1
+fi
+
+LOCAL_ENV=$(sudo docker inspect "$MYSQL_CID" --format '{{range .Config.Env}}{{println .}}{{end}}')
+LOCAL_ROOT_PW=$(echo "$LOCAL_ENV" | grep '^MYSQL_ROOT_PASSWORD=' | cut -d= -f2-)
+LOCAL_DB=$(echo "$LOCAL_ENV" | grep '^MYSQL_DATABASE=' | cut -d= -f2-)
+LOCAL_DB="${LOCAL_DB:-ppiyaki}"
+
+# === row count 가져오기 ===
+NCP_COUNTS=$(mysql --defaults-extra-file="$NCP_CNF" -N -e "
+    SELECT table_name, table_rows
+    FROM information_schema.tables
+    WHERE table_schema = '$NCP_DB'
+    ORDER BY table_name;
+")
+
+LOCAL_COUNTS=$(sudo docker exec -e "MYSQL_PWD=$LOCAL_ROOT_PW" "$MYSQL_CID" mysql -u root -N -e "
+    SELECT table_name, table_rows
+    FROM information_schema.tables
+    WHERE table_schema = '$LOCAL_DB'
+    ORDER BY table_name;
+")
+
+# === diff ===
+echo "=== NCP ($NCP_DB) vs docker ($LOCAL_DB) row counts ==="
+printf "%-50s %12s %12s %s\n" "table" "ncp_rows" "local_rows" "match"
+echo "-----------------------------------------------------------------------------------"
+
+MISMATCH=0
+while IFS=$'\t' read -r TBL NCP_ROWS; do
+    LOCAL_ROWS=$(echo "$LOCAL_COUNTS" | awk -v t="$TBL" '$1==t {print $2}')
+    LOCAL_ROWS="${LOCAL_ROWS:-MISSING}"
+    if [[ "$NCP_ROWS" == "$LOCAL_ROWS" ]]; then
+        MARK="OK"
+    else
+        MARK="MISMATCH"
+        MISMATCH=$((MISMATCH+1))
+    fi
+    printf "%-50s %12s %12s %s\n" "$TBL" "$NCP_ROWS" "$LOCAL_ROWS" "$MARK"
+done <<< "$NCP_COUNTS"
+
+echo
+if [[ "$MISMATCH" -eq 0 ]]; then
+    echo "모든 테이블 row count 일치."
+else
+    echo "$MISMATCH개 테이블 불일치. 통계값이라 ±10% 오차 가능 — 의심되는 테이블은 SELECT COUNT(*)로 정확히 검증할 것."
+fi

--- a/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
+++ b/src/main/java/com/ppiyaki/common/exception/ErrorCode.java
@@ -33,6 +33,10 @@ public enum ErrorCode {
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE_001", "Schedule not found"),
     SCHEDULE_MEDICINE_MISMATCH(HttpStatus.BAD_REQUEST, "SCHEDULE_002", "Schedule does not belong to this medicine"),
 
+    // Medication Log
+    MEDICATION_LOG_PHOTO_REQUIRED(HttpStatus.BAD_REQUEST, "LOG_001",
+            "Photo is required for senior in MANAGED care mode"),
+
     // DUR
     DUR_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "DUR_001", "DUR service unavailable"),
 

--- a/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppiyaki/common/exception/GlobalExceptionHandler.java
@@ -30,7 +30,11 @@ public class GlobalExceptionHandler {
         final ErrorResponse errorResponse = errorCode == ErrorCode.INTERNAL_SERVER_ERROR
                 ? ErrorResponse.of(errorCode)
                 : ErrorResponse.of(errorCode, exception.getMessage());
-        return ResponseEntity.status(errorCode.getStatus()).body(errorResponse);
+        final ResponseEntity.BodyBuilder builder = ResponseEntity.status(errorCode.getStatus());
+        if (exception instanceof final RetryAfterAware retryAfterAware) {
+            builder.header("Retry-After", String.valueOf(retryAfterAware.getRetryAfterSeconds()));
+        }
+        return builder.body(errorResponse);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/ppiyaki/common/exception/RetryAfterAware.java
+++ b/src/main/java/com/ppiyaki/common/exception/RetryAfterAware.java
@@ -1,0 +1,6 @@
+package com.ppiyaki.common.exception;
+
+public interface RetryAfterAware {
+
+    long getRetryAfterSeconds();
+}

--- a/src/main/java/com/ppiyaki/common/ratelimit/AttemptLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/AttemptLimiter.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.common.ratelimit;
+
+public interface AttemptLimiter {
+
+    void checkAllowed(final String key);
+
+    void recordAttempt(final String key);
+
+    void clear(final String key);
+}

--- a/src/main/java/com/ppiyaki/common/ratelimit/InMemoryAttemptLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/InMemoryAttemptLimiter.java
@@ -21,7 +21,10 @@ public class InMemoryAttemptLimiter implements AttemptLimiter {
 
     @Override
     public void recordAttempt(final String key) {
-        attempts.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+        final int newCount = attempts.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+        if (newCount > MAX_ATTEMPTS) {
+            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
     }
 
     @Override

--- a/src/main/java/com/ppiyaki/common/ratelimit/InMemoryAttemptLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/InMemoryAttemptLimiter.java
@@ -1,0 +1,31 @@
+package com.ppiyaki.common.ratelimit;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class InMemoryAttemptLimiter implements AttemptLimiter {
+
+    private static final int MAX_ATTEMPTS = 5;
+
+    private final ConcurrentHashMap<String, AtomicInteger> attempts = new ConcurrentHashMap<>();
+
+    @Override
+    public void checkAllowed(final String key) {
+        final AtomicInteger count = attempts.get(key);
+        if (count != null && count.get() >= MAX_ATTEMPTS) {
+            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
+    }
+
+    @Override
+    public void recordAttempt(final String key) {
+        attempts.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+    }
+
+    @Override
+    public void clear(final String key) {
+        attempts.remove(key);
+    }
+}

--- a/src/main/java/com/ppiyaki/common/ratelimit/InMemoryRateLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/InMemoryRateLimiter.java
@@ -5,9 +5,7 @@ import com.ppiyaki.common.exception.ErrorCode;
 import java.time.LocalDateTime;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import org.springframework.stereotype.Component;
 
-@Component
 public class InMemoryRateLimiter implements RateLimiter {
 
     private static final int MAX_ATTEMPTS_PER_MINUTE = 10;

--- a/src/main/java/com/ppiyaki/common/ratelimit/RateLimiterConfig.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/RateLimiterConfig.java
@@ -1,0 +1,38 @@
+package com.ppiyaki.common.ratelimit;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RateLimiterConfig {
+
+    @Bean
+    @Primary
+    @ConditionalOnBean(StringRedisTemplate.class)
+    public RateLimiter redisRateLimiter(final StringRedisTemplate redisTemplate) {
+        return new RedisRateLimiter(redisTemplate);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(RateLimiter.class)
+    public RateLimiter inMemoryRateLimiter() {
+        return new InMemoryRateLimiter();
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnBean(StringRedisTemplate.class)
+    public AttemptLimiter redisAttemptLimiter(final StringRedisTemplate redisTemplate) {
+        return new RedisAttemptLimiter(redisTemplate);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(AttemptLimiter.class)
+    public AttemptLimiter inMemoryAttemptLimiter() {
+        return new InMemoryAttemptLimiter();
+    }
+}

--- a/src/main/java/com/ppiyaki/common/ratelimit/RedisAttemptLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/RedisAttemptLimiter.java
@@ -1,0 +1,43 @@
+package com.ppiyaki.common.ratelimit;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import java.time.Duration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+public class RedisAttemptLimiter implements AttemptLimiter {
+
+    private static final int MAX_ATTEMPTS = 5;
+    private static final Duration TTL = Duration.ofMinutes(5);
+    private static final String KEY_PREFIX = "attempt-limit:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisAttemptLimiter(final StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void checkAllowed(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        final String value = redisTemplate.opsForValue().get(redisKey);
+        if (value != null && Integer.parseInt(value) >= MAX_ATTEMPTS) {
+            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
+    }
+
+    @Override
+    public void recordAttempt(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        final Long count = redisTemplate.opsForValue().increment(redisKey);
+        if (count != null && count == 1L) {
+            redisTemplate.expire(redisKey, TTL);
+        }
+    }
+
+    @Override
+    public void clear(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        redisTemplate.delete(redisKey);
+    }
+}

--- a/src/main/java/com/ppiyaki/common/ratelimit/RedisAttemptLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/RedisAttemptLimiter.java
@@ -3,10 +3,13 @@ package com.ppiyaki.common.ratelimit;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 public class RedisAttemptLimiter implements AttemptLimiter {
 
+    private static final Logger log = LoggerFactory.getLogger(RedisAttemptLimiter.class);
     private static final int MAX_ATTEMPTS = 5;
     private static final Duration TTL = Duration.ofMinutes(5);
     private static final String KEY_PREFIX = "attempt-limit:";
@@ -21,8 +24,15 @@ public class RedisAttemptLimiter implements AttemptLimiter {
     public void checkAllowed(final String key) {
         final String redisKey = KEY_PREFIX + key;
         final String value = redisTemplate.opsForValue().get(redisKey);
-        if (value != null && Integer.parseInt(value) >= MAX_ATTEMPTS) {
-            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        if (value != null) {
+            try {
+                if (Integer.parseInt(value) >= MAX_ATTEMPTS) {
+                    throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+                }
+            } catch (final NumberFormatException e) {
+                log.warn("Attempt limit key has invalid value: key={}, value={}", redisKey, value);
+                redisTemplate.delete(redisKey);
+            }
         }
     }
 

--- a/src/main/java/com/ppiyaki/common/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/com/ppiyaki/common/ratelimit/RedisRateLimiter.java
@@ -1,0 +1,57 @@
+package com.ppiyaki.common.ratelimit;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+public class RedisRateLimiter implements RateLimiter {
+
+    private static final int MAX_ATTEMPTS_PER_MINUTE = 10;
+    private static final Duration WINDOW = Duration.ofMinutes(1);
+    private static final String KEY_PREFIX = "rate-limit:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisRateLimiter(final StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void checkAllowed(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        final long windowStart = Instant.now().minus(WINDOW).toEpochMilli();
+
+        pruneOldEntries(redisKey, windowStart);
+
+        final Long count = redisTemplate.opsForZSet().zCard(redisKey);
+        if (count != null && count >= MAX_ATTEMPTS_PER_MINUTE) {
+            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
+    }
+
+    @Override
+    public void recordFailure(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        final long now = Instant.now().toEpochMilli();
+
+        pruneOldEntries(redisKey, now - WINDOW.toMillis());
+
+        final ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        zSetOps.add(redisKey, UUID.randomUUID().toString(), now);
+        redisTemplate.expire(redisKey, WINDOW);
+    }
+
+    @Override
+    public void clearFailures(final String key) {
+        final String redisKey = KEY_PREFIX + key;
+        redisTemplate.delete(redisKey);
+    }
+
+    private void pruneOldEntries(final String redisKey, final long windowStart) {
+        redisTemplate.opsForZSet().removeRangeByScore(redisKey, 0, windowStart);
+    }
+}

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoCache.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoCache.java
@@ -1,0 +1,10 @@
+package com.ppiyaki.infrastructure.druginfo;
+
+import java.util.Optional;
+
+public interface DrugInfoCache {
+
+    Optional<DrugInfoResponse> get(String itemName);
+
+    void put(String itemName, Optional<DrugInfoResponse> response);
+}

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoCacheConfig.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoCacheConfig.java
@@ -1,0 +1,29 @@
+package com.ppiyaki.infrastructure.druginfo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class DrugInfoCacheConfig {
+
+    @Bean
+    @Primary
+    @ConditionalOnBean(StringRedisTemplate.class)
+    public DrugInfoCache redisDrugInfoCache(
+            final StringRedisTemplate redisTemplate,
+            final ObjectMapper objectMapper
+    ) {
+        return new RedisDrugInfoCache(redisTemplate, objectMapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(DrugInfoCache.class)
+    public DrugInfoCache inMemoryDrugInfoCache() {
+        return new InMemoryDrugInfoCache();
+    }
+}

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoClient.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/DrugInfoClient.java
@@ -13,10 +13,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.Instant;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -30,7 +27,6 @@ public class DrugInfoClient {
 
     private static final Logger log = LoggerFactory.getLogger(DrugInfoClient.class);
     private static final String API_URL = "https://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList";
-    private static final Duration CACHE_TTL = Duration.ofHours(24);
 
     private static final String API = "drug_info";
     private static final String OPERATION = "search";
@@ -38,7 +34,7 @@ public class DrugInfoClient {
     private final String serviceKey;
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
-    private final Map<String, CachedDrugInfo> cache = new ConcurrentHashMap<>();
+    private final DrugInfoCache cache;
     private final MeterRegistry meterRegistry;
     private final Counter cacheHitCounter;
     private final Counter cacheMissCounter;
@@ -47,10 +43,12 @@ public class DrugInfoClient {
             final MfdsApiProperties properties,
             final RestClient.Builder restClientBuilder,
             final ObjectMapper objectMapper,
+            final DrugInfoCache cache,
             final MeterRegistry meterRegistry
     ) {
         this.serviceKey = properties.serviceKey();
         this.objectMapper = objectMapper;
+        this.cache = cache;
         this.meterRegistry = meterRegistry;
 
         final SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
@@ -70,11 +68,10 @@ public class DrugInfoClient {
     }
 
     public Optional<DrugInfoResponse> search(final String itemName) {
-        final String cacheKey = itemName.strip().toLowerCase();
-        final CachedDrugInfo cached = cache.get(cacheKey);
-        if (cached != null && cached.expiresAt().isAfter(Instant.now())) {
+        final Optional<DrugInfoResponse> cached = cache.get(itemName);
+        if (cached != null) {
             cacheHitCounter.increment();
-            return cached.response();
+            return cached;
         }
 
         cacheMissCounter.increment();
@@ -93,7 +90,7 @@ public class DrugInfoClient {
                     .body(String.class);
 
             final Optional<DrugInfoResponse> result = parseResponse(responseBody);
-            cache.put(cacheKey, new CachedDrugInfo(result, Instant.now().plus(CACHE_TTL)));
+            cache.put(itemName, result);
             ExternalApiMetrics.record(meterRegistry, API, OPERATION, ExternalApiMetrics.RESULT_SUCCESS, sample);
             return result;
 
@@ -142,11 +139,5 @@ public class DrugInfoClient {
             return null;
         }
         return text.replaceAll("<[^>]+>", "").strip();
-    }
-
-    private record CachedDrugInfo(
-            Optional<DrugInfoResponse> response,
-            Instant expiresAt
-    ) {
     }
 }

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/InMemoryDrugInfoCache.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/InMemoryDrugInfoCache.java
@@ -1,0 +1,40 @@
+package com.ppiyaki.infrastructure.druginfo;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryDrugInfoCache implements DrugInfoCache {
+
+    private static final Duration TTL = Duration.ofHours(24);
+
+    private final Map<String, CachedDrugInfo> cache = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<DrugInfoResponse> get(final String itemName) {
+        final String key = itemName.strip().toLowerCase();
+        final CachedDrugInfo cached = cache.get(key);
+        if (cached == null) {
+            return null;
+        }
+        if (cached.expiresAt().isBefore(Instant.now())) {
+            cache.remove(key);
+            return null;
+        }
+        return cached.response();
+    }
+
+    @Override
+    public void put(final String itemName, final Optional<DrugInfoResponse> response) {
+        final String key = itemName.strip().toLowerCase();
+        cache.put(key, new CachedDrugInfo(response, Instant.now().plus(TTL)));
+    }
+
+    private record CachedDrugInfo(
+            Optional<DrugInfoResponse> response,
+            Instant expiresAt
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/infrastructure/druginfo/RedisDrugInfoCache.java
+++ b/src/main/java/com/ppiyaki/infrastructure/druginfo/RedisDrugInfoCache.java
@@ -1,0 +1,64 @@
+package com.ppiyaki.infrastructure.druginfo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+public class RedisDrugInfoCache implements DrugInfoCache {
+
+    private static final Logger log = LoggerFactory.getLogger(RedisDrugInfoCache.class);
+    private static final Duration TTL = Duration.ofHours(24);
+    private static final String KEY_PREFIX = "drug-info:";
+    private static final String EMPTY_MARKER = "__EMPTY__";
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public RedisDrugInfoCache(
+            final StringRedisTemplate redisTemplate,
+            final ObjectMapper objectMapper
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Optional<DrugInfoResponse> get(final String itemName) {
+        final String redisKey = buildKey(itemName);
+        final String json = redisTemplate.opsForValue().get(redisKey);
+        if (json == null) {
+            return null;
+        }
+        if (EMPTY_MARKER.equals(json)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, DrugInfoResponse.class));
+        } catch (final JsonProcessingException e) {
+            log.warn("DrugInfo cache deserialize failed: key={}, error={}", redisKey, e.getMessage());
+            redisTemplate.delete(redisKey);
+            return null;
+        }
+    }
+
+    @Override
+    public void put(final String itemName, final Optional<DrugInfoResponse> response) {
+        final String redisKey = buildKey(itemName);
+        try {
+            final String json = response.isPresent()
+                    ? objectMapper.writeValueAsString(response.get())
+                    : EMPTY_MARKER;
+            redisTemplate.opsForValue().set(redisKey, json, TTL);
+        } catch (final JsonProcessingException e) {
+            log.warn("DrugInfo cache serialize failed: key={}, error={}", redisKey, e.getMessage());
+        }
+    }
+
+    private String buildKey(final String itemName) {
+        return KEY_PREFIX + itemName.strip().toLowerCase();
+    }
+}

--- a/src/main/java/com/ppiyaki/infrastructure/mfds/InMemoryMfdsResponseCache.java
+++ b/src/main/java/com/ppiyaki/infrastructure/mfds/InMemoryMfdsResponseCache.java
@@ -5,11 +5,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.stereotype.Component;
 
-@Component
-@ConditionalOnProperty(prefix = "mfds.api", name = "service-key")
 public class InMemoryMfdsResponseCache implements MfdsResponseCache {
 
     private static final Duration TTL = Duration.ofHours(24);

--- a/src/main/java/com/ppiyaki/infrastructure/mfds/MfdsResponseCacheConfig.java
+++ b/src/main/java/com/ppiyaki/infrastructure/mfds/MfdsResponseCacheConfig.java
@@ -1,0 +1,29 @@
+package com.ppiyaki.infrastructure.mfds;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class MfdsResponseCacheConfig {
+
+    @Bean
+    @Primary
+    @ConditionalOnBean(StringRedisTemplate.class)
+    public MfdsResponseCache redisMfdsResponseCache(
+            final StringRedisTemplate redisTemplate,
+            final ObjectMapper objectMapper
+    ) {
+        return new RedisMfdsResponseCache(redisTemplate, objectMapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(MfdsResponseCache.class)
+    public MfdsResponseCache inMemoryMfdsResponseCache() {
+        return new InMemoryMfdsResponseCache();
+    }
+}

--- a/src/main/java/com/ppiyaki/infrastructure/mfds/RedisMfdsResponseCache.java
+++ b/src/main/java/com/ppiyaki/infrastructure/mfds/RedisMfdsResponseCache.java
@@ -1,0 +1,63 @@
+package com.ppiyaki.infrastructure.mfds;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+public class RedisMfdsResponseCache implements MfdsResponseCache {
+
+    private static final Logger log = LoggerFactory.getLogger(RedisMfdsResponseCache.class);
+    private static final Duration TTL = Duration.ofHours(24);
+    private static final String KEY_PREFIX = "mfds-cache:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public RedisMfdsResponseCache(
+            final StringRedisTemplate redisTemplate,
+            final ObjectMapper objectMapper
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Optional<CachedMfdsResponse> get(final String operation, final String queryKey) {
+        final String redisKey = buildKey(operation, queryKey);
+        final String json = redisTemplate.opsForValue().get(redisKey);
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, CachedMfdsResponse.class));
+        } catch (final JsonProcessingException e) {
+            log.warn("MFDS cache deserialize failed: key={}, error={}", redisKey, e.getMessage());
+            redisTemplate.delete(redisKey);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void put(final String operation, final String queryKey, final CachedMfdsResponse response) {
+        final String redisKey = buildKey(operation, queryKey);
+        try {
+            final String json = objectMapper.writeValueAsString(response);
+            redisTemplate.opsForValue().set(redisKey, json, TTL);
+        } catch (final JsonProcessingException e) {
+            log.warn("MFDS cache serialize failed: key={}, error={}", redisKey, e.getMessage());
+        }
+    }
+
+    @Override
+    public void invalidate(final String operation, final String queryKey) {
+        redisTemplate.delete(buildKey(operation, queryKey));
+    }
+
+    private String buildKey(final String operation, final String queryKey) {
+        return KEY_PREFIX + operation + ":" + queryKey;
+    }
+}

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -17,7 +17,10 @@ import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.domain.CareMode;
+import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -53,6 +56,7 @@ public class MedicationLogService {
     private final MedicationScheduleRepository medicationScheduleRepository;
     private final MedicineRepository medicineRepository;
     private final CareRelationRepository careRelationRepository;
+    private final UserRepository userRepository;
     private final PhotoUrlAssembler photoUrlAssembler;
     private final OpenAiClient openAiClient;
     private final NcpStorageProperties storageProperties;
@@ -66,6 +70,7 @@ public class MedicationLogService {
             final MedicationScheduleRepository medicationScheduleRepository,
             final MedicineRepository medicineRepository,
             final CareRelationRepository careRelationRepository,
+            final UserRepository userRepository,
             final PhotoUrlAssembler photoUrlAssembler,
             final OpenAiClient openAiClient,
             final NcpStorageProperties storageProperties,
@@ -78,6 +83,7 @@ public class MedicationLogService {
         this.medicationScheduleRepository = medicationScheduleRepository;
         this.medicineRepository = medicineRepository;
         this.careRelationRepository = careRelationRepository;
+        this.userRepository = userRepository;
         this.photoUrlAssembler = photoUrlAssembler;
         this.openAiClient = openAiClient;
         this.storageProperties = storageProperties;
@@ -96,6 +102,14 @@ public class MedicationLogService {
         final Long seniorId = medicine.getOwnerId();
 
         final boolean isProxy = resolveProxyFlag(userId, seniorId);
+
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (senior.getCareMode() == CareMode.MANAGED
+                && request.status() == LogStatus.TAKEN
+                && (request.photoObjectKey() == null || request.photoObjectKey().isBlank())) {
+            throw new BusinessException(ErrorCode.MEDICATION_LOG_PHOTO_REQUIRED);
+        }
 
         if (request.photoObjectKey() != null && !request.photoObjectKey().isBlank()) {
             validatePhotoObjectKey(request.photoObjectKey(), userId);

--- a/src/main/java/com/ppiyaki/notification/Notification.java
+++ b/src/main/java/com/ppiyaki/notification/Notification.java
@@ -115,8 +115,7 @@ public class Notification extends BaseTimeEntity {
             final String title,
             final String body,
             final LocalDate targetDate,
-            final String mealSlot,
-            final Long scheduleId
+            final String mealSlot
     ) {
         return new Notification(
                 caregiverId,
@@ -127,7 +126,7 @@ public class Notification extends BaseTimeEntity {
                 null,
                 targetDate,
                 mealSlot,
-                scheduleId
+                null
         );
     }
 

--- a/src/main/java/com/ppiyaki/notification/NotificationCategory.java
+++ b/src/main/java/com/ppiyaki/notification/NotificationCategory.java
@@ -6,5 +6,6 @@ public enum NotificationCategory {
     MEDICATION_DELAY,
     DUR_WARNING,
     FAMILY_SAFETY,
-    MEDICATION_COMPLETE
+    MEDICATION_COMPLETE,
+    WELLBEING_PING
 }

--- a/src/main/java/com/ppiyaki/notification/controller/WellbeingPingController.java
+++ b/src/main/java/com/ppiyaki/notification/controller/WellbeingPingController.java
@@ -1,0 +1,31 @@
+package com.ppiyaki.notification.controller;
+
+import com.ppiyaki.notification.controller.dto.WellbeingPingCreateRequest;
+import com.ppiyaki.notification.service.WellbeingPingService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications/wellbeing-pings")
+public class WellbeingPingController {
+
+    private final WellbeingPingService wellbeingPingService;
+
+    public WellbeingPingController(final WellbeingPingService wellbeingPingService) {
+        this.wellbeingPingService = wellbeingPingService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> send(
+            @AuthenticationPrincipal final Long userId,
+            @Valid @RequestBody final WellbeingPingCreateRequest request
+    ) {
+        wellbeingPingService.send(userId, request.caregiverId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/controller/dto/WellbeingPingCreateRequest.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/WellbeingPingCreateRequest.java
@@ -1,0 +1,9 @@
+package com.ppiyaki.notification.controller.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record WellbeingPingCreateRequest(
+        @NotNull @Positive Long caregiverId
+) {
+}

--- a/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
@@ -70,6 +70,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             final Long scheduleId
     );
 
+    boolean existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot(
+            final Long userId,
+            final NotificationCategory category,
+            final Long seniorId,
+            final java.time.LocalDate targetDate,
+            final String mealSlot
+    );
+
     java.util.Optional<Notification> findFirstByUserIdAndCategoryAndSeniorIdOrderByCreatedAtDesc(
             final Long userId,
             final NotificationCategory category,

--- a/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
@@ -26,10 +26,12 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -109,6 +111,15 @@ public class MedicationDelayDispatcher {
                     takenScheduleIds.add(logRow.getScheduleId());
                 }
             }
+            final List<MedicationSchedule> unsentSchedules = new ArrayList<>();
+            for (final MedicationSchedule schedule : slotSchedules) {
+                if (!takenScheduleIds.contains(schedule.getId())) {
+                    unsentSchedules.add(schedule);
+                }
+            }
+            if (unsentSchedules.isEmpty()) {
+                continue;
+            }
 
             for (final CareRelation relation : relations) {
                 final Long caregiverId = relation.getCaregiverId();
@@ -123,18 +134,12 @@ public class MedicationDelayDispatcher {
                 if (now.isBefore(mealDateTime.plusMinutes(thresholdMinutes))) {
                     continue;
                 }
-                for (final MedicationSchedule schedule : slotSchedules) {
-                    if (takenScheduleIds.contains(schedule.getId())) {
-                        continue;
-                    }
-                    if (notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
-                            caregiverId, NotificationCategory.MEDICATION_DELAY, senior.getId(), today,
-                            schedule.getId())) {
-                        continue;
-                    }
-                    sendDelayNotification(caregiverId, senior, slot, today, schedule, thresholdMinutes);
-                    dispatched++;
+                if (notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot(
+                        caregiverId, NotificationCategory.MEDICATION_DELAY, senior.getId(), today, slot.name())) {
+                    continue;
                 }
+                sendDelayNotification(caregiverId, senior, slot, today, unsentSchedules, thresholdMinutes);
+                dispatched++;
             }
         }
         return dispatched;
@@ -145,21 +150,30 @@ public class MedicationDelayDispatcher {
             final User senior,
             final MealSlot slot,
             final LocalDate today,
-            final MedicationSchedule schedule,
+            final List<MedicationSchedule> schedules,
             final long thresholdMinutes
     ) {
         final String slotLabel = SLOT_LABELS.getOrDefault(slot, slot.name());
         final String title = "복약 지연 알림";
         final String seniorName = senior.getNickname() == null ? "" : senior.getNickname();
-        final String medicineLabel = resolveMedicineLabel(schedule);
-        final String body = String.format(
-                "%s 어르신이 %s에 %s을 아직 복용하지 않았어요. (%d분 경과)",
-                seniorName, slotLabel, medicineLabel, thresholdMinutes);
+        final StringBuilder bodyBuilder = new StringBuilder();
+        bodyBuilder.append(String.format(
+                "%s 어르신이 %s에 약 %d개를 아직 복용하지 않았어요. (%d분 경과)",
+                seniorName, slotLabel, schedules.size(), thresholdMinutes));
+        for (final MedicationSchedule schedule : schedules) {
+            bodyBuilder.append("\n• ").append(resolveMedicineLabel(schedule));
+        }
+        final String body = bodyBuilder.toString();
+        final String scheduleIdsJson = schedules.stream()
+                .map(MedicationSchedule::getId)
+                .map(String::valueOf)
+                .collect(Collectors.joining(",", "[", "]"));
+
         final Notification saved = notificationRepository.save(
                 Notification.createForMedicationDelay(
-                        caregiverId, senior.getId(), title, body, today, slot.name(), schedule.getId()));
-        log.info("MEDICATION_DELAY notification created (id={}, caregiver={}, senior={}, slot={}, schedule={})",
-                saved.getId(), caregiverId, senior.getId(), slot, schedule.getId());
+                        caregiverId, senior.getId(), title, body, today, slot.name()));
+        log.info("MEDICATION_DELAY notification created (id={}, caregiver={}, senior={}, slot={}, scheduleCount={})",
+                saved.getId(), caregiverId, senior.getId(), slot, schedules.size());
 
         final List<DeviceToken> tokens = deviceTokenRepository.findByUserIdAndIsActiveTrue(caregiverId);
         for (final DeviceToken token : tokens) {
@@ -167,7 +181,7 @@ public class MedicationDelayDispatcher {
                     new PushPayload(title, body, Map.of(
                             "category", "MEDICATION_DELAY",
                             "seniorId", String.valueOf(senior.getId()),
-                            "scheduleId", String.valueOf(schedule.getId()),
+                            "scheduleIds", scheduleIdsJson,
                             "mealSlot", slot.name()
                     )));
             if (result.tokenInvalid()) {

--- a/src/main/java/com/ppiyaki/notification/service/WellbeingPingCooldownException.java
+++ b/src/main/java/com/ppiyaki/notification/service/WellbeingPingCooldownException.java
@@ -1,0 +1,20 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.exception.RetryAfterAware;
+
+public class WellbeingPingCooldownException extends BusinessException implements RetryAfterAware {
+
+    private final long retryAfterSeconds;
+
+    public WellbeingPingCooldownException(final long retryAfterSeconds) {
+        super(ErrorCode.RATE_LIMIT_EXCEEDED,
+                "Wellbeing ping cooldown active, retry after " + retryAfterSeconds + "s");
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+
+    public long getRetryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/service/WellbeingPingCooldownStore.java
+++ b/src/main/java/com/ppiyaki/notification/service/WellbeingPingCooldownStore.java
@@ -1,0 +1,39 @@
+package com.ppiyaki.notification.service;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WellbeingPingCooldownStore {
+
+    private static final String KEY_PREFIX = "wellbeing-ping:cooldown:";
+    private static final Duration COOLDOWN = Duration.ofSeconds(60);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public WellbeingPingCooldownStore(final StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public boolean tryAcquire(final long seniorId, final long caregiverId) {
+        final String key = buildKey(seniorId, caregiverId);
+        final Boolean acquired = redisTemplate.opsForValue()
+                .setIfAbsent(key, "1", COOLDOWN);
+        return Boolean.TRUE.equals(acquired);
+    }
+
+    public Optional<Long> getRetryAfterSeconds(final long seniorId, final long caregiverId) {
+        final String key = buildKey(seniorId, caregiverId);
+        final Long ttlSeconds = redisTemplate.getExpire(key);
+        if (ttlSeconds == null || ttlSeconds <= 0L) {
+            return Optional.empty();
+        }
+        return Optional.of(ttlSeconds);
+    }
+
+    private String buildKey(final long seniorId, final long caregiverId) {
+        return KEY_PREFIX + seniorId + ":" + caregiverId;
+    }
+}

--- a/src/main/java/com/ppiyaki/notification/service/WellbeingPingService.java
+++ b/src/main/java/com/ppiyaki/notification/service/WellbeingPingService.java
@@ -1,0 +1,94 @@
+package com.ppiyaki.notification.service;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.infrastructure.messaging.fcm.PushPayload;
+import com.ppiyaki.infrastructure.messaging.fcm.PushSendResult;
+import com.ppiyaki.infrastructure.messaging.fcm.PushSender;
+import com.ppiyaki.notification.DeviceToken;
+import com.ppiyaki.notification.NotificationCategory;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import com.ppiyaki.user.domain.User;
+import com.ppiyaki.user.domain.UserRole;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class WellbeingPingService {
+
+    private static final Logger log = LoggerFactory.getLogger(WellbeingPingService.class);
+    private static final String PUSH_TITLE = "안부 알림";
+    private static final String PUSH_BODY_FORMAT = "%s 어르신이 안부를 전했어요.";
+
+    private final UserRepository userRepository;
+    private final CareRelationRepository careRelationRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final WellbeingPingCooldownStore cooldownStore;
+    private final PushSender pushSender;
+
+    public WellbeingPingService(
+            final UserRepository userRepository,
+            final CareRelationRepository careRelationRepository,
+            final DeviceTokenRepository deviceTokenRepository,
+            final WellbeingPingCooldownStore cooldownStore,
+            final PushSender pushSender
+    ) {
+        this.userRepository = userRepository;
+        this.careRelationRepository = careRelationRepository;
+        this.deviceTokenRepository = deviceTokenRepository;
+        this.cooldownStore = cooldownStore;
+        this.pushSender = pushSender;
+    }
+
+    @Transactional
+    public void send(final Long seniorId, final Long caregiverId) {
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (senior.getRole() != UserRole.SENIOR) {
+            throw new BusinessException(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
+        }
+
+        final User caregiver = userRepository.findById(caregiverId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (caregiver.getRole() != UserRole.CAREGIVER) {
+            throw new BusinessException(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
+        }
+
+        if (careRelationRepository
+                .findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(caregiverId, seniorId)
+                .isEmpty()) {
+            throw new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND);
+        }
+
+        if (!cooldownStore.tryAcquire(seniorId, caregiverId)) {
+            final long retryAfterSeconds = cooldownStore
+                    .getRetryAfterSeconds(seniorId, caregiverId)
+                    .orElse(1L);
+            log.debug("WELLBEING_PING cooldown blocked (sender={}, receiver={}, retryAfter={}s)",
+                    seniorId, caregiverId, retryAfterSeconds);
+            throw new WellbeingPingCooldownException(retryAfterSeconds);
+        }
+
+        final List<DeviceToken> tokens = deviceTokenRepository.findByUserIdAndIsActiveTrue(caregiverId);
+        final String body = PUSH_BODY_FORMAT.formatted(senior.getNickname() == null ? "" : senior.getNickname());
+        final PushPayload payload = new PushPayload(PUSH_TITLE, body, Map.of(
+                "category", NotificationCategory.WELLBEING_PING.name(),
+                "seniorId", String.valueOf(seniorId)
+        ));
+
+        for (final DeviceToken token : tokens) {
+            final PushSendResult result = pushSender.send(token.getToken(), payload);
+            if (result.tokenInvalid()) {
+                token.deactivate();
+            }
+        }
+        log.info("WELLBEING_PING dispatched (sender={}, receiver={}, tokens={})",
+                seniorId, caregiverId, tokens.size());
+    }
+}

--- a/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
+++ b/src/main/java/com/ppiyaki/user/controller/CareRelationController.java
@@ -1,5 +1,6 @@
 package com.ppiyaki.user.controller;
 
+import com.ppiyaki.user.controller.dto.CaregiverSummaryResponse;
 import com.ppiyaki.user.controller.dto.CodeLoginRequest;
 import com.ppiyaki.user.controller.dto.InviteCodeRequest;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
@@ -37,6 +38,15 @@ public class CareRelationController {
             @AuthenticationPrincipal final Long userId
     ) {
         final List<SeniorSummaryResponse> responses = careRelationService.readSeniors(userId);
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/care-relations/caregivers")
+    @PreAuthorize("hasRole('SENIOR')")
+    public ResponseEntity<List<CaregiverSummaryResponse>> readCaregivers(
+            @AuthenticationPrincipal final Long userId
+    ) {
+        final List<CaregiverSummaryResponse> responses = careRelationService.readCaregivers(userId);
         return ResponseEntity.ok(responses);
     }
 

--- a/src/main/java/com/ppiyaki/user/controller/UserController.java
+++ b/src/main/java/com/ppiyaki/user/controller/UserController.java
@@ -42,6 +42,15 @@ public class UserController {
         return ResponseEntity.ok(userService.updateMealTimes(userId, request));
     }
 
+    @PutMapping("/{seniorId}/meal-times")
+    public ResponseEntity<UserMeResponse> updateMealTimesForSenior(
+            @AuthenticationPrincipal final Long requesterId,
+            @PathVariable final Long seniorId,
+            @Valid @RequestBody final MealTimesUpdateRequest request
+    ) {
+        return ResponseEntity.ok(userService.updateMealTimesForSenior(requesterId, seniorId, request));
+    }
+
     @DeleteMapping("/me")
     public ResponseEntity<Void> withdraw(@AuthenticationPrincipal final Long userId) {
         userService.withdraw(userId);

--- a/src/main/java/com/ppiyaki/user/controller/dto/CaregiverSummaryResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/CaregiverSummaryResponse.java
@@ -1,0 +1,16 @@
+package com.ppiyaki.user.controller.dto;
+
+import com.ppiyaki.user.domain.User;
+
+public record CaregiverSummaryResponse(
+        Long id,
+        String nickname
+) {
+
+    public static CaregiverSummaryResponse from(final User user) {
+        return new CaregiverSummaryResponse(
+                user.getId(),
+                user.getNickname()
+        );
+    }
+}

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -5,6 +5,7 @@ import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.common.ratelimit.AttemptLimiter;
 import com.ppiyaki.common.ratelimit.RateLimiter;
+import com.ppiyaki.user.controller.dto.CaregiverSummaryResponse;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
 import com.ppiyaki.user.controller.dto.SeniorSummaryResponse;
@@ -70,6 +71,24 @@ public class CareRelationService {
         return careRelations.stream()
                 .map(relation -> seniorsById.get(relation.getSeniorId()))
                 .map(SeniorSummaryResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CaregiverSummaryResponse> readCaregivers(final Long seniorId) {
+        final List<CareRelation> careRelations = careRelationRepository.findBySeniorIdAndDeletedAtIsNull(
+                seniorId);
+
+        final List<Long> caregiverIds = careRelations.stream()
+                .map(CareRelation::getCaregiverId)
+                .toList();
+
+        final Map<Long, User> caregiversById = userRepository.findAllById(caregiverIds).stream()
+                .collect(Collectors.toMap(User::getId, user -> user));
+
+        return careRelations.stream()
+                .map(relation -> caregiversById.get(relation.getCaregiverId()))
+                .map(CaregiverSummaryResponse::from)
                 .toList();
     }
 

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -3,6 +3,7 @@ package com.ppiyaki.user.service;
 import com.ppiyaki.common.auth.JwtProvider;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.ratelimit.AttemptLimiter;
 import com.ppiyaki.common.ratelimit.RateLimiter;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
@@ -32,6 +33,7 @@ public class CareRelationService {
     private final JwtProvider jwtProvider;
     private final AuthService authService;
     private final RateLimiter rateLimiter;
+    private final AttemptLimiter attemptLimiter;
 
     public CareRelationService(
             final CareRelationRepository careRelationRepository,
@@ -40,7 +42,8 @@ public class CareRelationService {
             final UserRepository userRepository,
             final JwtProvider jwtProvider,
             final AuthService authService,
-            final RateLimiter rateLimiter
+            final RateLimiter rateLimiter,
+            final AttemptLimiter attemptLimiter
     ) {
         this.careRelationRepository = careRelationRepository;
         this.inviteCodeRepository = inviteCodeRepository;
@@ -49,6 +52,7 @@ public class CareRelationService {
         this.jwtProvider = jwtProvider;
         this.authService = authService;
         this.rateLimiter = rateLimiter;
+        this.attemptLimiter = attemptLimiter;
     }
 
     @Transactional(readOnly = true)
@@ -86,22 +90,28 @@ public class CareRelationService {
         rateLimiter.checkAllowed(rateLimitKey);
 
         final String codeHash = InviteCode.sha256(code);
+        final String attemptKey = "code:" + codeHash;
+        attemptLimiter.checkAllowed(attemptKey);
+
         final InviteCode inviteCode = inviteCodeRepository.findByCodeHashAndUsedAtIsNull(codeHash)
                 .orElse(null);
 
         if (inviteCode == null) {
             rateLimiter.recordFailure(rateLimitKey);
+            attemptLimiter.recordAttempt(attemptKey);
             throw new BusinessException(ErrorCode.CARE_RELATION_INVITE_INVALID);
         }
 
         final LocalDateTime now = LocalDateTime.now();
         if (inviteCode.isExpired(now)) {
             rateLimiter.recordFailure(rateLimitKey);
+            attemptLimiter.recordAttempt(attemptKey);
             throw new BusinessException(ErrorCode.CARE_RELATION_INVITE_INVALID);
         }
 
         inviteCode.markUsed(now);
         rateLimiter.clearFailures(rateLimitKey);
+        attemptLimiter.clear(attemptKey);
 
         final Long seniorId = inviteCode.getSeniorId();
         final User senior = findUserById(seniorId);

--- a/src/main/java/com/ppiyaki/user/service/UserService.java
+++ b/src/main/java/com/ppiyaki/user/service/UserService.java
@@ -60,6 +60,22 @@ public class UserService {
     }
 
     @Transactional
+    public UserMeResponse updateMealTimesForSenior(
+            final Long requesterId,
+            final Long seniorId,
+            final MealTimesUpdateRequest request
+    ) {
+        final User senior = userRepository.findById(seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(requesterId, seniorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
+
+        senior.updateMealTimes(request.breakfast(), request.lunch(), request.dinner());
+        return UserMeResponse.from(senior);
+    }
+
+    @Transactional
     public void withdraw(final Long userId) {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,9 @@
 spring:
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,7 +3,7 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
-      password: ${REDIS_PASSWORD:}
+      password: ${REDIS_PASSWORD}
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
           options:
             model: whisper-1
             language: ko
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
   datasource:
     url: jdbc:h2:mem:ppiyaki;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,7 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
   datasource:
     url: jdbc:h2:mem:ppiyaki;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa

--- a/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/medication/controller/MedicationLogControllerE2ETest.java
@@ -10,7 +10,9 @@ import com.ppiyaki.medication.domain.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.domain.CareMode;
 import com.ppiyaki.user.domain.CareRelation;
+import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import io.restassured.RestAssured;
@@ -239,7 +241,10 @@ class MedicationLogControllerE2ETest {
                 .statusCode(201)
                 .extract()
                 .asString();
-        final Long userId = userRepository.findByLoginId(loginId).orElseThrow().getId();
+        final User user = userRepository.findByLoginId(loginId).orElseThrow();
+        user.changeCareMode(CareMode.AUTONOMOUS);
+        userRepository.save(user);
+        final Long userId = user.getId();
         final String accessToken = io.restassured.path.json.JsonPath.from(response).getString("accessToken");
         return new SignupResult(userId, accessToken);
     }

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -3,6 +3,8 @@ package com.ppiyaki.medication.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,7 +22,10 @@ import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.domain.CareMode;
+import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
@@ -53,6 +58,8 @@ class MedicationLogServicePhase2Test {
     private MedicineRepository medicineRepository;
     @Mock
     private CareRelationRepository careRelationRepository;
+    @Mock
+    private UserRepository userRepository;
     @Mock
     private PhotoUrlAssembler photoUrlAssembler;
     @Mock
@@ -195,6 +202,7 @@ class MedicationLogServicePhase2Test {
         givenSiblingSchedules(List.of(triggerSchedule, peerSchedule));
         givenS3Returns(new byte[]{1, 2, 3});
         when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(2));
+        givenAutonomousSenior();
 
         // when
         service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
@@ -257,6 +265,7 @@ class MedicationLogServicePhase2Test {
         givenSiblingSchedules(List.of(triggerSchedule, peerSchedule));
         givenS3Returns(new byte[]{1, 2, 3});
         when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(2));
+        givenAutonomousSenior();
 
         // when
         service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
@@ -290,6 +299,13 @@ class MedicationLogServicePhase2Test {
         final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", 30, 30, "ITEM-1", null);
         setField(medicine, "id", MEDICINE_ID);
         when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(medicine));
+        givenAutonomousSenior();
+    }
+
+    private void givenAutonomousSenior() {
+        final User senior = mock(User.class);
+        lenient().when(senior.getCareMode()).thenReturn(CareMode.AUTONOMOUS);
+        lenient().when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(senior));
     }
 
     private void givenSiblingSchedules(final List<MedicationSchedule> schedules) {

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -3,6 +3,8 @@ package com.ppiyaki.medication.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -19,8 +21,11 @@ import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.user.domain.CareMode;
 import com.ppiyaki.user.domain.CareRelation;
+import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -47,6 +52,8 @@ class MedicationLogServiceTest {
     private MedicineRepository medicineRepository;
     @Mock
     private CareRelationRepository careRelationRepository;
+    @Mock
+    private UserRepository userRepository;
     @Mock
     private PhotoUrlAssembler photoUrlAssembler;
     @Mock
@@ -248,6 +255,46 @@ class MedicationLogServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("careMode=MANAGED + status=TAKEN + photoObjectKey 누락 시 MEDICATION_LOG_PHOTO_REQUIRED")
+    void managed_senior_taken_without_photo() throws Exception {
+        // given
+        givenScheduleAndMedicine();
+        final User managedSenior = mock(User.class);
+        when(managedSenior.getCareMode()).thenReturn(CareMode.MANAGED);
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(managedSenior));
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, null);
+
+        // when & then
+        assertThatThrownBy(() -> medicationLogService.upsert(SENIOR_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.MEDICATION_LOG_PHOTO_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("careMode=MANAGED + status=MISSED는 photoObjectKey 없어도 통과")
+    void managed_senior_missed_without_photo_ok() throws Exception {
+        // given
+        givenScheduleAndMedicine();
+        final User managedSenior = mock(User.class);
+        when(managedSenior.getCareMode()).thenReturn(CareMode.MANAGED);
+        when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(managedSenior));
+        when(medicationLogRepository.findByScheduleIdAndTargetDate(SCHEDULE_ID, TARGET_DATE))
+                .thenReturn(Optional.empty());
+        when(medicationLogRepository.saveAndFlush(any(MedicationLog.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(photoUrlAssembler.toFullUrl(any())).thenReturn(null);
+
+        final MedicationLogUpsertRequest request = new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.MISSED, null);
+
+        // when & then — 예외 없이 처리
+        medicationLogService.upsert(SENIOR_ID, request);
     }
 
     @Test
@@ -539,7 +586,14 @@ class MedicationLogServiceTest {
         final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", total, remaining, "ITEM-1", null);
         setField(medicine, "id", MEDICINE_ID);
         when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(medicine));
+        givenAutonomousSenior();
         return medicine;
+    }
+
+    private void givenAutonomousSenior() {
+        final User senior = mock(User.class);
+        lenient().when(senior.getCareMode()).thenReturn(CareMode.AUTONOMOUS);
+        lenient().when(userRepository.findById(SENIOR_ID)).thenReturn(Optional.of(senior));
     }
 
     private void givenScheduleAndMedicine() throws Exception {
@@ -558,6 +612,7 @@ class MedicationLogServiceTest {
         final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", 30, 30, "ITEM-1", null);
         setField(medicine, "id", MEDICINE_ID);
         when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(medicine));
+        givenAutonomousSenior();
     }
 
     private static void setField(final Object target, final String fieldName, final Object value) throws Exception {

--- a/src/test/java/com/ppiyaki/notification/controller/NotificationAutoTakenE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/NotificationAutoTakenE2ETest.java
@@ -13,6 +13,7 @@ import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
 import com.ppiyaki.notification.Notification;
 import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.user.domain.CareMode;
 import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.domain.UserRole;
 import com.ppiyaki.user.repository.UserRepository;
@@ -163,6 +164,7 @@ class NotificationAutoTakenE2ETest {
     private Long seedSenior() {
         return transactionTemplate.execute(status -> {
             final User senior = User.createSenior("E2E시니어" + userSequence++, (LocalDate) null);
+            senior.changeCareMode(CareMode.AUTONOMOUS);
             return userRepository.save(senior).getId();
         });
     }

--- a/src/test/java/com/ppiyaki/notification/controller/WellbeingPingControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/WellbeingPingControllerE2ETest.java
@@ -1,0 +1,178 @@
+package com.ppiyaki.notification.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+import com.ppiyaki.common.auth.JwtProvider;
+import com.ppiyaki.notification.service.WellbeingPingCooldownStore;
+import com.ppiyaki.user.domain.User;
+import com.ppiyaki.user.domain.UserRole;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("POST /api/v1/notifications/wellbeing-pings E2E")
+class WellbeingPingControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private JwtProvider jwtProvider;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @MockBean
+    private WellbeingPingCooldownStore cooldownStore;
+
+    private static long userSequence = 900000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        Mockito.when(cooldownStore.tryAcquire(anyLong(), anyLong())).thenReturn(true);
+    }
+
+    @Test
+    @DisplayName("시니어가 CareRelation 있는 보호자에게 안부 발송 → 204")
+    void wellbeing_ping_success() {
+        final Long seniorId = seedSenior();
+        final Long caregiverId = seedCaregiver();
+        seedCareRelation(seniorId, caregiverId);
+        seedDeviceToken(caregiverId, "fcm-wp-" + caregiverId);
+
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"caregiverId": %d}
+                        """.formatted(caregiverId))
+                .when()
+                .post("/api/v1/notifications/wellbeing-pings")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    @DisplayName("쿨다운 차단 시 429 + Retry-After 헤더")
+    void wellbeing_ping_cooldown_blocked() {
+        final Long seniorId = seedSenior();
+        final Long caregiverId = seedCaregiver();
+        seedCareRelation(seniorId, caregiverId);
+
+        Mockito.when(cooldownStore.tryAcquire(seniorId, caregiverId)).thenReturn(false);
+        Mockito.when(cooldownStore.getRetryAfterSeconds(seniorId, caregiverId))
+                .thenReturn(Optional.of(42L));
+
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"caregiverId": %d}
+                        """.formatted(caregiverId))
+                .when()
+                .post("/api/v1/notifications/wellbeing-pings")
+                .then()
+                .statusCode(429)
+                .header("Retry-After", "42")
+                .body("error.code", is("COMMON_006"));
+    }
+
+    @Test
+    @DisplayName("CareRelation 없는 보호자에게 발송 → 403 CARE_001")
+    void wellbeing_ping_no_care_relation() {
+        final Long seniorId = seedSenior();
+        final Long caregiverId = seedCaregiver();
+        // No care_relations INSERT
+
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"caregiverId": %d}
+                        """.formatted(caregiverId))
+                .when()
+                .post("/api/v1/notifications/wellbeing-pings")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    @Test
+    @DisplayName("보호자 JWT로 호출 → 403 CARE_008 역할 mismatch")
+    void wellbeing_ping_caller_not_senior() {
+        final Long callerCaregiverId = seedCaregiver();
+        final Long targetCaregiverId = seedCaregiver();
+
+        final String caregiverToken = jwtProvider.createAccessToken(
+                callerCaregiverId, UserRole.CAREGIVER.name());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + caregiverToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"caregiverId": %d}
+                        """.formatted(targetCaregiverId))
+                .when()
+                .post("/api/v1/notifications/wellbeing-pings")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_008"));
+    }
+
+    // --- fixtures ---
+
+    private Long seedSenior() {
+        return transactionTemplate.execute(status -> {
+            final User senior = User.createSenior("WP시니어" + userSequence++, (LocalDate) null);
+            return userRepository.save(senior).getId();
+        });
+    }
+
+    private Long seedCaregiver() {
+        final long seq = userSequence++;
+        return transactionTemplate.execute(status -> {
+            final User caregiver = User.createSenior("WP보호자" + seq, (LocalDate) null);
+            caregiver.assignRole(UserRole.CAREGIVER);
+            return userRepository.save(caregiver).getId();
+        });
+    }
+
+    private void seedCareRelation(final Long seniorId, final Long caregiverId) {
+        jdbcTemplate.update(
+                "INSERT INTO care_relations (senior_id, caregiver_id, created_at, updated_at) "
+                        + "VALUES (?, ?, NOW(6), NOW(6))",
+                seniorId, caregiverId);
+    }
+
+    private void seedDeviceToken(final Long userId, final String token) {
+        jdbcTemplate.update(
+                "INSERT INTO device_tokens "
+                        + "(user_id, token, platform, is_active, created_at, updated_at) "
+                        + "VALUES (?, ?, 'ANDROID', TRUE, NOW(6), NOW(6))",
+                userId, token);
+    }
+}

--- a/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
@@ -3,17 +3,26 @@ package com.ppiyaki.notification.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.ppiyaki.infrastructure.messaging.fcm.PushPayload;
+import com.ppiyaki.infrastructure.messaging.fcm.PushSendResult;
 import com.ppiyaki.infrastructure.messaging.fcm.PushSender;
+import com.ppiyaki.medication.domain.LogStatus;
 import com.ppiyaki.medication.domain.MealSlot;
+import com.ppiyaki.medication.domain.MedicationLog;
 import com.ppiyaki.medication.domain.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationLogRepository;
 import com.ppiyaki.medication.repository.MedicationScheduleRepository;
 import com.ppiyaki.medicine.Medicine;
 import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.notification.DeviceToken;
 import com.ppiyaki.notification.Notification;
 import com.ppiyaki.notification.repository.DeviceTokenRepository;
 import com.ppiyaki.notification.repository.NotificationRepository;
@@ -43,7 +52,7 @@ import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@DisplayName("MedicationDelayDispatcher 메시지 빌더")
+@DisplayName("MedicationDelayDispatcher 슬롯 단위 묶음 발송")
 class MedicationDelayDispatcherTest {
 
     @Mock
@@ -77,88 +86,171 @@ class MedicationDelayDispatcherTest {
     private static final LocalDate TODAY = LocalDate.of(2026, 5, 13);
 
     @Test
-    @DisplayName("발송 메시지 본문에 약 이름 + 복용량 포함 (issue #345)")
-    void body_includes_medicine_name_and_dosage() throws Exception {
-        givenSenior();
+    @DisplayName("미인증 약 1개도 묶음 포맷으로 발송 (issue #409)")
+    void single_unsent_uses_grouped_format() throws Exception {
         givenCareRelation();
         givenSettingsDefault();
         final MedicationSchedule schedule = buildSchedule(46L, 100L, "1정");
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
-                .thenReturn(List.of(schedule));
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
-                .thenReturn(List.of());
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
-                .thenReturn(List.of());
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(schedule));
+        givenEmptyOtherSlots();
         when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
         when(medicineRepository.findById(100L)).thenReturn(Optional.of(buildMedicine(100L, "록스펜씨알정")));
-        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
-                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        givenNoExistingDelayNotification();
         when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
         when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
 
-        dispatcher.dispatchForSenior(seniorUser(), TODAY);
+        final int dispatched = dispatcher.dispatchForSenior(seniorUser(), TODAY);
 
+        assertThat(dispatched).isEqualTo(1);
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
-        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
-        final Notification saved = captor.getValue();
-        assertThat(saved.getBody())
-                .isEqualTo("김철수 어르신이 아침에 록스펜씨알정 1정을 아직 복용하지 않았어요. (60분 경과)");
+        verify(notificationRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getBody())
+                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정 1정");
     }
 
     @Test
-    @DisplayName("medicine 조회 실패 시 fallback \"약\"")
+    @DisplayName("medicine 조회 실패 시 fallback \"약\" + 묶음 포맷")
     void body_fallback_when_medicine_not_found() throws Exception {
-        givenSenior();
         givenCareRelation();
         givenSettingsDefault();
         final MedicationSchedule schedule = buildSchedule(46L, 999L, "2캡슐");
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
-                .thenReturn(List.of(schedule));
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
-                .thenReturn(List.of());
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
-                .thenReturn(List.of());
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(schedule));
+        givenEmptyOtherSlots();
         when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
         when(medicineRepository.findById(999L)).thenReturn(Optional.empty());
-        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
-                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        givenNoExistingDelayNotification();
         when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
         when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
 
         dispatcher.dispatchForSenior(seniorUser(), TODAY);
 
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
-        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
+        verify(notificationRepository).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 2캡슐을 아직 복용하지 않았어요. (60분 경과)");
+                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 약 2캡슐");
     }
 
     @Test
     @DisplayName("dosage가 null이면 약 이름만 표시")
     void body_omits_dosage_when_null() throws Exception {
-        givenSenior();
         givenCareRelation();
         givenSettingsDefault();
         final MedicationSchedule schedule = buildSchedule(46L, 100L, null);
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.BREAKFAST)))
-                .thenReturn(List.of(schedule));
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
-                .thenReturn(List.of());
-        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
-                .thenReturn(List.of());
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(schedule));
+        givenEmptyOtherSlots();
         when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
         when(medicineRepository.findById(100L)).thenReturn(Optional.of(buildMedicine(100L, "록스펜씨알정")));
-        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndScheduleId(
-                anyLong(), any(), anyLong(), any(), anyLong())).thenReturn(false);
+        givenNoExistingDelayNotification();
         when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
         when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
 
         dispatcher.dispatchForSenior(seniorUser(), TODAY);
 
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
-        org.mockito.Mockito.verify(notificationRepository).save(captor.capture());
+        verify(notificationRepository).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 록스펜씨알정을 아직 복용하지 않았어요. (60분 경과)");
+                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정");
+    }
+
+    @Test
+    @DisplayName("한 슬롯 미인증 3개 → 알림 1건 묶음 발송 + payload scheduleIds JSON 배열")
+    void groups_multiple_unsent_into_single_notification() throws Exception {
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule s1 = buildScheduleWithId(101L, 1001L, "1정");
+        final MedicationSchedule s2 = buildScheduleWithId(102L, 1002L, "2캡슐");
+        final MedicationSchedule s3 = buildScheduleWithId(103L, 1003L, null);
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(s1, s2, s3));
+        givenEmptyOtherSlots();
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
+        when(medicineRepository.findById(1001L)).thenReturn(Optional.of(buildMedicine(1001L, "타이레놀500mg")));
+        when(medicineRepository.findById(1002L)).thenReturn(Optional.of(buildMedicine(1002L, "비타민C")));
+        when(medicineRepository.findById(1003L)).thenReturn(Optional.of(buildMedicine(1003L, "위장약")));
+        givenNoExistingDelayNotification();
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID))
+                .thenReturn(List.of(buildDeviceToken("token-xyz")));
+        when(pushSender.send(anyString(), any(PushPayload.class)))
+                .thenReturn(new PushSendResult(true, false, null));
+
+        final int dispatched = dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        assertThat(dispatched).isEqualTo(1);
+        final ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository, times(1)).save(notificationCaptor.capture());
+        assertThat(notificationCaptor.getValue().getBody())
+                .isEqualTo("김철수 어르신이 아침에 약 3개를 아직 복용하지 않았어요. (60분 경과)"
+                        + "\n• 타이레놀500mg 1정"
+                        + "\n• 비타민C 2캡슐"
+                        + "\n• 위장약");
+        assertThat(notificationCaptor.getValue().getScheduleId()).isNull();
+
+        final ArgumentCaptor<PushPayload> payloadCaptor = ArgumentCaptor.forClass(PushPayload.class);
+        verify(pushSender, times(1)).send(eq("token-xyz"), payloadCaptor.capture());
+        assertThat(payloadCaptor.getValue().data())
+                .containsEntry("category", "MEDICATION_DELAY")
+                .containsEntry("seniorId", String.valueOf(SENIOR_ID))
+                .containsEntry("mealSlot", MealSlot.BREAKFAST.name())
+                .containsEntry("scheduleIds", "[101,102,103]");
+    }
+
+    @Test
+    @DisplayName("일부만 인증된 경우 미인증 schedule만 본문에 포함")
+    void excludes_taken_schedules_from_body() throws Exception {
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule s1 = buildScheduleWithId(101L, 1001L, "1정");
+        final MedicationSchedule s2 = buildScheduleWithId(102L, 1002L, "2캡슐");
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(s1, s2));
+        givenEmptyOtherSlots();
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY))
+                .thenReturn(List.of(buildTakenLog(101L)));
+        when(medicineRepository.findById(1002L)).thenReturn(Optional.of(buildMedicine(1002L, "비타민C")));
+        givenNoExistingDelayNotification();
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID)).thenReturn(List.of());
+
+        dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getBody())
+                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 비타민C 2캡슐");
+    }
+
+    @Test
+    @DisplayName("슬롯의 모든 schedule이 인증된 경우 알림 발송 없음")
+    void no_notification_when_all_taken() throws Exception {
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule s1 = buildScheduleWithId(101L, 1001L, "1정");
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(s1));
+        givenEmptyOtherSlots();
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY))
+                .thenReturn(List.of(buildTakenLog(101L)));
+
+        final int dispatched = dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        assertThat(dispatched).isZero();
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("같은 slot+date에 이미 발송된 경우 재발송 안 함 (멱등)")
+    void idempotent_per_slot_and_date() throws Exception {
+        givenCareRelation();
+        givenSettingsDefault();
+        final MedicationSchedule s1 = buildScheduleWithId(101L, 1001L, "1정");
+        givenSlotSchedules(MealSlot.BREAKFAST, List.of(s1));
+        givenEmptyOtherSlots();
+        when(logRepository.findBySeniorIdAndTargetDate(SENIOR_ID, TODAY)).thenReturn(List.of());
+        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot(
+                anyLong(), any(), anyLong(), any(), anyString())).thenReturn(true);
+
+        final int dispatched = dispatcher.dispatchForSenior(seniorUser(), TODAY);
+
+        assertThat(dispatched).isZero();
+        verify(notificationRepository, never()).save(any(Notification.class));
     }
 
     // --- fixtures ---
@@ -167,13 +259,8 @@ class MedicationDelayDispatcherTest {
         final User mockSenior = mock(User.class);
         when(mockSenior.getId()).thenReturn(SENIOR_ID);
         when(mockSenior.getNickname()).thenReturn("김철수");
-        // BREAKFAST만 설정 — LUNCH/DINNER는 null이라 dispatcher가 skip
         when(mockSenior.getBreakfastTime()).thenReturn(LocalTime.of(10, 0));
         return mockSenior;
-    }
-
-    private void givenSenior() {
-        // no-op (User mock에서 mealTimes 직접 stub)
     }
 
     private void givenCareRelation() {
@@ -185,10 +272,32 @@ class MedicationDelayDispatcherTest {
 
     private void givenSettingsDefault() {
         when(settingsRepository.findByCaregiverIdAndSeniorId(CAREGIVER_ID, SENIOR_ID))
-                .thenReturn(Optional.empty()); // default threshold 60
+                .thenReturn(Optional.empty());
+    }
+
+    private void givenSlotSchedules(final MealSlot slot, final List<MedicationSchedule> schedules) {
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(slot)))
+                .thenReturn(schedules);
+    }
+
+    private void givenEmptyOtherSlots() {
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.LUNCH)))
+                .thenReturn(List.of());
+        when(scheduleRepository.findActiveByOwnerAndMealSlot(eq(SENIOR_ID), eq(TODAY), eq(MealSlot.DINNER)))
+                .thenReturn(List.of());
+    }
+
+    private void givenNoExistingDelayNotification() {
+        when(notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot(
+                anyLong(), any(), anyLong(), any(), anyString())).thenReturn(false);
     }
 
     private MedicationSchedule buildSchedule(final Long id, final Long medicineId,
+            final String dosage) throws Exception {
+        return buildScheduleWithId(id, medicineId, dosage);
+    }
+
+    private MedicationSchedule buildScheduleWithId(final Long id, final Long medicineId,
             final String dosage) throws Exception {
         final java.lang.reflect.Constructor<MedicationSchedule> ctor = MedicationSchedule.class
                 .getDeclaredConstructor();
@@ -213,6 +322,24 @@ class MedicationDelayDispatcherTest {
         final Medicine m = new Medicine(SENIOR_ID, null, name, 30, 30, "ITEM-" + id, null);
         setField(m, "id", id);
         return m;
+    }
+
+    private MedicationLog buildTakenLog(final Long scheduleId) throws Exception {
+        final java.lang.reflect.Constructor<MedicationLog> ctor = MedicationLog.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final MedicationLog log = ctor.newInstance();
+        setField(log, "scheduleId", scheduleId);
+        setField(log, "status", LogStatus.TAKEN);
+        return log;
+    }
+
+    private DeviceToken buildDeviceToken(final String token) throws Exception {
+        final java.lang.reflect.Constructor<DeviceToken> ctor = DeviceToken.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        final DeviceToken dt = ctor.newInstance();
+        setField(dt, "token", token);
+        setField(dt, "isActive", true);
+        return dt;
     }
 
     private static void setField(final Object target, final String fieldName, final Object value) throws Exception {

--- a/src/test/java/com/ppiyaki/notification/service/WellbeingPingCooldownStoreTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/WellbeingPingCooldownStoreTest.java
@@ -1,0 +1,66 @@
+package com.ppiyaki.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+class WellbeingPingCooldownStoreTest {
+
+    private static final long SENIOR_ID = 1L;
+    private static final long CAREGIVER_ID = 2L;
+    private static final String KEY = "wellbeing-ping:cooldown:1:2";
+
+    private StringRedisTemplate redisTemplate;
+    private ValueOperations<String, String> valueOps;
+    private WellbeingPingCooldownStore store;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        redisTemplate = mock(StringRedisTemplate.class);
+        valueOps = mock(ValueOperations.class);
+        given(redisTemplate.opsForValue()).willReturn(valueOps);
+        store = new WellbeingPingCooldownStore(redisTemplate);
+    }
+
+    @Test
+    @DisplayName("setIfAbsent 성공 시 tryAcquire true")
+    void tryAcquire_success() {
+        given(valueOps.setIfAbsent(eq(KEY), eq("1"), any(Duration.class))).willReturn(true);
+
+        assertThat(store.tryAcquire(SENIOR_ID, CAREGIVER_ID)).isTrue();
+    }
+
+    @Test
+    @DisplayName("setIfAbsent 실패 시 tryAcquire false")
+    void tryAcquire_fails_when_key_exists() {
+        given(valueOps.setIfAbsent(eq(KEY), eq("1"), any(Duration.class))).willReturn(false);
+
+        assertThat(store.tryAcquire(SENIOR_ID, CAREGIVER_ID)).isFalse();
+    }
+
+    @Test
+    @DisplayName("getRetryAfterSeconds 가 TTL 양수면 Optional 반환")
+    void getRetryAfterSeconds_returns_positive_ttl() {
+        given(redisTemplate.getExpire(KEY)).willReturn(42L);
+
+        assertThat(store.getRetryAfterSeconds(SENIOR_ID, CAREGIVER_ID)).contains(42L);
+    }
+
+    @Test
+    @DisplayName("TTL 0 이하면 Optional.empty")
+    void getRetryAfterSeconds_empty_when_no_ttl() {
+        given(redisTemplate.getExpire(KEY)).willReturn(-1L);
+
+        assertThat(store.getRetryAfterSeconds(SENIOR_ID, CAREGIVER_ID)).isEmpty();
+    }
+}

--- a/src/test/java/com/ppiyaki/notification/service/WellbeingPingServiceTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/WellbeingPingServiceTest.java
@@ -1,0 +1,191 @@
+package com.ppiyaki.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.ppiyaki.common.exception.BusinessException;
+import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.infrastructure.messaging.fcm.PushPayload;
+import com.ppiyaki.infrastructure.messaging.fcm.PushSendResult;
+import com.ppiyaki.infrastructure.messaging.fcm.PushSender;
+import com.ppiyaki.notification.DeviceToken;
+import com.ppiyaki.notification.repository.DeviceTokenRepository;
+import com.ppiyaki.user.domain.CareRelation;
+import com.ppiyaki.user.domain.User;
+import com.ppiyaki.user.domain.UserRole;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WellbeingPingServiceTest {
+
+    private static final long SENIOR_ID = 10L;
+    private static final long CAREGIVER_ID = 20L;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private CareRelationRepository careRelationRepository;
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+    @Mock
+    private WellbeingPingCooldownStore cooldownStore;
+    @Mock
+    private PushSender pushSender;
+
+    @InjectMocks
+    private WellbeingPingService wellbeingPingService;
+
+    @Test
+    @DisplayName("정상 발송 — 모든 활성 토큰에 push 호출")
+    void send_success_dispatches_to_all_tokens() {
+        // given
+        final User senior = mockUser(UserRole.SENIOR);
+        given(senior.getNickname()).willReturn("김장군");
+        final User caregiver = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(caregiver));
+        given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
+                CAREGIVER_ID, SENIOR_ID)).willReturn(Optional.of(mock(CareRelation.class)));
+        given(cooldownStore.tryAcquire(SENIOR_ID, CAREGIVER_ID)).willReturn(true);
+
+        final DeviceToken token1 = mock(DeviceToken.class);
+        final DeviceToken token2 = mock(DeviceToken.class);
+        given(token1.getToken()).willReturn("t1");
+        given(token2.getToken()).willReturn("t2");
+        given(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID))
+                .willReturn(List.of(token1, token2));
+        given(pushSender.send(anyString(), any(PushPayload.class))).willReturn(PushSendResult.ok());
+
+        // when
+        wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID);
+
+        // then
+        verify(pushSender, times(2)).send(anyString(), any(PushPayload.class));
+        verify(token1, never()).deactivate();
+        verify(token2, never()).deactivate();
+    }
+
+    @Test
+    @DisplayName("발신자가 시니어가 아니면 CARE_RELATION_ROLE_MISMATCH")
+    void send_caller_not_senior_throws() {
+        final User notSenior = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(notSenior));
+
+        assertThatThrownBy(() -> wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting(throwable -> ((BusinessException) throwable).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("수신자가 보호자가 아니면 CARE_RELATION_ROLE_MISMATCH")
+    void send_receiver_not_caregiver_throws() {
+        final User senior = mockUser(UserRole.SENIOR);
+        final User wrongRole = mockUser(UserRole.SENIOR);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(wrongRole));
+
+        assertThatThrownBy(() -> wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting(throwable -> ((BusinessException) throwable).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_ROLE_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("CareRelation 없으면 CARE_RELATION_NOT_FOUND")
+    void send_no_care_relation_throws() {
+        final User senior = mockUser(UserRole.SENIOR);
+        final User caregiver = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(caregiver));
+        given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
+                CAREGIVER_ID, SENIOR_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting(throwable -> ((BusinessException) throwable).getErrorCode())
+                .isEqualTo(ErrorCode.CARE_RELATION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("쿨다운 차단 시 WellbeingPingCooldownException + retryAfterSeconds 전달")
+    void send_cooldown_blocks_with_retry_after() {
+        final User senior = mockUser(UserRole.SENIOR);
+        final User caregiver = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(caregiver));
+        given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
+                CAREGIVER_ID, SENIOR_ID)).willReturn(Optional.of(mock(CareRelation.class)));
+        given(cooldownStore.tryAcquire(SENIOR_ID, CAREGIVER_ID)).willReturn(false);
+        given(cooldownStore.getRetryAfterSeconds(SENIOR_ID, CAREGIVER_ID))
+                .willReturn(Optional.of(33L));
+
+        assertThatThrownBy(() -> wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID))
+                .isInstanceOf(WellbeingPingCooldownException.class)
+                .extracting(throwable -> ((WellbeingPingCooldownException) throwable).getRetryAfterSeconds())
+                .isEqualTo(33L);
+    }
+
+    @Test
+    @DisplayName("tokenInvalid 결과 시 DeviceToken.deactivate 호출")
+    void send_invalid_token_deactivates() {
+        final User senior = mockUser(UserRole.SENIOR);
+        final User caregiver = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(caregiver));
+        given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
+                CAREGIVER_ID, SENIOR_ID)).willReturn(Optional.of(mock(CareRelation.class)));
+        given(cooldownStore.tryAcquire(SENIOR_ID, CAREGIVER_ID)).willReturn(true);
+
+        final DeviceToken token = mock(DeviceToken.class);
+        given(token.getToken()).willReturn("invalid-t");
+        given(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID))
+                .willReturn(List.of(token));
+        given(pushSender.send(eq("invalid-t"), any(PushPayload.class)))
+                .willReturn(PushSendResult.tokenInvalid("unregistered"));
+
+        wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID);
+
+        verify(token).deactivate();
+    }
+
+    @Test
+    @DisplayName("활성 토큰 0개여도 정상 종료")
+    void send_no_tokens_completes() {
+        final User senior = mockUser(UserRole.SENIOR);
+        final User caregiver = mockUser(UserRole.CAREGIVER);
+        given(userRepository.findById(SENIOR_ID)).willReturn(Optional.of(senior));
+        given(userRepository.findById(CAREGIVER_ID)).willReturn(Optional.of(caregiver));
+        given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(
+                CAREGIVER_ID, SENIOR_ID)).willReturn(Optional.of(mock(CareRelation.class)));
+        given(cooldownStore.tryAcquire(SENIOR_ID, CAREGIVER_ID)).willReturn(true);
+        given(deviceTokenRepository.findByUserIdAndIsActiveTrue(CAREGIVER_ID))
+                .willReturn(List.of());
+
+        wellbeingPingService.send(SENIOR_ID, CAREGIVER_ID);
+
+        verify(pushSender, never()).send(anyString(), any(PushPayload.class));
+    }
+
+    private User mockUser(final UserRole role) {
+        final User user = mock(User.class);
+        given(user.getRole()).willReturn(role);
+        return user;
+    }
+}

--- a/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
@@ -156,4 +156,100 @@ class CareRelationControllerE2ETest {
                 .body("$", hasSize(1))
                 .body("[0].nickname", is("시니어코드E2E"));
     }
+
+    @Test
+    @DisplayName("시니어가 본인의 보호자 목록을 조회한다")
+    void readCaregivers_success() {
+        // given — 보호자 회원가입 + 시니어 대리 생성 + 초대 코드 + 코드 로그인 → 시니어 토큰
+        final String caregiverToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "cg_code_e2e",
+                            "password": "pass1234!",
+                            "nickname": "보호자코드E2E"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("accessToken");
+
+        final Integer seniorId = RestAssured.given()
+                .header("Authorization", "Bearer " + caregiverToken)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "nickname": "시니어코드E2E",
+                            "birthDate": "1945-03-15"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/seniors")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("seniorId");
+
+        final String inviteCode = RestAssured.given()
+                .header("Authorization", "Bearer " + caregiverToken)
+                .contentType(ContentType.JSON)
+                .body("{\"seniorId\": " + seniorId + "}")
+                .when()
+                .post("/api/v1/care-relations/invite")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("inviteCode");
+
+        final String seniorToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("{\"code\": \"" + inviteCode + "\"}")
+                .when()
+                .post("/api/v1/auth/code-login")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("accessToken");
+
+        // when & then — 시니어가 본인의 보호자 목록 조회
+        RestAssured.given()
+                .header("Authorization", "Bearer " + seniorToken)
+                .when()
+                .get("/api/v1/care-relations/caregivers")
+                .then()
+                .statusCode(200)
+                .body("$", hasSize(1))
+                .body("[0].nickname", is("보호자코드E2E"))
+                .body("[0].id", notNullValue());
+    }
+
+    @Test
+    @DisplayName("보호자가 시니어 전용 endpoint(/care-relations/caregivers) 호출 시 403")
+    void readCaregivers_caregiver_forbidden() {
+        final String caregiverToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                            "loginId": "cg_code_e2e",
+                            "password": "pass1234!",
+                            "nickname": "보호자코드E2E"
+                        }
+                        """)
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("accessToken");
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + caregiverToken)
+                .when()
+                .get("/api/v1/care-relations/caregivers")
+                .then()
+                .statusCode(403);
+    }
 }

--- a/src/test/java/com/ppiyaki/user/controller/MealTimesControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/MealTimesControllerE2ETest.java
@@ -5,7 +5,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.ppiyaki.user.domain.CareRelation;
 import com.ppiyaki.user.domain.User;
+import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -26,6 +28,9 @@ class MealTimesControllerE2ETest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private CareRelationRepository careRelationRepository;
 
     private static long userSequence = 800000L;
 
@@ -121,6 +126,89 @@ class MealTimesControllerE2ETest {
                 .put("/api/v1/users/me/meal-times")
                 .then()
                 .statusCode(401);
+    }
+
+    @Test
+    @DisplayName("활성 보호자가 시니어 mealTimes 변경 시 200 + DB 반영")
+    void caregiver_updates_senior_meal_times_success() {
+        // given
+        final SignupResult senior = signup("시니어E");
+        final SignupResult caregiver = signup("보호자E");
+        careRelationRepository.save(CareRelation.createLinked(senior.userId(), caregiver.userId()));
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .body("""
+                        {
+                            "breakfast": "07:30:00",
+                            "lunch": "12:00:00",
+                            "dinner": "19:00:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/" + senior.userId() + "/meal-times")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(senior.userId().intValue()))
+                .body("mealTimes.breakfast", is("07:30:00"))
+                .body("mealTimes.lunch", is("12:00:00"))
+                .body("mealTimes.dinner", is("19:00:00"));
+
+        final User reloaded = userRepository.findById(senior.userId()).orElseThrow();
+        assertThat(reloaded.getBreakfastTime()).isEqualTo(LocalTime.of(7, 30));
+        assertThat(reloaded.getLunchTime()).isEqualTo(LocalTime.of(12, 0));
+        assertThat(reloaded.getDinnerTime()).isEqualTo(LocalTime.of(19, 0));
+    }
+
+    @Test
+    @DisplayName("관계 없는 사용자가 시니어 mealTimes 변경 시도하면 403 CARE_001")
+    void unrelated_user_rejected_when_updating_senior_meal_times() {
+        // given
+        final SignupResult senior = signup("시니어F");
+        final SignupResult stranger = signup("타인G");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + stranger.accessToken())
+                .body("""
+                        {
+                            "breakfast": "08:00:00",
+                            "lunch": "12:30:00",
+                            "dinner": "18:30:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/" + senior.userId() + "/meal-times")
+                .then()
+                .statusCode(403)
+                .body("error.code", is("CARE_001"));
+    }
+
+    @Test
+    @DisplayName("seniorId 미존재 시 404 USER_001")
+    void senior_not_found_when_updating_meal_times() {
+        // given
+        final SignupResult caregiver = signup("보호자H");
+
+        // when & then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + caregiver.accessToken())
+                .body("""
+                        {
+                            "breakfast": "08:00:00",
+                            "lunch": "12:30:00",
+                            "dinner": "18:30:00"
+                        }
+                        """)
+                .when()
+                .put("/api/v1/users/9999999/meal-times")
+                .then()
+                .statusCode(404)
+                .body("error.code", is("USER_001"));
     }
 
     private SignupResult signup(final String nickname) {

--- a/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
@@ -119,6 +119,8 @@ class CareRelationServiceTest {
         assertThat(response.refreshToken()).isEqualTo("refresh-token");
         assertThat(inviteCodeWithRaw.inviteCode().isUsed()).isTrue();
         verify(rateLimiter).clearFailures("code-login:127.0.0.1");
+        verify(attemptLimiter).checkAllowed("code:" + codeHash);
+        verify(attemptLimiter).clear("code:" + codeHash);
     }
 
     @Test
@@ -137,6 +139,8 @@ class CareRelationServiceTest {
                     assertThat(be.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_INVITE_INVALID);
                 });
         verify(rateLimiter).recordFailure("code-login:127.0.0.1");
+        verify(attemptLimiter).checkAllowed("code:" + InviteCode.sha256("BADCOD"));
+        verify(attemptLimiter).recordAttempt("code:" + InviteCode.sha256("BADCOD"));
     }
 
     @Test
@@ -158,6 +162,8 @@ class CareRelationServiceTest {
                     assertThat(be.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_INVITE_INVALID);
                 });
         verify(rateLimiter).recordFailure("code-login:127.0.0.1");
+        verify(attemptLimiter).checkAllowed("code:" + codeHash);
+        verify(attemptLimiter).recordAttempt("code:" + codeHash);
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import com.ppiyaki.common.auth.JwtProvider;
 import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
+import com.ppiyaki.common.ratelimit.AttemptLimiter;
 import com.ppiyaki.common.ratelimit.RateLimiter;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
@@ -54,6 +55,9 @@ class CareRelationServiceTest {
 
     @Mock
     private RateLimiter rateLimiter;
+
+    @Mock
+    private AttemptLimiter attemptLimiter;
 
     @InjectMocks
     private CareRelationService careRelationService;

--- a/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
@@ -13,6 +13,7 @@ import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.common.ratelimit.AttemptLimiter;
 import com.ppiyaki.common.ratelimit.RateLimiter;
+import com.ppiyaki.user.controller.dto.CaregiverSummaryResponse;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
 import com.ppiyaki.user.domain.CareRelation;
@@ -24,6 +25,7 @@ import com.ppiyaki.user.repository.InviteCodeRepository;
 import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -183,10 +185,61 @@ class CareRelationServiceTest {
         verify(inviteCodeRepository, org.mockito.Mockito.never()).findByCodeHashAndUsedAtIsNull(any());
     }
 
+    @Test
+    @DisplayName("시니어가 본인의 보호자 목록을 조회하면 활성 care_relation의 보호자가 DTO로 변환된다")
+    void readCaregivers_returnsActiveCaregivers() {
+        // given
+        final Long seniorId = 1L;
+        final Long caregiverA = 10L;
+        final Long caregiverB = 11L;
+
+        final CareRelation relationA = mock(CareRelation.class);
+        given(relationA.getCaregiverId()).willReturn(caregiverA);
+        final CareRelation relationB = mock(CareRelation.class);
+        given(relationB.getCaregiverId()).willReturn(caregiverB);
+        given(careRelationRepository.findBySeniorIdAndDeletedAtIsNull(seniorId))
+                .willReturn(List.of(relationA, relationB));
+
+        final User userA = mockUserWithNickname(caregiverA, "보호자A");
+        final User userB = mockUserWithNickname(caregiverB, "보호자B");
+        given(userRepository.findAllById(List.of(caregiverA, caregiverB)))
+                .willReturn(List.of(userA, userB));
+
+        // when
+        final List<CaregiverSummaryResponse> responses = careRelationService.readCaregivers(seniorId);
+
+        // then
+        assertThat(responses).hasSize(2);
+        assertThat(responses).extracting(CaregiverSummaryResponse::id).containsExactly(caregiverA, caregiverB);
+        assertThat(responses).extracting(CaregiverSummaryResponse::nickname).containsExactly("보호자A", "보호자B");
+    }
+
+    @Test
+    @DisplayName("연동된 보호자가 없으면 빈 리스트를 반환한다")
+    void readCaregivers_returnsEmptyWhenNoRelations() {
+        // given
+        given(careRelationRepository.findBySeniorIdAndDeletedAtIsNull(1L))
+                .willReturn(List.of());
+        given(userRepository.findAllById(List.of())).willReturn(List.of());
+
+        // when
+        final List<CaregiverSummaryResponse> responses = careRelationService.readCaregivers(1L);
+
+        // then
+        assertThat(responses).isEmpty();
+    }
+
     private User mockUser(final Long id, final UserRole role) {
         final User user = mock(User.class);
         lenient().when(user.getId()).thenReturn(id);
         lenient().when(user.getRole()).thenReturn(role);
+        return user;
+    }
+
+    private User mockUserWithNickname(final Long id, final String nickname) {
+        final User user = mock(User.class);
+        lenient().when(user.getId()).thenReturn(id);
+        lenient().when(user.getNickname()).thenReturn(nickname);
         return user;
     }
 }


### PR DESCRIPTION
## Highlights

- **🐛 prod 404 해소**: `PUT /api/v1/users/{seniorId}/meal-times` — 보호자가 시니어 식사시간 변경 시 발생하던 404 (5/21 디스코드 보고). #393
- **✨ 안부 알림 (시니어→보호자) feature 통째**: spec → 구현 → 시니어→보호자 목록 조회 endpoint까지. #413 #414 #421
- **📦 인프라 대전환**: NCP DB → self-hosted docker MySQL 마이그레이션, Redis 인프라 도입(rate limiter / DRUG/MFDS 캐시 / 안부 알림 쿨다운). #395~#406, #416
- **🔔 복약 지연 알림 묶기**: 슬롯·시니어·날짜 단위로 1건 묶음 발송, payload `scheduleId` → `scheduleIds` cut-over. #409 #411

## Changes

### feat
- `feat(user)` 안부 알림 (시니어→보호자) 발송 API 구현 (#414)
- `feat(user)` 시니어 본인의 보호자 목록 조회 API 구현 (#421)
- `feat(user)` Rate Limiter Redis 전환 및 초대코드 횟수 제한 (#405)
- `feat(medication)` 복약 지연 알림 슬롯 단위 묶음 발송 (#411)
- `feat` 시니어 식사시간을 연결된 보호자도 수정 가능하게 (#393)
- `feat` 복약 인증 사진 정책을 careMode로 분기 (#394)
- `feat(infra)` docker MySQL host 127.0.0.1:13306 publish (#402)
- `feat(infra)` NCP → docker MySQL 마이그레이션 스크립트 (#398)
- `feat(infra)` self-hosted MySQL spec + docker-compose 서비스 정의 (#396)

### refactor
- `refactor(medication)` 약 정보 / DUR 캐시를 Redis로 전환 (#404)

### chore / infra
- `chore(infra)` Redis 인프라 설정 및 Spring Boot 연동 구성 (#403, #406)
- `chore(infra)` CI workflow에 redis 서비스 추가 (#416)

### docs
- `docs(user)` 안부 알림 Feature Spec 초안 + @Transactional 정정 (#413, #415)
- `docs(user)` User.nickname NOT NULL 강제 Feature Spec 초안 (#418)
- `docs(medication)` 복약 지연 알림 슬롯 묶기 Feature Spec 초안 (#410)
- `docs(infra)` DB 이전 완료 기록 ADR 0011 (#400)

## 배포 후 검증
- [ ] 보호자 계정으로 `PUT /api/v1/users/{seniorId}/meal-times` 200 OK (5/21 진영 보고 케이스)
- [ ] 시니어 토큰으로 `GET /api/v1/care-relations/caregivers` 200 OK
- [ ] 시니어 토큰으로 `POST /api/v1/notifications/wellbeing-pings` 204 + 보호자 폰 푸시 수신
- [ ] `MEDICATION_DELAY` 알림 payload에 `scheduleIds` (JSON 배열 문자열) 들어가는지 확인

## 머지 방식
- **Merge commit** (Squash 금지 — develop 히스토리 보존)

🤖 Generated with [Claude Code](https://claude.com/claude-code)