### PR TITLE
fix(pet): 첫 복약 인증 이후 펫 포인트·streak 갱신 안 되던 문제 수정

### DIFF
--- a/docs/features/pet-growth-badge.md
+++ b/docs/features/pet-growth-badge.md
@@ -129,3 +129,4 @@ FIRST_STEP, MIRACLE_MORNING, FAMILY_LINK, HEALTH_GUARDIAN, BUDDY
 
 ## 9) 결정 로그
 - 2026-05-09: 초안 작성. 6단계 성장, 7일 미인증 리셋, 뱃지 5종. 기존 point/level과 공존.
+- 2026-06-04: **버그 수정 — 첫 복약 인증 이후 포인트/streak이 갱신되지 않던 문제.** 원인: `BadgeService.checkAndAwardBadges`가 포인트 트랜잭션(`PetPointListener`, REQUIRES_NEW)에 합류(REQUIRED)한 채 뱃지를 insert-and-catch 하는데, 2번째 인증부터 `FIRST_STEP` 중복 INSERT가 유니크 제약(`uk_badges_pet_type`)을 위반 → 예외를 catch해도 트랜잭션이 rollback-only로 오염되어 `addPoint`/`incrementStreak`까지 통째로 롤백됨(첫 인증만 +10 커밋, 이후 멈춤). 보호자 대시보드는 `medication_logs` 직접 집계라 영향 없었음. 수정: ① `saveIfAbsent` 존재-확인 후 INSERT, ② `checkAndAwardBadges`를 `REQUIRES_NEW`로 격리, ③ 리스너에서 뱃지 부여를 best-effort(try/catch)로 분리해 실패해도 포인트/streak 보존. 회귀 E2E `PetMedicationPointE2ETest` 추가.

--- a/src/main/java/com/ppiyaki/pet/service/BadgeService.java
+++ b/src/main/java/com/ppiyaki/pet/service/BadgeService.java
@@ -7,8 +7,8 @@ import com.ppiyaki.pet.repository.BadgeRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -26,7 +26,12 @@ public class BadgeService {
         this.meterRegistry = meterRegistry;
     }
 
