### PR TITLE
fix(medication): 복약 완료 알림 끼니별 발송 + 알림함 미저장 버그 수정

### DIFF
--- a/docs/features/medication-notification.md
+++ b/docs/features/medication-notification.md
@@ -28,7 +28,7 @@ last_reviewed: 2026-05-10
 - **시니어**는 아침 8시(자기 mealTime)에 "삐~약드실 시간이에요~" 푸시를 받고 앱을 열어 복약을 인증한다.
 - **보호자**는 시니어가 아침 약을 8시 30분이 지나도 인증하지 않으면 "김장군 어르신이 아침 약 복용 시간을 30분 넘겼습니다" 푸시를 받는다 (임계는 보호자가 시니어별로 설정 가능).
 - **보호자**는 새 처방전이 등록되어 DUR 위험(연령 금기/병용 금기)이 검출되면 "새로 등록된 처방전에 연령 금기 주의 약물이 포함되어 있습니다" 푸시를 받는다.
-- **보호자**는 시니어가 그 날 모든 복약을 완료하면 "축하합니다! 김장군 어르신이 모든 복약을 완료하셨습니다!" 푸시를 받는다.
+- **보호자**는 시니어가 한 끼니(아침/점심/저녁)의 복약을 완료할 때마다 "축하합니다! 김장군 어르신이 아침 복약을 완료하셨습니다!" 푸시를 받는다 (끼니별 1회).
 - **보호자**는 시니어가 24시간(설정 가능) 동안 앱에 접속하지 않으면 "앱 미접속" 알림을 받는다.
 - **보호자**는 알림함에서 "전체 / 긴급 경고 / 복약 완료" 탭으로 과거 알림을 분류 조회할 수 있다.
 - **보호자**는 알림 설정 페이지에서 시니어별로 항목 on/off 및 임계값을 조정하거나, **일반/집중 프리셋**을 선택해 일괄 적용한다.
@@ -39,7 +39,7 @@ last_reviewed: 2026-05-10
 - [ ] **시니어 복약 시간 알림** (`MEDICATION_REMINDER`): 시니어 mealTime(아침/점심/저녁) 도래 시 시니어 본인에게 푸시 + 알림함 row.
 - [ ] **보호자 미복약/지연 알림** (`MEDICATION_DELAY`): mealTime + 임계 분 경과 후 미인증 schedule이 있으면 보호자에게 푸시 + 알림함 row.
 - [ ] **보호자 DUR 긴급 경고** (`DUR_WARNING`): 처방전 등록 후 DUR 검사 결과 연령 금기/병용 금기가 있으면 보호자에게 즉시 푸시 + 알림함 row.
-- [ ] **보호자 복약 완료 알림** (`MEDICATION_COMPLETE`): 시니어가 그 날 등록된 모든 복약 schedule을 인증하면 보호자에게 푸시 + 알림함 row. (멱등 — 하루 1회만)
+- [ ] **보호자 복약 완료 알림** (`MEDICATION_COMPLETE`): 시니어가 한 끼니(meal_slot)에 속한 모든 복약 schedule을 인증하면 그 끼니에 대해 보호자에게 푸시 + 알림함 row. (멱등 — 끼니별 1회, 하루 최대 아침/점심/저녁 3회)
 - [ ] **보호자 가족 안전망 알림** (`FAMILY_SAFETY`): 시니어 `last_active_at` + 임계 시간 경과 시 보호자에게 푸시 + 알림함 row. (멱등 — 임계 도달 시 1회, 시니어 재접속까지 재발송 X)
 - [ ] **알림함 조회 API**: 페이징, 카테고리 필터(전체/긴급 경고/복약 완료), 읽음 상태.
 - [ ] **알림 읽음 처리 API**: 단건 + 모두 읽음.
@@ -150,7 +150,7 @@ last_reviewed: 2026-05-10
 
 **DUR 경고**: 즉시 트리거. `PrescriptionService.confirm` → DUR 검사 → 위험 시 알림.
 
