### PR TITLE
feat(user): 시니어/보호자 목록 응답에 프로필 사진 필드 추가

### DIFF
--- a/src/main/java/com/ppiyaki/user/controller/dto/CaregiverSummaryResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/CaregiverSummaryResponse.java
@@ -4,13 +4,17 @@ import com.ppiyaki.user.domain.User;
 
 public record CaregiverSummaryResponse(
         Long id,
-        String nickname
+        String nickname,
+        Integer profileImage,
+        String profileImageUrl
 ) {
 
-    public static CaregiverSummaryResponse from(final User user) {
+    public static CaregiverSummaryResponse from(final User user, final String profileImageUrl) {
         return new CaregiverSummaryResponse(
                 user.getId(),
-                user.getNickname()
+                user.getNickname(),
+                user.getProfileImage(),
+                profileImageUrl
         );
     }
 }

--- a/src/main/java/com/ppiyaki/user/controller/dto/SeniorSummaryResponse.java
+++ b/src/main/java/com/ppiyaki/user/controller/dto/SeniorSummaryResponse.java
@@ -10,16 +10,20 @@ public record SeniorSummaryResponse(
         String nickname,
         LocalDate birthDate,
         Gender gender,
-        CareMode careMode
+        CareMode careMode,
+        Integer profileImage,
+        String profileImageUrl
 ) {
 
-    public static SeniorSummaryResponse from(final User user) {
+    public static SeniorSummaryResponse from(final User user, final String profileImageUrl) {
         return new SeniorSummaryResponse(
                 user.getId(),
                 user.getNickname(),
                 user.getBirthDate(),
                 user.getGender(),
-                user.getCareMode()
+                user.getCareMode(),
+                user.getProfileImage(),
+                profileImageUrl
         );
     }
 }

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -93,7 +93,8 @@ public class CareRelationService {
 
         return careRelations.stream()
                 .map(relation -> caregiversById.get(relation.getCaregiverId()))
-                .map(CaregiverSummaryResponse::from)
+                .map(caregiver -> CaregiverSummaryResponse.from(
+                        caregiver, profileImageUrlResolver.resolve(caregiver.getProfileImageObjectKey())))
                 .toList();
     }
 

--- a/src/main/java/com/ppiyaki/user/service/CareRelationService.java
+++ b/src/main/java/com/ppiyaki/user/service/CareRelationService.java
@@ -5,6 +5,7 @@ import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.common.ratelimit.AttemptLimiter;
 import com.ppiyaki.common.ratelimit.RateLimiter;
+import com.ppiyaki.infrastructure.storage.ProfileImageUrlResolver;
 import com.ppiyaki.user.controller.dto.CaregiverSummaryResponse;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
@@ -35,6 +36,7 @@ public class CareRelationService {
     private final AuthService authService;
     private final RateLimiter rateLimiter;
     private final AttemptLimiter attemptLimiter;
+    private final ProfileImageUrlResolver profileImageUrlResolver;
 
     public CareRelationService(
             final CareRelationRepository careRelationRepository,
@@ -44,7 +46,8 @@ public class CareRelationService {
             final JwtProvider jwtProvider,
             final AuthService authService,
             final RateLimiter rateLimiter,
-            final AttemptLimiter attemptLimiter
+            final AttemptLimiter attemptLimiter,
+            final ProfileImageUrlResolver profileImageUrlResolver
     ) {
         this.careRelationRepository = careRelationRepository;
         this.inviteCodeStore = inviteCodeStore;
@@ -54,6 +57,7 @@ public class CareRelationService {
         this.authService = authService;
         this.rateLimiter = rateLimiter;
         this.attemptLimiter = attemptLimiter;
+        this.profileImageUrlResolver = profileImageUrlResolver;
     }
 
     @Transactional(readOnly = true)
@@ -70,7 +74,8 @@ public class CareRelationService {
 
         return careRelations.stream()
                 .map(relation -> seniorsById.get(relation.getSeniorId()))
-                .map(SeniorSummaryResponse::from)
+                .map(senior -> SeniorSummaryResponse.from(
+                        senior, profileImageUrlResolver.resolve(senior.getProfileImageObjectKey())))
                 .toList();
     }
 

--- a/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
@@ -229,7 +229,9 @@ class CareRelationControllerE2ETest {
                 .statusCode(200)
                 .body("$", hasSize(1))
                 .body("[0].nickname", is("보호자코드E2E"))
-                .body("[0].id", notNullValue());
+                .body("[0].id", notNullValue())
+                .body("[0]", hasKey("profileImage"))
+                .body("[0]", hasKey("profileImageUrl"));
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -159,7 +160,9 @@ class CareRelationControllerE2ETest {
                 .body("$", hasSize(1))
                 .body("[0].nickname", is("시니어코드E2E"))
                 .body("[0]", hasKey("profileImage"))
-                .body("[0]", hasKey("profileImageUrl"));
+                .body("[0]", hasKey("profileImageUrl"))
+                .body("[0].profileImage", is(nullValue()))
+                .body("[0].profileImageUrl", is(nullValue()));
     }
 
     @Test
@@ -231,7 +234,9 @@ class CareRelationControllerE2ETest {
                 .body("[0].nickname", is("보호자코드E2E"))
                 .body("[0].id", notNullValue())
                 .body("[0]", hasKey("profileImage"))
-                .body("[0]", hasKey("profileImageUrl"));
+                .body("[0]", hasKey("profileImageUrl"))
+                .body("[0].profileImage", is(nullValue()))
+                .body("[0].profileImageUrl", is(nullValue()));
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/user/controller/CareRelationControllerE2ETest.java
@@ -1,5 +1,6 @@
 package com.ppiyaki.user.controller;
 
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -156,7 +157,9 @@ class CareRelationControllerE2ETest {
                 .then()
                 .statusCode(200)
                 .body("$", hasSize(1))
-                .body("[0].nickname", is("시니어코드E2E"));
+                .body("[0].nickname", is("시니어코드E2E"))
+                .body("[0]", hasKey("profileImage"))
+                .body("[0]", hasKey("profileImageUrl"));
     }
 
     @Test

--- a/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
+++ b/src/test/java/com/ppiyaki/user/service/CareRelationServiceTest.java
@@ -14,6 +14,7 @@ import com.ppiyaki.common.exception.BusinessException;
 import com.ppiyaki.common.exception.ErrorCode;
 import com.ppiyaki.common.ratelimit.AttemptLimiter;
 import com.ppiyaki.common.ratelimit.RateLimiter;
+import com.ppiyaki.infrastructure.storage.ProfileImageUrlResolver;
 import com.ppiyaki.user.controller.dto.CaregiverSummaryResponse;
 import com.ppiyaki.user.controller.dto.InviteCodeResponse;
 import com.ppiyaki.user.controller.dto.LoginResponse;
@@ -61,6 +62,9 @@ class CareRelationServiceTest {
 
     @Mock
     private AttemptLimiter attemptLimiter;
+
+    @Mock
+    private ProfileImageUrlResolver profileImageUrlResolver;
 
     @InjectMocks
     private CareRelationService careRelationService;


### PR DESCRIPTION
## AS-IS
- `GET /api/v1/care-relations/seniors` 응답에 시니어 프로필 사진 정보가 없어 보호자 앱 시니어 목록 화면에서 프로필 이미지를 표시할 수 없다.

## TO-BE
- 응답 각 항목에 `profileImage`(프리셋 아바타 인덱스, Integer)와 `profileImageUrl`(업로드 이미지 presigned GET URL) 필드를 추가한다.
- `/users/me`(`UserMeResponse`)와 동일하게 `profileImageObjectKey`를 `ProfileImageUrlResolver`로 해석하며, 두 필드는 상호배타·미설정 시 null이다.

## 관련 이슈
- closes #439

## 리뷰어 참고 포인트
- `CareRelationService.readSeniors`에서 시니어별로 `ProfileImageUrlResolver.resolve()`를 호출한다. 스토리지 미설정(local/test) 환경에서는 `ObjectProvider`로 감싸 null을 반환하므로 기존과 동일하게 동작한다.

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료
- [x] `scope:*` 라벨 1개 부여 완료
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크 (AI 작성 시)
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 변경 범위의 회귀 가능 구간을 확인했다. (DTO 필드 추가만, 기존 필드 불변)
- [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다. (응답 필드 추가뿐이라 revert만으로 롤백 가능, DB 변경 없음)

## DDD/OOP 준수 체크 (AI 작성 시)
- [x] 도메인 용어가 기존 컨텍스트와 일치한다. (profileImage/profileImageUrl은 UserMeResponse와 동일)
- [x] 계층 침범(Controller -> Repository 직접 호출 등)이 없다.
- [x] 객체 역할/책임이 명확하며, 과도한 God Object를 만들지 않았다.

## 보안/민감정보 체크 (AI 작성 시)
- [x] 시크릿 하드코딩이 없다.
- [x] 의료정보를 로그/스크린샷에 노출하지 않았다.
- [x] 민감정보가 필요한 경우 마스킹 처리했다. (해당 없음)

## 예외 머지 여부 (AI 작성 시)
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: `/api/v1/care-relations/seniors` 응답에 profileImage, profileImageUrl 추가 요청
- AI가 직접 수정한 파일/범위: `SeniorSummaryResponse`, `CareRelationService`, `CareRelationControllerE2ETest`
- 사람이 수동 검증한 항목: (리뷰 대기)
- 잔여 리스크/추가 확인 필요사항: 없음 (DB/스키마 변경 없음)

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 시니어 목록 조회 시 프로필 이미지 정보가 응답에 포함됩니다.
  * 각 시니어의 프로필 이미지 파일 정보와 URL을 함께 확인할 수 있어, 사용자 인터페이스에서 시니어의 프로필 사진을 직접 표시할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->