### PR TITLE
 fix(user): POST /api/v1/seniors 요청 필드를 birthDate에서    gender, careMode로 변경 (#432)       

### DIFF
--- a/src/main/java/com/ppiyaki/user/controller/dto/SeniorCreateRequest.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/SeniorCreateRequest.java
@@ -1,10 +1,13 @@
 package com.ppiyaki.user.controller.dto;
 
+import com.ppiyaki.user.domain.CareMode;
+import com.ppiyaki.user.domain.Gender;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
+import jakarta.validation.constraints.NotNull;
 
 public record SeniorCreateRequest(
         @NotBlank String nickname,
-        LocalDate birthDate
+        @NotNull Gender gender,
+        @NotNull CareMode careMode
 ) {
 }

--- a/src/main/java/com/ppiyaki/user/service/SeniorService.java
+++ b/src/main/java/com/ppiyaki/user/service/SeniorService.java
@@ -31,7 +31,8 @@ public class SeniorService {
     @Transactional
     public SeniorCreateResponse createSenior(final Long caregiverId, final SeniorCreateRequest seniorCreateRequest) {
         final User senior = userRepository.save(
-                User.createSenior(seniorCreateRequest.nickname(), seniorCreateRequest.birthDate()));
+                User.createSenior(seniorCreateRequest.nickname(), seniorCreateRequest.gender()));
+        senior.changeCareMode(seniorCreateRequest.careMode());
 
         final Pet pet = petRepository.save(Pet.create());
         senior.assignPet(pet.getId());

--- a/src/test/java/com/ppiyaki/common/auth/RoleAuthorizationE2ETest.java
+++ b/src/test/java/com/ppiyaki/common/auth/RoleAuthorizationE2ETest.java
@@ -75,7 +75,9 @@ class RoleAuthorizationE2ETest {
                 .contentType(ContentType.JSON)
                 .body("""
                         {
-                            "nickname": "할머니"
+                            "nickname": "할머니",
+                            "gender": "FEMALE",
+                            "careMode": "MANAGED"
                         }
                         """)
                 .when()

--- a/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
@@ -67,7 +67,8 @@ class CareRelationControllerE2ETest {
                 .body("""
                         {
                             "nickname": "시니어코드E2E",
-                            "birthDate": "1945-03-15"
+                            "gender": "FEMALE",
+                            "careMode": "MANAGED"
                         }
                         """)
                 .when()
@@ -138,7 +139,8 @@ class CareRelationControllerE2ETest {
                 .body("""
                         {
                             "nickname": "시니어코드E2E",
-                            "birthDate": "1945-03-15"
+                            "gender": "FEMALE",
+                            "careMode": "MANAGED"
                         }
                         """)
                 .when()
@@ -183,7 +185,8 @@ class CareRelationControllerE2ETest {
                 .body("""
                         {
                             "nickname": "시니어코드E2E",
-                            "birthDate": "1945-03-15"
+                            "gender": "FEMALE",
+                            "careMode": "MANAGED"
                         }
                         """)
                 .when()

--- a/src/test/java/com/ppiyaki/user/controller/SeniorControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/SeniorControllerE2ETest.java
@@ -61,7 +61,8 @@ class SeniorControllerE2ETest {
                 .body("""
                         {
                             "nickname": "시니어E2E대리",
-                            "birthDate": "1945-03-15"
+                            "gender": "FEMALE",
+                            "careMode": "MANAGED"
                         }
                         """)
                 .when()

--- a/src/test/java/com/ppiyaki/user/service/SeniorServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/SeniorServiceTest.java
@@ -9,11 +9,12 @@ import com.ppiyaki.pet.Pet;
 import com.ppiyaki.pet.repository.PetRepository;
 import com.ppiyaki.user.controller.dto.SeniorCreateRequest;
 import com.ppiyaki.user.controller.dto.SeniorCreateResponse;
+import com.ppiyaki.user.domain.CareMode;
 import com.ppiyaki.user.domain.CareRelation;
+import com.ppiyaki.user.domain.Gender;
 import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
-import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,7 +53,7 @@ class SeniorServiceTest {
         given(careRelation.getId()).willReturn(1L);
         given(careRelationRepository.save(any(CareRelation.class))).willReturn(careRelation);
 
-        final SeniorCreateRequest request = new SeniorCreateRequest("시니어할머니", LocalDate.of(1945, 3, 15));
+        final SeniorCreateRequest request = new SeniorCreateRequest("시니어할머니", Gender.FEMALE, CareMode.MANAGED);
 
         // when
         final SeniorCreateResponse response = seniorService.createSenior(1L, request);


### PR DESCRIPTION
                                                       
  ## AS-IS                                                           
  - POST /api/v1/seniors에서 nickname + birthDate를 받음             
  - 온보딩의 SeniorEntry(nickname + gender + careMode)와 필드 구성이 
  불일치                                                             
  - 마이페이지에서 시니어 추가 시 성별/케어모드 지정 불가            
                                                                     
  ## TO-BE                                                           
  - POST /api/v1/seniors에서 nickname + gender + careMode를 받도록 
  변경                                                               
  - 온보딩 SeniorEntry와 동일한 필드 구성으로 통일
  - gender, careMode 모두 @NotNull 필수값                            
                                              
  변경 전: `{"nickname": "할머니", "birthDate": "1945-03-15"}`     
  변경 후: `{"nickname": "할머니", "gender": "FEMALE", "careMode":   
  "MANAGED"}`                                                        
                                                                     
  ## 변경 파일                                                       
  - `SeniorCreateRequest.java` — birthDate 제거 → gender, careMode   
  추가 (@NotNull)                                                  
  - `SeniorService.java` — createSenior(nickname, gender) +          
  changeCareMode() 호출로 변경                
  - `SeniorServiceTest.java` — 요청 생성자 변경                      
  - `SeniorControllerE2ETest.java` — 요청 body 변경
  - `CareRelationControllerE2ETest.java` — 시니어 생성 요청 body 변경
   (3곳)                                      
  - `RoleAuthorizationE2ETest.java` — 시니어 생성 요청 body에 gender,
   careMode 추가                                                     
                                                                     
  ## 관련 이슈                                                       
  - closes #432                                                      
                                                                   
  ## 리뷰어 참고 포인트                                              
  - **Breaking Change**: 기존 API 요청 형식이 변경됨. 프론트에서
  시니어 추가 요청 body를 맞춰야 함                                
  - 온보딩의 `User.createSenior(nickname, gender)`와 동일한 팩토리   
  메서드 사용으로 시니어 생성 로직 통일       
                                                                     
  ## 라벨 부여 확인                           
  - [x] `type:fix` 라벨 1개 부여 완료                                
  - [x] `scope:user` 라벨 1개 부여 완료       
  - [x] (AI 작성 시) `ai-generated` 라벨 부여 완료                   
  - [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료
                                                                     
  <details>                               
  <summary>AI Agent 전용 체크리스트 (해당 시 작성)</summary>         
                                                                     
  ## AI 작업 여부                                                    
  - [ ] AI 작업 아님 (사람 작성 PR)                                  
  - [x] AI 보조/생성 사용                                            
                                                                     
  ## 품질 게이트 체크 (AI 작성 시)                                   
  - [x] `./gradlew checkstyleMain spotlessCheck`                     
  - [x] `./gradlew test`                                             
  - [x] 변경 범위의 회귀 가능 구간을 확인했다.                       
  - [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다.         
                                                                     
  > 롤백: SeniorCreateRequest에 birthDate 복원 + gender/careMode   
  제거. 테스트 body 원복.                                            
                                                                     
  ## DDD/OOP 준수 체크 (AI 작성 시)                                  
  - [x] 도메인 용어가 기존 컨텍스트와 일치한다.                      
  - [x] 계층 침범(Controller -> Repository 직접 호출 등)이 없다.     
  - [x] 객체 역할/책임이 명확하며, 과도한 God Object를 만들지 않았다.
                                                                   
  ## 보안/민감정보 체크 (AI 작성 시)                                 
  - [x] 시크릿(API 키/토큰/비밀번호) 하드코딩이 없다.                
  - [x] 복약 기록/건강 프로필 등 의료정보를 로그/스크린샷에 노출하지 
  않았다.                                                            
  - [x] 민감정보가 필요한 경우 마스킹 처리했다.                      
                                                                     
  ## 예외 머지 여부 (AI 작성 시)                                     
  - [x] 예외 머지 아님                                               
  - [ ] 예외 머지임                                                  
                                                                   
  ## AI 작업 기록                                                    
  - 사용한 프롬프트/지시 요약: POST /api/v1/seniors 요청 필드를      
  birthDate에서 gender, careMode로 변경 요청                       
  - AI가 직접 수정한 파일/범위: SeniorCreateRequest, SeniorService,  
  SeniorServiceTest, SeniorControllerE2ETest, 
  CareRelationControllerE2ETest, RoleAuthorizationE2ETest            
  - 사람이 수동 검증한 항목: 프론트엔드 시니어 추가 요청 body 변경
  필요                                                               
  - 잔여 리스크/추가 확인 필요사항: 프론트에서 API 요청 형식 맞추기
  필요                                                               
                                                                     
  </details>                                                       
                                                                     
  