-**복약 완료 알림**: `MedicationLog` 업서트 후 그 날 schedule이 모두 인증되었는지 확인 → 마지막 인증 시 발송. 멱등 `(caregiver_id, category=MEDICATION_COMPLETE, senior_id, target_date)`.
+**복약 완료 알림**: `MedicationLog` 업서트(TAKEN 신규 전환) 후 `MedicationTakenEvent`를 `AFTER_COMMIT`으로 수신 → 그 날 끼니(meal_slot)별로 해당 끼니의 모든 schedule이 인증되었는지 확인 → 완료된 끼니마다 발송. 멱등 `(caregiver_id, category=MEDICATION_COMPLETE, senior_id, target_date, meal_slot)`. `AFTER_COMMIT` 리스너에서 INSERT가 유실되지 않도록 dispatcher는 `@Transactional(REQUIRES_NEW)`로 독립 트랜잭션을 연다 (푸시 ↔ 알림함 row 1:1 보장, §10 Q7).
 
 **가족 안전망 알림**: Cron `FamilySafetyChecker` 매 시간 실행. `User.last_active_at + 임계` 경과한 시니어의 보호자에게 발송. 멱등 — `last_active_at` 갱신 시점 이후의 가장 최근 `FAMILY_SAFETY` row가 없으면 발송, 있으면 skip. 시니어 재접속 시 다음 임계 초과 때 새 알림 가능 (cooldown 정책 = 시니어 재접속까지 1회만).
 
@@ -269,3 +269,5 @@ ALTER TABLE users ADD COLUMN last_active_at DATETIME NULL;
 - 2026-05-10: **Q7 해소** — 푸시 ↔ 알림함 row 항상 1:1. 이유: Figma 5종(시니어 복약시간 / 보호자 미복약·DUR·가족안전망·복약완료) 모두 알림함 표시 의도, 단순/일관성, 푸시 누락 보완, ppiyaki 규모에서 부하 무시 가능.
 - 2026-05-10: **Q8 해소** — 가족 안전망 알림 cooldown = 시니어 재접속까지 1회만. 구현은 `last_active_at` 갱신 시점 이후의 가장 최근 `FAMILY_SAFETY` row 존재 여부로 판정. 이유: 알림 피로 방지, 보호자가 한 번 인지하면 후속은 본인 책임, 구현 단순 (시니어 재접속 시 자연 reset).
 - 2026-05-10: 모든 오픈 질문 해소 → status `draft` → `approved`. 다음 단계: PR 머지 후 PR 2(refactor + notification_settings) 착수.
+- 2026-06-04: **복약 완료 알림을 "하루 전체 완료 1회" → "끼니별 완료" 로 변경.** 이유: 알림 의도(보호자가 끼니 단위로 복약 현황을 확인)에 맞춤. 끼니(meal_slot)별로 해당 끼니의 모든 schedule 인증 시 발송, 멱등키에 `meal_slot` 추가(하루 최대 아침/점심/저녁 3회). 기존 "모든 복약 완료" 알림은 제거. 사용자 합의.
+- 2026-06-04: **버그 수정 — 복약 완료 알림이 푸시는 뜨는데 알림함 row가 저장되지 않던 문제.** 원인: `MedicationCompleteDispatcher`가 `AFTER_COMMIT` 이벤트 리스너에서 호출되는데 `@Transactional`(기본 REQUIRED)이라 이미 커밋된 트랜잭션에 합류해 INSERT가 유실됨(푸시는 트랜잭션 무관이라 정상 발송 → Q7의 1:1 불변식 위반). 수정: dispatcher를 `@Transactional(REQUIRES_NEW)`로 변경하여 독립 트랜잭션 커밋 보장. 회귀 테스트 `MedicationCompleteNotificationE2ETest` 추가.