-    @Transactional
+    /**
+     * 뱃지 부여는 포인트/streak 갱신과 분리된 독립 트랜잭션({@link Propagation#REQUIRES_NEW})에서 수행한다.
+     * 뱃지 INSERT가 유니크 제약(uk_badges_pet_type)에 걸려도 호출자(PetPointListener)의 포인트 트랜잭션을
+     * 오염(rollback-only)시키지 않도록 격리한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void checkAndAwardBadges(final Pet pet) {
         checkFirstStep(pet);
         checkHealthGuardian(pet);
@@ -45,12 +50,11 @@ public class BadgeService {
     }
 
     private void saveIfAbsent(final Long petId, final BadgeType badgeType) {
-        try {
-            badgeRepository.save(new Badge(petId, badgeType));
-            badgeRepository.flush();
-            meterRegistry.counter(METRIC, "badge_type", badgeType.name()).increment();
-        } catch (final DataIntegrityViolationException e) {
+        if (badgeRepository.existsByPetIdAndBadgeType(petId, badgeType)) {
             log.debug("Badge already exists: petId={}, type={}", petId, badgeType);
+            return;
         }
+        badgeRepository.save(new Badge(petId, badgeType));
+        meterRegistry.counter(METRIC, "badge_type", badgeType.name()).increment();
     }
 }

--- a/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
+++ b/src/main/java/com/ppiyaki/pet/service/PetPointListener.java
@@ -77,7 +77,13 @@ public class PetPointListener {
             pet.incrementStreak(targetDate);
         }
 
-        badgeService.checkAndAwardBadges(pet);
+        // 뱃지 부여는 best-effort. 독립 트랜잭션(REQUIRES_NEW)이라 실패해도 포인트/streak는 보존된다.
+        try {
+            badgeService.checkAndAwardBadges(pet);
+        } catch (final RuntimeException e) {
+            log.warn("Badge award failed for petId={}; point/streak preserved", pet.getId(), e);
+            meterRegistry.counter(METRIC, "result", "badge_failed").increment();
+        }
         meterRegistry.counter(METRIC, "result", "granted").increment();
     }
 

--- a/src/test/java/com/ppiyaki/pet/controller/PetMedicationPointE2ETest.java
+++ b/src/test/java/com/ppiyaki/pet/controller/PetMedicationPointE2ETest.java
@@ -1,0 +1,140 @@
+package com.ppiyaki.pet.controller;
+
+import com.ppiyaki.common.auth.JwtProvider;
+import com.ppiyaki.medication.domain.DosageUnit;
+import com.ppiyaki.medication.domain.MealSlot;
+import com.ppiyaki.medication.domain.MedicationSchedule;
+import com.ppiyaki.medication.repository.MedicationScheduleRepository;
+import com.ppiyaki.medicine.Medicine;
+import com.ppiyaki.medicine.repository.MedicineRepository;
+import com.ppiyaki.pet.BadgeType;
+import com.ppiyaki.pet.Pet;
+import com.ppiyaki.pet.repository.BadgeRepository;
+import com.ppiyaki.pet.repository.PetRepository;
+import com.ppiyaki.user.domain.CareMode;
+import com.ppiyaki.user.domain.User;
+import com.ppiyaki.user.domain.UserRole;
+import com.ppiyaki.user.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "openai.api-key=sk-test-placeholder",
+        "openai.model=gpt-test",
+        "ncp.storage.endpoint=https://kr.object.ncloudstorage.com",
+        "ncp.storage.region=kr-standard",
+        "ncp.storage.access-key=test-access-key",
+        "ncp.storage.secret-key=test-secret-key",
+        "ncp.storage.bucket-name=ppiyaki-test"
+})
+@DisplayName("복약 인증 → 펫 포인트/streak 누적 E2E")
+class PetMedicationPointE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private MedicineRepository medicineRepository;
+    @Autowired
+    private MedicationScheduleRepository scheduleRepository;
+    @Autowired
+    private PetRepository petRepository;
+    @Autowired
+    private BadgeRepository badgeRepository;
+    @Autowired
+    private JwtProvider jwtProvider;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static long userSequence = 950000L;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("아/점/저 3건을 모두 인증하면 포인트가 10점씩 3회(30점) 누적되고 streak이 1로 증가한다")
+    void everyTaken_accumulatesPointAndStreak() {
+        // given — 펫이 연동된 시니어 + 아/점/저 schedule 3건
+        final Long petId = seedPet();
+        final Long seniorId = seedSeniorWithPet(petId);
+        final String seniorToken = jwtProvider.createAccessToken(seniorId, UserRole.SENIOR.name());
+        final Long medicineId = seedMedicine(seniorId);
+        final Long breakfast = seedSchedule(medicineId, MealSlot.BREAKFAST);
+        final Long lunch = seedSchedule(medicineId, MealSlot.LUNCH);
+        final Long dinner = seedSchedule(medicineId, MealSlot.DINNER);
+        final LocalDate today = LocalDate.now();
+
+        // when — 3건 순차 인증
+        certifyTaken(seniorToken, breakfast, today);
+        certifyTaken(seniorToken, lunch, today);
+        certifyTaken(seniorToken, dinner, today);
+
+        // then — 첫 1건만 반영되고 멈추던 버그(포인트 10/streak 0) 회귀 방지
+        final Pet pet = petRepository.findById(petId).orElseThrow();
+        Assertions.assertThat(pet.getPoint()).isEqualTo(30L);
+        Assertions.assertThat(pet.getStreak()).isEqualTo(1);
+        Assertions.assertThat(pet.getLastTakenDate()).isEqualTo(today);
+        // FIRST_STEP 뱃지는 1개만 (중복 INSERT 시도가 포인트 트랜잭션을 깨지 않아야 함)
+        Assertions.assertThat(badgeRepository.existsByPetIdAndBadgeType(petId, BadgeType.FIRST_STEP)).isTrue();
+    }
+
+    // --- helpers ---
+
+    private void certifyTaken(final String seniorToken, final Long scheduleId, final LocalDate today) {
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + seniorToken)
+                .body("""
+                        {"scheduleId": %d, "targetDate": "%s", "status": "TAKEN"}
+                        """.formatted(scheduleId, today))
+                .when()
+                .put("/api/v1/medication-logs")
+                .then()
+                .statusCode(200);
+    }
+
+    // --- fixtures ---
+
+    private Long seedPet() {
+        return transactionTemplate.execute(status -> petRepository.save(Pet.create()).getId());
+    }
+
+    private Long seedSeniorWithPet(final Long petId) {
+        return transactionTemplate.execute(status -> {
+            final User senior = User.createSenior("포인트시니어" + userSequence++, (LocalDate) null);
+            senior.changeCareMode(CareMode.AUTONOMOUS);
+            senior.assignPet(petId);
+            return userRepository.save(senior).getId();
+        });
+    }
+
+    private Long seedMedicine(final Long seniorId) {
+        return transactionTemplate.execute(status -> {
+            final Medicine medicine = new Medicine(seniorId, null, "테스트약", 30, 30, "ITEM-1", null);
+            return medicineRepository.save(medicine).getId();
+        });
+    }
+
+    private Long seedSchedule(final Long medicineId, final MealSlot slot) {
+        return transactionTemplate.execute(status -> {
+            final MedicationSchedule schedule = new MedicationSchedule(
+                    medicineId, slot, BigDecimal.ONE, DosageUnit.TABLET,
+                    "DAILY", LocalDate.now(), null);
+            return scheduleRepository.save(schedule).getId();
+        });
+    }
+}


### PR DESCRIPTION
## AS-IS
- 시니어 `GET /api/v1/pets/me`가 **첫 복약 인증 이후로 point/streak이 갱신 안 됨**. 아/점/저 다 클리어해도 streak 0, 첫 10포인트에서 멈춤. (보호자 대시보드는 정상 — `medication_logs` 직접 집계라 펫과 무관)

## 원인
`BadgeService.checkAndAwardBadges`가 포인트 트랜잭션(`PetPointListener`, `REQUIRES_NEW`)에 **`REQUIRED`로 합류**한 채 뱃지를 insert-and-catch 한다. 2번째 인증부터 `FIRST_STEP` 뱃지 중복 INSERT가 유니크 제약(`uk_badges_pet_type`)을 위반 → 예외를 `catch`해도 트랜잭션이 **rollback-only**로 오염되어 `addPoint`/`incrementStreak`까지 통째로 롤백된다. (첫 인증만 +10 커밋, 이후 전부 무효)

## TO-BE
1. `saveIfAbsent` — `existsByPetIdAndBadgeType` 존재 확인 후 INSERT (결정적 제약 위반 제거)
2. `checkAndAwardBadges` — `@Transactional(REQUIRES_NEW)`로 격리 (뱃지 실패가 포인트 트랜잭션을 오염시키지 못하게)
3. `PetPointListener` — 뱃지 부여를 best-effort(try/catch)로 분리. 실패해도 포인트/streak는 보존
- 멀티 기기 동시 인증(레이스) 시나리오까지 고려한 격리.

## 관련 이슈
- closes #445

## 리뷰어 참고 포인트
- 기존 `PetPointListenerTest`는 `BadgeService`를 mock해서 실제 제약 위반·트랜잭션 오염을 못 잡았다. 신규 `PetMedicationPointE2ETest`는 실제 뱃지 플로우를 태워 3건 인증 시 30점/streak 1을 검증하며, 수정 전 코드로 되돌리면 line 88(point=30)에서 실패함을 로컬 확인했다.
- **스키마 변경 없음** → prod 마이그레이션 불필요.

## 라벨 부여 확인
- [x] `type:*` 라벨 1개 부여 완료
- [x] `scope:*` 라벨 1개 부여 완료
- [x] (AI 작성 시) `ai-generated` 라벨 부여 완료
- [ ] (보호 영역 변경 시) `needs-human-review` 라벨 부여 완료

<details>
<summary>AI Agent 전용 체크리스트</summary>

## AI 작업 여부
- [x] AI 보조/생성 사용

## 품질 게이트 체크 (AI 작성 시)
- [x] `./gradlew checkstyleMain spotlessCheck`
- [x] `./gradlew test`
- [x] 변경 범위의 회귀 가능 구간을 확인했다. (BadgeService/PetPointListener 트랜잭션 경계 변경, 전체 스위트 통과)
- [x] 롤백 절차를 작성했거나, 롤백 불필요 사유를 작성했다. (스키마 변경 없어 revert만으로 롤백)

## DDD/OOP 준수 체크 (AI 작성 시)
- [x] 도메인 용어 일치 / 계층 침범 없음 / 책임 명확 (뱃지=side-effect로 분리)

## 보안/민감정보 체크 (AI 작성 시)
- [x] 시크릿·의료정보 노출 없음

## 예외 머지 여부 (AI 작성 시)
- [x] 예외 머지 아님

## AI 작업 기록
- 지시 요약: 첫 인증 후 펫 point/streak 갱신 안 되는 버그 해결
- 수정 범위: `BadgeService`, `PetPointListener`, 신규 E2E, pet-growth-badge spec 결정 로그
- 잔여 리스크: 없음 (스키마 변경 없음)
</details>