### PR TITLE
feat(chat): 음성 메시지 SSE 응답에 STT 변환 텍스트 이벤트 추가 (#428)     

### DIFF
--- a/src/main/java/com/ppiyaki/chat/service/ChatSessionService.java
+++ b/src/main/java/com/ppiyaki/chat/service/ChatSessionService.java
@@ -1,11 +1,15 @@
 package com.ppiyaki.chat.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
@@ -22,6 +26,7 @@ import reactor.core.Disposable;
 @RequiredArgsConstructor
 public class ChatSessionService {
 
+    private static final Logger log = LoggerFactory.getLogger(ChatSessionService.class);
     private static final long SSE_TIMEOUT = 60_000L;
 
     /**
@@ -76,6 +81,7 @@ public class ChatSessionService {
     private final ChatSessionPersistenceService persistenceService;
     private final ChatClient chatClient;
     private final Executor chatStreamExecutor;
+    private final ObjectMapper objectMapper;
 
     public SseEmitter sendMessageStream(final Long userId, final Long sessionId, final String message) {
         final List<Message> promptMessages = persistenceService.loadSessionAndBuildPrompt(userId, sessionId, message);
@@ -130,10 +136,15 @@ public class ChatSessionService {
 
         chatStreamExecutor.execute(() -> {
             try {
-                final String transcriptionJson = "{\"type\":\"transcription\",\"text\":\""
-                        + escapeJson(transcribedText) + "\"}";
+                final String transcriptionJson = objectMapper.writeValueAsString(
+                        Map.of("type", "transcription", "text", transcribedText));
                 emitter.send(SseEmitter.event().data(transcriptionJson));
+            } catch (final JsonProcessingException e) {
+                log.warn("transcription 이벤트 직렬화 실패 sessionId={}", sessionId, e);
+                emitter.completeWithError(e);
+                return;
             } catch (final Exception e) {
+                log.warn("transcription 이벤트 전송 실패 sessionId={}", sessionId, e);
                 emitter.completeWithError(e);
                 return;
             }

--- a/src/main/java/com/ppiyaki/chat/service/ChatSessionService.java
+++ b/src/main/java/com/ppiyaki/chat/service/ChatSessionService.java
@@ -129,6 +129,15 @@ public class ChatSessionService {
         final SentenceBuffer sentenceBuffer = new SentenceBuffer();
 
         chatStreamExecutor.execute(() -> {
+            try {
+                final String transcriptionJson = "{\"type\":\"transcription\",\"text\":\""
+                        + escapeJson(transcribedText) + "\"}";
+                emitter.send(SseEmitter.event().data(transcriptionJson));
+            } catch (final Exception e) {
+                emitter.completeWithError(e);
+                return;
+            }
+
             final Disposable subscription = chatClient.prompt(new Prompt(promptMessages))
                     .toolContext(Map.of("userId", userId))
                     .stream()

--- a/src/test/java/com/ppiyaki/chat/ChatSessionServiceTest.java
+++ b/src/test/java/com/ppiyaki/chat/ChatSessionServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppiyaki.chat.service.ChatSessionPersistenceService;
 import com.ppiyaki.chat.service.ChatSessionService;
 import com.ppiyaki.common.exception.BusinessException;
@@ -36,7 +37,7 @@ class ChatSessionServiceTest {
         persistenceService = mock(ChatSessionPersistenceService.class);
         chatClient = mock(ChatClient.class);
         final Executor executor = Runnable::run;
-        chatSessionService = new ChatSessionService(persistenceService, chatClient, executor);
+        chatSessionService = new ChatSessionService(persistenceService, chatClient, executor, new ObjectMapper());
     }
 
     @Test


### PR DESCRIPTION
                                                      
  ## AS-IS                                                        
  - POST /api/v1/chat/voice-messages가 STT → LLM → TTS를 처리하지만 
  STT 변환 텍스트를 클라이언트에 전달하지 않음
  - 클라이언트가 사용자의 음성 입력을 텍스트로 표시할 수 없음       
                                                                    
  ## TO-BE                                                          
  - SSE 첫 이벤트로 `{"type":"transcription","text":"..."}` 전송    
  - 클라이언트가 `type` 필드 유무로 STT 결과와 AI 응답을 구분 가능  
  - 기존 AI 응답 이벤트 형식은 변경 없음 (하위 호환)              
                                                                    
  변경 후 SSE 흐름:                           
  → {"type":"transcription","text":"타이레놀 효능 알려줘"}   (신규) 
  → {"text":"타이레놀은...","audio":"base64..."}              (기존)
  → {"text":"복용 시...","audio":"base64..."}                 (기존)
  → [DONE]                                                          
                                                                    
  ## 변경 파일                                                      
  | 파일 | 변경 내용 |                                              
  |---|---|                                                         
  | `ChatSessionService.java` | `sendVoiceMessageStream`에서 LLM    
  스트리밍 전 transcription 이벤트 전송 (7줄 추가) |              
                                                                  
  ## 관련 이슈                                                      
  - closes #428                                                     
                                                                    
  ## 리뷰어 참고 포인트                                             
  - 기존 AI 응답 이벤트에 `type` 필드를 추가하지 않았음 — 프론트에서
   `type` 유무로 구분 (`type` 있으면 transcription, 없으면 AI 응답)
  - transcription 전송 실패 시 `emitter.completeWithError` +        
  `return`으로 LLM 스트리밍 진입 안 함        
  - `escapeJson`으로 transcribedText 내 특수문자 이스케이프 처리    
                                              
  ## 라벨 부여 확인                                                 
  - [x] `type:feat` 라벨 1개 부여 완료
  - [x] `scope:chat` 라벨 1개 부여 완료                             
  - [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
  - [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료     
                                                                    
  <details>                                                         
  <summary>AI Agent 전용 체크리스트 (해당 시 작성)</summary>        
                                                                    
  ## AI 작업 여부                                                   
  - [ ] AI 작업 아님 (사람 작성 PR)                                 
  - [x] AI 보조/생성 사용                                           
                                                                    
  ## 품질 게이트 체크 (AI 작성 시)                                  
  - [x] `./gradlew checkstyleMain spotlessCheck`                    
  - [x] `./gradlew test`                                            
  - [x] 변경 범위의 회귀 가능 구간을 확인했다.                      
  - [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다.        
                                                                    
  > 롤백: transcription 이벤트 전송 코드 7줄 제거. 기존 동작으로  
  즉시 복원.                                                        
                                                                    
  ## DDD/OOP 준수 체크 (AI 작성 시)                                 
  - [x] 도메인 용어가 기존 컨텍스트와 일치한다.                     
  - [x] 계층 침범(Controller -> Repository 직접 호출 등)이 없다.    
  - [x] 객체 역할/책임이 명확하며, 과도한 God Object를 만들지       
  않았다.                                                         
                                                                    
  ## 보안/민감정보 체크 (AI 작성 시)                                
  - [x] 시크릿(API 키/토큰/비밀번호) 하드코딩이 없다.               
  - [x] 복약 기록/건강 프로필 등 의료정보를 로그/스크린샷에 노출하지
   않았다.                                                          
  - [x] 민감정보가 필요한 경우 마스킹 처리했다.                     
                                                                    
  ## 예외 머지 여부 (AI 작성 시)                                    
  - [x] 예외 머지 아님                                              
  - [ ] 예외 머지임                                                 
                                                                    
  ## AI 작업 기록                                                   
  - 사용한 프롬프트/지시 요약: 음성 메시지 SSE 응답에 STT 변환    
  텍스트 이벤트 추가 요청                                           
  - AI가 직접 수정한 파일/범위: ChatSessionService.java
  sendVoiceMessageStream 메서드 (7줄 추가)                          
  - 사람이 수동 검증한 항목: SSE 이벤트 형식 프론트엔드 호환성    
  - 잔여 리스크/추가 확인 필요사항: 프론트엔드에서 type 필드 파싱   
  로직 추가 필요                                                    
                                                                    
  </details>                                                        
                                                                  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 음성 메시지 스트리밍 시작 시 전사된 텍스트가 실시간 이벤트로 전송

* **버그 수정**
  * 음성 스트리밍 중 전사 이벤트 전송 실패 시 안정적인 오류 처리 및 로깅 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ppiyaki/ppiyaki-backend/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->