--- a/src/main/java/com/ppiyaki/notification/Notification.java
+++ b/src/main/java/com/ppiyaki/notification/Notification.java
@@ -175,7 +175,8 @@ public class Notification extends BaseTimeEntity {
             final Long seniorId,
             final String title,
             final String body,
-            final LocalDate targetDate
+            final LocalDate targetDate,
+            final String mealSlot
     ) {
         return new Notification(
                 caregiverId,
@@ -185,7 +186,7 @@ public class Notification extends BaseTimeEntity {
                 body,
                 null,
                 targetDate,
-                null,
+                mealSlot,
                 null
         );
     }

--- a/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ppiyaki/notification/repository/NotificationRepository.java
@@ -83,11 +83,4 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             final NotificationCategory category,
             final Long seniorId
     );
-
-    boolean existsByUserIdAndCategoryAndSeniorIdAndTargetDate(
-            final Long userId,
-            final NotificationCategory category,
-            final Long seniorId,
-            final java.time.LocalDate targetDate
-    );
 }

--- a/src/main/java/com/ppiyaki/notification/service/MedicationCompleteDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationCompleteDispatcher.java
@@ -4,6 +4,7 @@ import com.ppiyaki.infrastructure.messaging.fcm.PushPayload;
 import com.ppiyaki.infrastructure.messaging.fcm.PushSendResult;
 import com.ppiyaki.infrastructure.messaging.fcm.PushSender;
 import com.ppiyaki.medication.domain.LogStatus;
+import com.ppiyaki.medication.domain.MealSlot;
 import com.ppiyaki.medication.domain.MedicationLog;
 import com.ppiyaki.medication.domain.MedicationSchedule;
 import com.ppiyaki.medication.repository.MedicationLogRepository;
@@ -20,13 +21,16 @@ import com.ppiyaki.user.domain.User;
 import com.ppiyaki.user.repository.CareRelationRepository;
 import com.ppiyaki.user.repository.UserRepository;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
@@ -63,8 +67,14 @@ public class MedicationCompleteDispatcher {
         this.pushSender = pushSender;
     }
 
