### PR TITLE
 feat(user): 초대코드 저장소를 MySQL에서 Redis로 이전 (#420)         

### DIFF
--- a/src/main/java/com/ppiyaki/user/domain/InviteCode.java
+++ b/src/main/java/com/ppiyaki/user/domain/InviteCode.java
@@ -89,11 +89,11 @@ public class InviteCode extends CreatedTimeEntity {
     }
 
     public static String generateCode() {
-        final StringBuilder sb = new StringBuilder(CODE_LENGTH);
+        final StringBuilder codeBuilder = new StringBuilder(CODE_LENGTH);
         for (int i = 0; i < CODE_LENGTH; i++) {
-            sb.append(CODE_CHARS.charAt(RANDOM.nextInt(CODE_CHARS.length())));
+            codeBuilder.append(CODE_CHARS.charAt(RANDOM.nextInt(CODE_CHARS.length())));
         }
-        return sb.toString();
+        return codeBuilder.toString();
     }
 
     public record InviteCodeWithRaw(

--- a/src/main/java/com/ppiyaki/user/domain/InviteCode.java
+++ b/src/main/java/com/ppiyaki/user/domain/InviteCode.java
@@ -88,7 +88,7 @@ public class InviteCode extends CreatedTimeEntity {
         this.usedAt = now;
     }
 
-    private static String generateCode() {
+    public static String generateCode() {
         final StringBuilder sb = new StringBuilder(CODE_LENGTH);
         for (int i = 0; i < CODE_LENGTH; i++) {
             sb.append(CODE_CHARS.charAt(RANDOM.nextInt(CODE_CHARS.length())));

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -112,7 +112,7 @@ public class CareRelationService {
         final String attemptKey = "code:" + codeHash;
         attemptLimiter.checkAllowed(attemptKey);
 
-        final Long seniorId = inviteCodeStore.findSeniorIdByCodeHash(codeHash)
+        final Long seniorId = inviteCodeStore.consume(codeHash)
                 .orElse(null);
 
         if (seniorId == null) {
@@ -121,7 +121,6 @@ public class CareRelationService {
             throw new BusinessException(ErrorCode.CARE_RELATION_INVITE_INVALID);
         }
 
-        inviteCodeStore.markUsed(codeHash);
         rateLimiter.clearFailures(rateLimitKey);
         attemptLimiter.clear(attemptKey);
 

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -10,10 +10,8 @@ import com.ppiyaki.user.controller.dto.LoginResponse;
 import com.ppiyaki.user.controller.dto.SeniorSummaryResponse;
 import com.ppiyaki.user.domain.CareRelation;
 import com.ppiyaki.user.domain.InviteCode;
-import com.ppiyaki.user.domain.InviteCode.InviteCodeWithRaw;
 import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
-import com.ppiyaki.user.repository.InviteCodeRepository;
 import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDateTime;
@@ -26,8 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CareRelationService {
 
+    private static final long INVITE_CODE_TTL_SECONDS = 300L;
+
     private final CareRelationRepository careRelationRepository;
-    private final InviteCodeRepository inviteCodeRepository;
+    private final InviteCodeStore inviteCodeStore;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
@@ -37,7 +37,7 @@ public class CareRelationService {
 
     public CareRelationService(
             final CareRelationRepository careRelationRepository,
-            final InviteCodeRepository inviteCodeRepository,
+            final InviteCodeStore inviteCodeStore,
             final RefreshTokenRepository refreshTokenRepository,
             final UserRepository userRepository,
             final JwtProvider jwtProvider,
@@ -46,7 +46,7 @@ public class CareRelationService {
             final AttemptLimiter attemptLimiter
     ) {
         this.careRelationRepository = careRelationRepository;
-        this.inviteCodeRepository = inviteCodeRepository;
+        this.inviteCodeStore = inviteCodeStore;
         this.refreshTokenRepository = refreshTokenRepository;
         this.userRepository = userRepository;
         this.jwtProvider = jwtProvider;
@@ -73,18 +73,18 @@ public class CareRelationService {
                 .toList();
     }
 
-    @Transactional
     public InviteCodeResponse createInviteCode(final Long caregiverId, final Long seniorId) {
         careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(caregiverId, seniorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARE_RELATION_NOT_FOUND));
 
-        final InviteCodeWithRaw inviteCodeWithRaw = InviteCode.create(seniorId, LocalDateTime.now());
-        inviteCodeRepository.save(inviteCodeWithRaw.inviteCode());
+        final String rawCode = InviteCode.generateCode();
+        final String codeHash = InviteCode.sha256(rawCode);
+        inviteCodeStore.save(codeHash, seniorId, INVITE_CODE_TTL_SECONDS);
 
-        return new InviteCodeResponse(inviteCodeWithRaw.rawCode(), inviteCodeWithRaw.inviteCode().getExpiresAt());
+        final LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(INVITE_CODE_TTL_SECONDS);
+        return new InviteCodeResponse(rawCode, expiresAt);
     }
 
-    @Transactional
     public LoginResponse codeLogin(final String code, final String clientIp) {
         final String rateLimitKey = "code-login:" + clientIp;
         rateLimiter.checkAllowed(rateLimitKey);
@@ -93,27 +93,19 @@ public class CareRelationService {
         final String attemptKey = "code:" + codeHash;
         attemptLimiter.checkAllowed(attemptKey);
 
-        final InviteCode inviteCode = inviteCodeRepository.findByCodeHashAndUsedAtIsNull(codeHash)
+        final Long seniorId = inviteCodeStore.findSeniorIdByCodeHash(codeHash)
                 .orElse(null);
 
-        if (inviteCode == null) {
+        if (seniorId == null) {
             rateLimiter.recordFailure(rateLimitKey);
             attemptLimiter.recordAttempt(attemptKey);
             throw new BusinessException(ErrorCode.CARE_RELATION_INVITE_INVALID);
         }
 
-        final LocalDateTime now = LocalDateTime.now();
-        if (inviteCode.isExpired(now)) {
-            rateLimiter.recordFailure(rateLimitKey);
-            attemptLimiter.recordAttempt(attemptKey);
-            throw new BusinessException(ErrorCode.CARE_RELATION_INVITE_INVALID);
-        }
-
-        inviteCode.markUsed(now);
+        inviteCodeStore.markUsed(codeHash);
         rateLimiter.clearFailures(rateLimitKey);
         attemptLimiter.clear(attemptKey);
 
-        final Long seniorId = inviteCode.getSeniorId();
         final User senior = findUserById(seniorId);
         final String accessToken = jwtProvider.createAccessToken(seniorId, senior.getRole().name());
         final String refreshToken = jwtProvider.createRefreshToken(seniorId);

--- a/src/main/java/com/ppiyaki/user/service/InMemoryInviteCodeStore.java
+++ b/src/main/java/com/ppiyaki/user/service/InMemoryInviteCodeStore.java
@@ -15,21 +15,15 @@ public class InMemoryInviteCodeStore implements InviteCodeStore {
     }
 
     @Override
-    public Optional<Long> findSeniorIdByCodeHash(final String codeHash) {
-        final CachedInviteCode cached = store.get(codeHash);
+    public Optional<Long> consume(final String codeHash) {
+        final CachedInviteCode cached = store.remove(codeHash);
         if (cached == null) {
             return Optional.empty();
         }
         if (Instant.now().isAfter(cached.expiresAt())) {
-            store.remove(codeHash);
             return Optional.empty();
         }
         return Optional.of(cached.seniorId());
-    }
-
-    @Override
-    public void markUsed(final String codeHash) {
-        store.remove(codeHash);
     }
 
     private record CachedInviteCode(

--- a/src/main/java/com/ppiyaki/user/service/InMemoryInviteCodeStore.java
+++ b/src/main/java/com/ppiyaki/user/service/InMemoryInviteCodeStore.java
@@ -1,0 +1,40 @@
+package com.ppiyaki.user.service;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryInviteCodeStore implements InviteCodeStore {
+
+    private final Map<String, CachedInviteCode> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(final String codeHash, final Long seniorId, final long ttlSeconds) {
+        store.put(codeHash, new CachedInviteCode(seniorId, Instant.now().plusSeconds(ttlSeconds)));
+    }
+
+    @Override
+    public Optional<Long> findSeniorIdByCodeHash(final String codeHash) {
+        final CachedInviteCode cached = store.get(codeHash);
+        if (cached == null) {
+            return Optional.empty();
+        }
+        if (Instant.now().isAfter(cached.expiresAt())) {
+            store.remove(codeHash);
+            return Optional.empty();
+        }
+        return Optional.of(cached.seniorId());
+    }
+
+    @Override
+    public void markUsed(final String codeHash) {
+        store.remove(codeHash);
+    }
+
+    private record CachedInviteCode(
+            Long seniorId,
+            Instant expiresAt
+    ) {
+    }
+}

--- a/src/main/java/com/ppiyaki/user/service/InviteCodeStore.java
+++ b/src/main/java/com/ppiyaki/user/service/InviteCodeStore.java
@@ -6,7 +6,5 @@ public interface InviteCodeStore {
 
     void save(String codeHash, Long seniorId, long ttlSeconds);
 
-    Optional<Long> findSeniorIdByCodeHash(String codeHash);
-
-    void markUsed(String codeHash);
+    Optional<Long> consume(String codeHash);
 }

--- a/src/main/java/com/ppiyaki/user/service/InviteCodeStore.java
+++ b/src/main/java/com/ppiyaki/user/service/InviteCodeStore.java
@@ -1,0 +1,12 @@
+package com.ppiyaki.user.service;
+
+import java.util.Optional;
+
+public interface InviteCodeStore {
+
+    void save(String codeHash, Long seniorId, long ttlSeconds);
+
+    Optional<Long> findSeniorIdByCodeHash(String codeHash);
+
+    void markUsed(String codeHash);
+}

--- a/src/main/java/com/ppiyaki/user/service/InviteCodeStoreConfig.java
+++ b/src/main/java/com/ppiyaki/user/service/InviteCodeStoreConfig.java
@@ -1,0 +1,25 @@
+package com.ppiyaki.user.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class InviteCodeStoreConfig {
+
+    @Bean
+    @Primary
+    @ConditionalOnBean(StringRedisTemplate.class)
+    public InviteCodeStore redisInviteCodeStore(final StringRedisTemplate redisTemplate) {
+        return new RedisInviteCodeStore(redisTemplate);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(InviteCodeStore.class)
+    public InviteCodeStore inMemoryInviteCodeStore() {
+        return new InMemoryInviteCodeStore();
+    }
+}

--- a/src/main/java/com/ppiyaki/user/service/RedisInviteCodeStore.java
+++ b/src/main/java/com/ppiyaki/user/service/RedisInviteCodeStore.java
@@ -2,10 +2,13 @@ package com.ppiyaki.user.service;
 
 import java.time.Duration;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 public class RedisInviteCodeStore implements InviteCodeStore {
 
+    private static final Logger log = LoggerFactory.getLogger(RedisInviteCodeStore.class);
     private static final String KEY_PREFIX = "invite-code:";
 
     private final StringRedisTemplate redisTemplate;
@@ -21,18 +24,17 @@ public class RedisInviteCodeStore implements InviteCodeStore {
     }
 
     @Override
-    public Optional<Long> findSeniorIdByCodeHash(final String codeHash) {
+    public Optional<Long> consume(final String codeHash) {
         final String redisKey = KEY_PREFIX + codeHash;
-        final String value = redisTemplate.opsForValue().get(redisKey);
+        final String value = redisTemplate.opsForValue().getAndDelete(redisKey);
         if (value == null) {
             return Optional.empty();
         }
-        return Optional.of(Long.parseLong(value));
-    }
-
-    @Override
-    public void markUsed(final String codeHash) {
-        final String redisKey = KEY_PREFIX + codeHash;
-        redisTemplate.delete(redisKey);
+        try {
+            return Optional.of(Long.parseLong(value));
+        } catch (final NumberFormatException e) {
+            log.warn("Invite code key has invalid value: key={}, value={}", redisKey, value);
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/com/ppiyaki/user/service/RedisInviteCodeStore.java
+++ b/src/main/java/com/ppiyaki/user/service/RedisInviteCodeStore.java
@@ -1,0 +1,38 @@
+package com.ppiyaki.user.service;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+public class RedisInviteCodeStore implements InviteCodeStore {
+
+    private static final String KEY_PREFIX = "invite-code:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisInviteCodeStore(final StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void save(final String codeHash, final Long seniorId, final long ttlSeconds) {
+        final String redisKey = KEY_PREFIX + codeHash;
+        redisTemplate.opsForValue().set(redisKey, String.valueOf(seniorId), Duration.ofSeconds(ttlSeconds));
+    }
+
+    @Override
+    public Optional<Long> findSeniorIdByCodeHash(final String codeHash) {
+        final String redisKey = KEY_PREFIX + codeHash;
+        final String value = redisTemplate.opsForValue().get(redisKey);
+        if (value == null) {
+            return Optional.empty();
+        }
+        return Optional.of(Long.parseLong(value));
+    }
+
+    @Override
+    public void markUsed(final String codeHash) {
+        final String redisKey = KEY_PREFIX + codeHash;
+        redisTemplate.delete(redisKey);
+    }
+}

--- a/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
@@ -105,7 +105,7 @@ class CareRelationServiceTest {
         // given
         final String rawCode = "ABC123";
         final String codeHash = InviteCode.sha256(rawCode);
-        given(inviteCodeStore.findSeniorIdByCodeHash(codeHash))
+        given(inviteCodeStore.consume(codeHash))
                 .willReturn(Optional.of(2L));
 
         final User senior = mockUser(2L, UserRole.SENIOR);
@@ -119,7 +119,7 @@ class CareRelationServiceTest {
         // then
         assertThat(response.accessToken()).isEqualTo("access-token");
         assertThat(response.refreshToken()).isEqualTo("refresh-token");
-        verify(inviteCodeStore).markUsed(codeHash);
+        verify(inviteCodeStore).consume(codeHash);
         verify(rateLimiter).clearFailures("code-login:127.0.0.1");
         verify(attemptLimiter).checkAllowed("code:" + codeHash);
         verify(attemptLimiter).clear("code:" + codeHash);
@@ -130,7 +130,7 @@ class CareRelationServiceTest {
     void codeLogin_invalidCode_throws() {
         // given
         final String codeHash = InviteCode.sha256("BADCOD");
-        given(inviteCodeStore.findSeniorIdByCodeHash(codeHash))
+        given(inviteCodeStore.consume(codeHash))
                 .willReturn(Optional.empty());
 
         // when & then
@@ -159,7 +159,7 @@ class CareRelationServiceTest {
                     final BusinessException be = (BusinessException) exception;
                     assertThat(be.getErrorCode()).isEqualTo(ErrorCode.RATE_LIMIT_EXCEEDED);
                 });
-        verify(inviteCodeStore, Mockito.never()).findSeniorIdByCodeHash(any());
+        verify(inviteCodeStore, Mockito.never()).consume(any());
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
@@ -3,6 +3,7 @@ package com.ppiyaki.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -20,7 +21,6 @@ import com.ppiyaki.user.domain.InviteCode;
 import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.domain.UserRole;
 import com.ppiyaki.user.repository.CareRelationRepository;
-import com.ppiyaki.user.repository.InviteCodeRepository;
 import com.ppiyaki.user.repository.RefreshTokenRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDateTime;
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,7 +40,7 @@ class CareRelationServiceTest {
     private CareRelationRepository careRelationRepository;
 
     @Mock
-    private InviteCodeRepository inviteCodeRepository;
+    private InviteCodeStore inviteCodeStore;
 
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
@@ -69,7 +70,6 @@ class CareRelationServiceTest {
         final CareRelation existingRelation = CareRelation.createLinked(2L, 1L);
         given(careRelationRepository.findByCaregiverIdAndSeniorIdAndDeletedAtIsNull(1L, 2L))
                 .willReturn(Optional.of(existingRelation));
-        given(inviteCodeRepository.save(any(InviteCode.class))).willAnswer(inv -> inv.getArgument(0));
 
         // when
         final InviteCodeResponse response = careRelationService.createInviteCode(1L, 2L);
@@ -78,6 +78,7 @@ class CareRelationServiceTest {
         assertThat(response.inviteCode()).hasSize(6);
         assertThat(response.inviteCode()).matches("[A-Z0-9]{6}");
         assertThat(response.expiresAt()).isAfter(LocalDateTime.now());
+        verify(inviteCodeStore).save(any(String.class), eq(2L), eq(300L));
     }
 
     @Test
@@ -100,14 +101,13 @@ class CareRelationServiceTest {
     @DisplayName("유효한 초대 코드로 코드 로그인하면 JWT가 발급된다")
     void codeLogin_success() {
         // given
-        final InviteCode.InviteCodeWithRaw inviteCodeWithRaw = InviteCode.create(2L, LocalDateTime.now());
-        final String rawCode = inviteCodeWithRaw.rawCode();
+        final String rawCode = "ABC123";
         final String codeHash = InviteCode.sha256(rawCode);
-        given(inviteCodeRepository.findByCodeHashAndUsedAtIsNull(codeHash))
-                .willReturn(java.util.Optional.of(inviteCodeWithRaw.inviteCode()));
+        given(inviteCodeStore.findSeniorIdByCodeHash(codeHash))
+                .willReturn(Optional.of(2L));
 
         final User senior = mockUser(2L, UserRole.SENIOR);
-        given(userRepository.findById(2L)).willReturn(java.util.Optional.of(senior));
+        given(userRepository.findById(2L)).willReturn(Optional.of(senior));
         given(jwtProvider.createAccessToken(2L, "SENIOR")).willReturn("access-token");
         given(jwtProvider.createRefreshToken(2L)).willReturn("refresh-token");
 
@@ -117,7 +117,7 @@ class CareRelationServiceTest {
         // then
         assertThat(response.accessToken()).isEqualTo("access-token");
         assertThat(response.refreshToken()).isEqualTo("refresh-token");
-        assertThat(inviteCodeWithRaw.inviteCode().isUsed()).isTrue();
+        verify(inviteCodeStore).markUsed(codeHash);
         verify(rateLimiter).clearFailures("code-login:127.0.0.1");
         verify(attemptLimiter).checkAllowed("code:" + codeHash);
         verify(attemptLimiter).clear("code:" + codeHash);
@@ -128,34 +128,11 @@ class CareRelationServiceTest {
     void codeLogin_invalidCode_throws() {
         // given
         final String codeHash = InviteCode.sha256("BADCOD");
-        given(inviteCodeRepository.findByCodeHashAndUsedAtIsNull(codeHash))
-                .willReturn(java.util.Optional.empty());
+        given(inviteCodeStore.findSeniorIdByCodeHash(codeHash))
+                .willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> careRelationService.codeLogin("BADCOD", "127.0.0.1"))
-                .isInstanceOf(BusinessException.class)
-                .satisfies(exception -> {
-                    final BusinessException be = (BusinessException) exception;
-                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.CARE_RELATION_INVITE_INVALID);
-                });
-        verify(rateLimiter).recordFailure("code-login:127.0.0.1");
-        verify(attemptLimiter).checkAllowed("code:" + InviteCode.sha256("BADCOD"));
-        verify(attemptLimiter).recordAttempt("code:" + InviteCode.sha256("BADCOD"));
-    }
-
-    @Test
-    @DisplayName("만료된 코드로 로그인 시도하면 CARE_RELATION_INVITE_INVALID 에러")
-    void codeLogin_expiredCode_throws() {
-        // given
-        final InviteCode.InviteCodeWithRaw inviteCodeWithRaw = InviteCode.create(
-                2L, LocalDateTime.now().minusMinutes(10));
-        final String rawCode = inviteCodeWithRaw.rawCode();
-        final String codeHash = InviteCode.sha256(rawCode);
-        given(inviteCodeRepository.findByCodeHashAndUsedAtIsNull(codeHash))
-                .willReturn(java.util.Optional.of(inviteCodeWithRaw.inviteCode()));
-
-        // when & then
-        assertThatThrownBy(() -> careRelationService.codeLogin(rawCode, "127.0.0.1"))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(exception -> {
                     final BusinessException be = (BusinessException) exception;
@@ -170,7 +147,7 @@ class CareRelationServiceTest {
     @DisplayName("Rate Limit 초과 시 429 에러가 발생하고 downstream은 호출되지 않는다")
     void codeLogin_rateLimitExceeded_throws() {
         // given
-        org.mockito.Mockito.doThrow(new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED))
+        Mockito.doThrow(new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED))
                 .when(rateLimiter).checkAllowed("code-login:127.0.0.1");
 
         // when & then
@@ -180,7 +157,7 @@ class CareRelationServiceTest {
                     final BusinessException be = (BusinessException) exception;
                     assertThat(be.getErrorCode()).isEqualTo(ErrorCode.RATE_LIMIT_EXCEEDED);
                 });
-        verify(inviteCodeRepository, org.mockito.Mockito.never()).findByCodeHashAndUsedAtIsNull(any());
+        verify(inviteCodeStore, Mockito.never()).findSeniorIdByCodeHash(any());
     }
 
     private User mockUser(final Long id, final UserRole role) {


### PR DESCRIPTION
                                        
  ## AS-IS                                               
  - 6자리 초대코드를 invite_codes 테이블(MySQL)에 SHA-256
   해시로 저장                                         
  - 5분 TTL 일회성 코드인데 DB에 만료된 레코드가 계속    
  누적                                        
  - JPA PESSIMISTIC_WRITE 락으로 동시 사용 방지          
                                              
  ## TO-BE                                               
  - Redis에 `invite-code:{codeHash}` → `seniorId` 형태로
  저장 (TTL 5분, 자동 만료)                              
  - 만료된 코드가 자동 삭제되어 DB 누적 문제 해소
  - Redis 단일 키 조회로 락 불필요                       
  - Redis 미가용 환경(테스트/CI)에서는 InMemory fallback 
                                                       
  ## 변경 파일                                           
  | 파일 | 변경 내용 |                                   
  |---|---|                                              
  | `InviteCodeStore.java` | 신규 — 초대코드 저장        
  인터페이스 (save, find, markUsed) |                    
  | `RedisInviteCodeStore.java` | 신규 — Redis 구현체    
  (TTL 5분 자동 만료) |                                
  | `InMemoryInviteCodeStore.java` | 신규 — Redis 없을 때
   fallback |                                 
  | `InviteCodeStoreConfig.java` | 신규 — Redis/InMemory 
  빈 자동 선택 |  
  | `CareRelationService.java` | InviteCodeRepository →  
  InviteCodeStore 전환, @Transactional 제거 | 
  | `InviteCode.java` | generateCode() public으로 변경 | 
  | `CareRelationServiceTest.java` | InviteCodeRepository
   mock → InviteCodeStore mock 전환 |                    
                                          
  ## 관련 이슈                                           
  - closes #420                                          
  - 참고: docs/features/redis-infra-setup.md           
                                                         
  ## 리뷰어 참고 포인트                   
  - `InviteCodeRepository`와 `InviteCode` 엔티티는 아직
  삭제하지 않음 — invite_codes 테이블 drop은 별도        
  마이그레이션 PR로 분리 예정             
  - `markUsed()`는 Redis 키를 삭제하는 방식. 코드 사용 = 
  키 삭제 = 재사용 불가                                  
  - `createInviteCode`/`codeLogin`에서 `@Transactional` 
  제거 — 더 이상 DB를 쓰지 않으므로 불필요               
                                                         
  ## 라벨 부여 확인                                    
  - [x] `type:feat` 라벨 1개 부여 완료                   
  - [x] `scope:user` 라벨 1개 부여 완료       
  - [x] (AI 작성 시) `ai-generated` 라벨 부여 완료       
  - [ ] (보호 영역 변경 시) `needs-human-review` 라벨 
  부여 완료                                              
                                                         
  <details>                                              
  <summary>AI Agent 전용 체크리스트 (해당 시             
  작성)</summary>                                        
                                                         
  ## AI 작업 여부                                      
  - [ ] AI 작업 아님 (사람 작성 PR)                      
  - [x] AI 보조/생성 사용                     
                                                         
  ## 품질 게이트 체크 (AI 작성 시)            
  - [x] `./gradlew checkstyleMain spotlessCheck`         
  - [x] `./gradlew test`                                 
  - [x] 변경 범위의 회귀 가능 구간을 확인했다.           
  - [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를       
  작성했다.                                              
                                                       
  > 롤백: InviteCodeRepository를 CareRelationService에   
  복원 + InviteCodeStore 관련 코드 revert. invite_codes  
  테이블은 아직 존재하므로 즉시 롤백 가능.               
                                                         
  ## DDD/OOP 준수 체크 (AI 작성 시)                    
  - [x] 도메인 용어가 기존 컨텍스트와 일치한다.          
  - [x] 계층 침범(Controller -> Repository 직접 호출
  등)이 없다.                                            
  - [x] 객체 역할/책임이 명확하며, 과도한 God Object를
  만들지 않았다.                                         
                                                         
  ## 보안/민감정보 체크 (AI 작성 시)                     
  - [x] 시크릿(API 키/토큰/비밀번호) 하드코딩이 없다.    
  - [x] 복약 기록/건강 프로필 등 의료정보를            
  로그/스크린샷에 노출하지 않았다.                       
  - [x] 민감정보가 필요한 경우 마스킹 처리했다.
                                                         
  ## 예외 머지 여부 (AI 작성 시)                         
  - [x] 예외 머지 아님                                 
  - [ ] 예외 머지임                                      
                                          
  ## AI 작업 기록                                        
  - 사용한 프롬프트/지시 요약: 초대코드 저장소를         
  MySQL에서 Redis로 이전 요청                          
  - AI가 직접 수정한 파일/범위: InviteCodeStore,         
  RedisInviteCodeStore, InMemoryInviteCodeStore,
  InviteCodeStoreConfig, CareRelationService, InviteCode,
   CareRelationServiceTest
  - 사람이 수동 검증한 항목: NCP 서버 Redis 컨테이너 기동
   확인 (이전 PR에서 완료)                    
  - 잔여 리스크/추가 확인 필요사항: prod 배포 후 초대코드
   발급/로그인 흐름 E2E 확인, invite_codes 테이블 drop은 
  별도 PR                                                
   
  </details>                                             
                  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 초대 코드 저장/검증을 해시 기반 저장소로 전환하고 Redis 우선 사용/메모리 대체 구성으로 변경했습니다.
* **Bug Fixes / Behavior**
  * 초대 코드 사용 시 즉시 무효화되고 TTL 만료 처리가 일관되게 적용됩니다.
* **Tests**
  * 초대 코드 흐름 관련 단위 테스트를 저장소 교체와 다양한 성공/실패 시나리오에 맞게 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->