-    @Transactional
-    public int dispatchIfDayComplete(final Long seniorId, final LocalDate targetDate) {
+    /**
+     * 끼니(아침/점심/저녁)별로 그 끼니에 속한 모든 schedule이 인증되면 보호자에게 완료 알림을 보낸다.
+     *
+     * <p>{@code AFTER_COMMIT} 이벤트 리스너에서 호출되므로, 이미 커밋된 트랜잭션에 합류해 INSERT가 유실되는 것을
+     * 막기 위해 {@link Propagation#REQUIRES_NEW}로 독립 트랜잭션을 연다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int dispatchCompletedSlots(final Long seniorId, final LocalDate targetDate) {
         final List<MedicationSchedule> schedules = scheduleRepository.findActiveByOwnerAndDate(seniorId, targetDate);
         if (schedules.isEmpty()) {
             return 0;
@@ -75,10 +85,19 @@ public class MedicationCompleteDispatcher {
                 takenScheduleIds.add(logRow.getScheduleId());
             }
         }
-        for (final MedicationSchedule schedule : schedules) {
-            if (!takenScheduleIds.contains(schedule.getId())) {
-                return 0;
+
+        final Map<MealSlot, List<MedicationSchedule>> schedulesBySlot = schedules.stream()
+                .collect(Collectors.groupingBy(MedicationSchedule::getMealSlot));
+        final List<MealSlot> completedSlots = new ArrayList<>();
+        for (final Map.Entry<MealSlot, List<MedicationSchedule>> entry : schedulesBySlot.entrySet()) {
+            final boolean slotComplete = entry.getValue().stream()
+                    .allMatch(schedule -> takenScheduleIds.contains(schedule.getId()));
+            if (slotComplete) {
+                completedSlots.add(entry.getKey());
             }
+        }
+        if (completedSlots.isEmpty()) {
+            return 0;
         }
 
         final List<CareRelation> relations = careRelationRepository.findBySeniorIdAndDeletedAtIsNull(seniorId);
@@ -89,11 +108,25 @@ public class MedicationCompleteDispatcher {
         if (senior == null) {
             return 0;
         }
+        final String seniorName = senior.getNickname() == null ? "" : senior.getNickname();
 
+        int dispatched = 0;
+        for (final MealSlot slot : completedSlots) {
+            dispatched += dispatchForSlot(seniorId, targetDate, slot, seniorName, relations);
+        }
+        return dispatched;
+    }
+
+    private int dispatchForSlot(
+            final Long seniorId,
+            final LocalDate targetDate,
+            final MealSlot slot,
+            final String seniorName,
+            final List<CareRelation> relations
+    ) {
         final String title = "복약 완료 알림";
         final String body = String.format(
-                "축하합니다! %s 어르신이 모든 복약을 완료하셨습니다!",
-                senior.getNickname() == null ? "" : senior.getNickname());
+                "축하합니다! %s 어르신이 %s 복약을 완료하셨습니다!", seniorName, slotLabel(slot));
 
         int dispatched = 0;
         for (final CareRelation relation : relations) {
@@ -104,14 +137,14 @@ public class MedicationCompleteDispatcher {
             if (settings != null && !settings.isMedicationCompleteEnabled()) {
                 continue;
             }
-            if (notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDate(
-                    caregiverId, NotificationCategory.MEDICATION_COMPLETE, seniorId, targetDate)) {
+            if (notificationRepository.existsByUserIdAndCategoryAndSeniorIdAndTargetDateAndMealSlot(
+                    caregiverId, NotificationCategory.MEDICATION_COMPLETE, seniorId, targetDate, slot.name())) {
                 continue;
             }
-            final Notification saved = notificationRepository.save(
-                    Notification.createForMedicationComplete(caregiverId, seniorId, title, body, targetDate));
-            log.info("MEDICATION_COMPLETE notification created (id={}, caregiver={}, senior={}, date={})",
-                    saved.getId(), caregiverId, seniorId, targetDate);
+            final Notification saved = notificationRepository.save(Notification.createForMedicationComplete(
+                    caregiverId, seniorId, title, body, targetDate, slot.name()));
+            log.info("MEDICATION_COMPLETE notification created (id={}, caregiver={}, senior={}, date={}, slot={})",
+                    saved.getId(), caregiverId, seniorId, targetDate, slot);
 
             final List<DeviceToken> tokens = deviceTokenRepository.findByUserIdAndIsActiveTrue(caregiverId);
             for (final DeviceToken token : tokens) {
@@ -119,7 +152,8 @@ public class MedicationCompleteDispatcher {
                         new PushPayload(title, body, Map.of(
                                 "category", "MEDICATION_COMPLETE",
                                 "seniorId", String.valueOf(seniorId),
-                                "targetDate", targetDate.toString()
+                                "targetDate", targetDate.toString(),
+                                "mealSlot", slot.name()
                         )));
                 if (result.tokenInvalid()) {
                     token.deactivate();
@@ -128,5 +162,13 @@ public class MedicationCompleteDispatcher {
             dispatched++;
         }
         return dispatched;
+    }
+
+    private String slotLabel(final MealSlot slot) {
+        return switch (slot) {
+            case BREAKFAST -> "아침";
+            case LUNCH -> "점심";
+            case DINNER -> "저녁";
+        };
     }
 }

--- a/src/main/java/com/ppiyaki/notification/service/MedicationCompleteListener.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationCompleteListener.java
@@ -18,6 +18,6 @@ public class MedicationCompleteListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @EventListener
     public void onMedicationTaken(final MedicationTakenEvent event) {
-        dispatcher.dispatchIfDayComplete(event.seniorId(), event.targetDate());
+        dispatcher.dispatchCompletedSlots(event.seniorId(), event.targetDate());
     }
 }

--- a/src/test/java/com/ppiyaki/notification/controller/MedicationCompleteNotificationE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/MedicationCompleteNotificationE2ETest.java
@@ -1,0 +1,202 @@
+package com.ppiyaki.notification.controller;
+
+import com.ppiyaki.common.auth.JwtProvider;
+import com.ppiyaki.medication.domain.DosageUnit;
+import com.ppiyaki.medication.domain.MealSlot;
+import com.ppiyaki.medication.domain.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.notification.Notification;
+import com.ppiyaki.notification.NotificationCategory;
+import com.ppiyaki.notification.repository.NotificationRepository;
+import com.ppiyaki.user.domain.CareMode;
+import com.ppiyaki.user.domain.CareRelation;
+import com.ppiyaki.user.domain.User;
+import com.ppiyaki.user.domain.UserRole;
+import com.ppiyaki.user.repository.CareRelationRepository;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("끼니별 복약 완료 알림 발송 E2E (MEDICATION_COMPLETE)")
+class MedicationCompleteNotificationE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private MedicineRepository medicineRepository;
+    @Autowired
+    private MedicationScheduleRepository scheduleRepository;
+    @Autowired
+    private CareRelationRepository careRelationRepository;
+    @Autowired
+    private NotificationRepository notificationRepository;
+    @Autowired
+    private JwtProvider jwtProvider;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 900000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("끼니의 모든 schedule 인증 시 보호자 알림함에 MEDICATION_COMPLETE row가 끼니 단위로 저장된다 (AFTER_COMMIT 커밋 보장)")
+    void slotComplete_persistsNotificationForCaregiver() {
+        // given — 시니어 + 보호자 연동 + BREAKFAST schedule 1정
+        final Long seniorId = seedSenior();
+        final Long caregiverId = seedCaregiver();
+        seedRelation(seniorId, caregiverId);
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+        final Long medicineId = seedMedicine(seniorId);
+        final Long scheduleId = seedSchedule(medicineId, MealSlot.BREAKFAST);
+        final LocalDate today = LocalDate.now();
+
+        // when — 시니어가 BREAKFAST schedule TAKEN 인증 → 아침 끼니 완료
+        certifyTaken(seniorToken, scheduleId, today);
+
+        // then — 보호자 알림함에 아침 완료 알림 1건 (AFTER_COMMIT 리스너 저장이 실제 커밋되어야 함)
+        final List<Notification> completed = findCompleteNotifications(caregiverId);
+        Assertions.assertThat(completed).hasSize(1);
+        Assertions.assertThat(completed.get(0).getSeniorId()).isEqualTo(seniorId);
+        Assertions.assertThat(completed.get(0).getTargetDate()).isEqualTo(today);
+        Assertions.assertThat(completed.get(0).getMealSlot()).isEqualTo(MealSlot.BREAKFAST.name());
+        Assertions.assertThat(completed.get(0).getBody()).contains("아침 복약을 완료");
+    }
+
+    @Test
+    @DisplayName("끼니에 schedule이 2개인데 1개만 인증되면 완료 알림이 발송되지 않는다")
+    void slotPartiallyTaken_noNotification() {
+        final Long seniorId = seedSenior();
+        final Long caregiverId = seedCaregiver();
+        seedRelation(seniorId, caregiverId);
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+        final Long medicineId = seedMedicine(seniorId);
+        final Long scheduleA = seedSchedule(medicineId, MealSlot.BREAKFAST);
+        seedSchedule(medicineId, MealSlot.BREAKFAST);
+        final LocalDate today = LocalDate.now();
+
+        // when — BREAKFAST 2정 중 1정만 인증
+        certifyTaken(seniorToken, scheduleA, today);
+
+        // then — 아침 끼니가 아직 완료되지 않았으므로 알림 없음
+        Assertions.assertThat(findCompleteNotifications(caregiverId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("아침/점심을 각각 완료하면 끼니별로 알림이 1건씩 쌓이고, 같은 끼니 재인증은 중복 발송되지 않는다")
+    void perSlot_independentAndIdempotent() {
+        final Long seniorId = seedSenior();
+        final Long caregiverId = seedCaregiver();
+        seedRelation(seniorId, caregiverId);
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+        final Long medicineId = seedMedicine(seniorId);
+        final Long breakfastScheduleId = seedSchedule(medicineId, MealSlot.BREAKFAST);
+        final Long lunchScheduleId = seedSchedule(medicineId, MealSlot.LUNCH);
+        final LocalDate today = LocalDate.now();
+
+        // 아침 완료 → 아침 알림 1건
+        certifyTaken(seniorToken, breakfastScheduleId, today);
+        Assertions.assertThat(findCompleteNotifications(caregiverId))
+                .extracting(Notification::getMealSlot)
+                .containsExactlyInAnyOrder(MealSlot.BREAKFAST.name());
+
+        // 점심 완료 → 점심 알림 추가 (총 2건)
+        certifyTaken(seniorToken, lunchScheduleId, today);
+        Assertions.assertThat(findCompleteNotifications(caregiverId))
+                .extracting(Notification::getMealSlot)
+                .containsExactlyInAnyOrder(MealSlot.BREAKFAST.name(), MealSlot.LUNCH.name());
+
+        // 아침 재인증(멱등 호출) → 중복 발송 없음 (여전히 2건)
+        certifyTaken(seniorToken, breakfastScheduleId, today);
+        Assertions.assertThat(findCompleteNotifications(caregiverId)).hasSize(2);
+    }
+
+    // --- helpers ---
+
+    private void certifyTaken(final String seniorToken, final Long scheduleId, final LocalDate today) {
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + seniorToken)
+                .body("""
+                        {"scheduleId": %d, "targetDate": "%s", "status": "TAKEN"}
+                        """.formatted(scheduleId, today))
+                .when()
+                .put("/api/v1/medication-logs")
+                .then()
+                .statusCode(200);
+    }
+
+    private List<Notification> findCompleteNotifications(final Long caregiverId) {
+        return notificationRepository.findAll().stream()
+                .filter(n -> n.getUserId().equals(caregiverId))
+                .filter(n -> n.getCategory() == NotificationCategory.MEDICATION_COMPLETE)
+                .toList();
+    }
+
+    // --- fixtures ---
+
+    private Long seedSenior() {
+        return transactionTemplate.execute(status -> {
+            final User senior = User.createSenior("완료시니어" + userSequence++, (LocalDate) null);
+            senior.changeCareMode(CareMode.AUTONOMOUS);
+            return userRepository.save(senior).getId();
+        });
+    }
+
+    private Long seedCaregiver() {
+        return transactionTemplate.execute(status -> {
+            final User caregiver = User.createSenior("완료보호자" + userSequence++, (LocalDate) null);
+            caregiver.assignRole(UserRole.CAREGIVER);
+            return userRepository.save(caregiver).getId();
+        });
+    }
+
+    private void seedRelation(final Long seniorId, final Long caregiverId) {
+        transactionTemplate.executeWithoutResult(status -> careRelationRepository.save(CareRelation.createLinked(
+                seniorId, caregiverId)));
+    }
+
+    private Long seedMedicine(final Long seniorId) {
+        return transactionTemplate.execute(status -> {
+            final Medicine medicine = new Medicine(seniorId, null, "테스트약", 30, 30, "ITEM-1", null);
+            return medicineRepository.save(medicine).getId();
+        });
+    }
+
+    private Long seedSchedule(final Long medicineId, final MealSlot slot) {
+        return transactionTemplate.execute(status -> {
+            final MedicationSchedule schedule = new MedicationSchedule(
+                    medicineId, slot, BigDecimal.ONE, DosageUnit.TABLET,
+                    "DAILY", LocalDate.now(), null);
+            return scheduleRepository.save(schedule).getId();
+        });
+    }
+}


### PR DESCRIPTION
## AS-IS
1. 복약 완료 알림이 그 날 **아/점/저 모든 복약을 완료해야** 1회만 발송됐다.
2. 복약 완료 알림이 앱 미접속 시 **푸시로는 뜨지만 알림함(목록)에는 저장되지 않았다.** (지연·검토 등 다른 알림은 정상 누적)

## TO-BE
1. **끼니(meal_slot)별 발송** — 한 끼니에 속한 모든 schedule을 인증하면 그 끼니에 대해 완료 알림 발송. 멱등키에 `meal_slot` 추가(하루 최대 아침/점심/저녁 3회). 메시지를 "아침/점심/저녁 복약을 완료하셨습니다"로 분기. 기존 '하루 전체 완료' 알림은 제거.
2. **알림함 미저장 버그 수정** — `MedicationCompleteDispatcher`를 `@Transactional(REQUIRES_NEW)`로 변경.

## 원인 (2번)
복약 완료 알림만 `@TransactionalEventListener(AFTER_COMMIT)`에서 발송된다. `AFTER_COMMIT` 단계에서 `@Transactional`(기본 `REQUIRED`)로 저장하면 이미 커밋된 트랜잭션에 합류해 **INSERT가 유실**된다(푸시는 트랜잭션 무관이라 정상 발송). 스케줄러 기반 다른 dispatcher(지연/검토)는 새 트랜잭션이라 영향이 없었다. → 스펙 §10 Q7 "푸시 ↔ 알림함 row 1:1" 불변식 위반.

## 관련 이슈
- closes #441

## 리뷰어 참고 포인트
- 회귀 테스트 `MedicationCompleteNotificationE2ETest`는 실제 HTTP 요청 → `AFTER_COMMIT` 리스너 경로를 태운다. `REQUIRED`로 되돌리면 2개 케이스가 실패함을 로컬에서 확인했다(수정 효과 입증).
- **스키마 변경 없음**: `meal_slot` 컬럼·`uk_notifications_dedup` 유니크 제약은 기존. 기존 완료 row(meal_slot=NULL)와 신규 row(slot명) 공존 OK → prod 마이그레이션 불필요.

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료
- [x] `scope:*` 라벨 1개 부여 완료
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크 (AI 작성 시)
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 변경 범위의 회귀 가능 구간을 확인했다. (renamed dispatcher method, factory 시그니처 변경, 미사용 repo 메서드 제거 — 전체 grep 후 잔여 참조 없음 확인)
- [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다. (스키마 변경 없어 revert만으로 롤백 가능)

## DDD/OOP 준수 체크 (AI 작성 시)
- [x] 도메인 용어가 기존 컨텍스트와 일치한다. (MealSlot/MEDICATION_COMPLETE 기존 용어)
- [x] 계층 침범이 없다.
- [x] 객체 역할/책임이 명확하다.

## 보안/민감정보 체크 (AI 작성 시)
- [x] 시크릿 하드코딩 없음.
- [x] 의료정보 로그/스크린샷 노출 없음. (알림 본문에 약명 없음, 닉네임만)
- [x] 해당 시 마스킹 — 해당 없음.

## 예외 머지 여부 (AI 작성 시)
- [x] 예외 머지 아님

## AI 작업 기록
- 사용한 프롬프트/지시 요약: 복약 완료 알림 끼니별 발송 + 알림함 미저장 확인 요청
- AI가 직접 수정한 파일/범위: `Notification`(factory), `MedicationCompleteDispatcher`(per-slot + REQUIRES_NEW), `MedicationCompleteListener`, `NotificationRepository`(미사용 메서드 제거), 신규 E2E, spec
- 사람이 수동 검증한 항목: (리뷰 대기)
- 잔여 리스크/추가 확인 필요사항: 없음 (스키마 변경 없음)

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 복약 완료 알림이 하루 1회 발송에서 끼니(아침/점심/저녁)별 발송으로 변경되어, 보호자가 최대 하루 3회 받도록 개선됨

* **버그 수정**
  * 복약 완료 알림이 푸시로는 발송되지만 알림함에 저장되지 않던 문제 해결

* **테스트**
  * 복약 완료 알림 E2E 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->