### PR TITLE
fix(medicine): 약물 검색 주성분 표시값 정제

### DIFF
--- a/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineCandidate.java
+++ b/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineCandidate.java
@@ -1,6 +1,8 @@
 package com.ppiyaki.medicine.controller.dto;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 public record MedicineCandidate(
         String itemSeq,
@@ -17,11 +19,42 @@ public record MedicineCandidate(
                 getString(item, "ITEM_SEQ"),
                 getString(item, "ITEM_NAME"),
                 getString(item, "ENTP_NAME"),
-                getString(item, "MATERIAL_NAME"),
+                formatMainIngredient(getString(item, "MATERIAL_NAME")),
                 getString(item, "CHART"),
                 getString(item, "ETC_OTC_CODE"),
                 getString(item, "CLASS_NO")
         );
+    }
+
+    /**
+     * 식약처 MATERIAL_NAME 원본을 사람이 읽을 수 있는 주성분 문구로 변환한다.
+     * 원본 형식: 성분마다 {@code /} 로 구분, 각 성분은 {@code 성분명,총량,분량,단위,규격,비고} 를
+     * 쉼표로 나열한다. 분량 등이 비면 {@code ,,,} 가 그대로 노출되고 규격(USP·KP)·총량 코드처럼
+     * 사용자에게 의미 없는 값이 섞이므로, 성분명과 분량·단위만 추려 {@code "성분명 분량단위, ..."} 로 만든다.
+     */
+    private static String formatMainIngredient(final String materialName) {
+        if (materialName == null || materialName.isBlank()) {
+            return null;
+        }
+        final Set<String> ingredients = new LinkedHashSet<>();
+        for (final String segment : materialName.split("/")) {
+            final String[] fields = segment.split(",", -1);
+            final String ingredientName = fields[0].strip();
+            if (ingredientName.isEmpty()) {
+                continue;
+            }
+            final String amount = fields.length > 2 ? normalizeAmount(fields[2].strip()) : "";
+            final String unit = fields.length > 3 ? fields[3].strip() : "";
+            ingredients.add(amount.isEmpty() ? ingredientName : ingredientName + " " + amount + unit);
+        }
+        return ingredients.isEmpty() ? null : String.join(", ", ingredients);
+    }
+
+    private static String normalizeAmount(final String amount) {
+        if (!amount.contains(".")) {
+            return amount;
+        }
+        return amount.replaceAll("0+$", "").replaceAll("\\.$", "");
     }
 
     private static String getString(final Map<String, Object> item, final String key) {

--- a/src/test/java/com/ppiyaki/medicine/controller/dto/MedicineCandidateTest.java
+++ b/src/test/java/com/ppiyaki/medicine/controller/dto/MedicineCandidateTest.java
@@ -1,0 +1,87 @@
+package com.ppiyaki.medicine.controller.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MedicineCandidateTest {
+
+    private static Map<String, Object> itemWithMaterial(final String materialName) {
+        final Map<String, Object> item = new HashMap<>();
+        item.put("ITEM_SEQ", "1");
+        item.put("ITEM_NAME", "테스트정");
+        item.put("MATERIAL_NAME", materialName);
+        return item;
+    }
+
+    @Test
+    @DisplayName("단일 성분은 성분명과 분량·단위만 남긴다 (규격·빈 칸 제거)")
+    void formatSingleIngredient() {
+        // given
+        final Map<String, Object> item = itemWithMaterial("아세트아미노펜,,500,밀리그램,USP,");
+
+        // when
+        final MedicineCandidate candidate = MedicineCandidate.fromMfdsItem(item);
+
+        // then
+        assertThat(candidate.mainIngr()).isEqualTo("아세트아미노펜 500밀리그램");
+    }
+
+    @Test
+    @DisplayName("분량이 비어 있으면 성분명만 남기고 연속 쉼표(,,,)를 만들지 않는다")
+    void formatIngredientWithoutAmount() {
+        // given
+        final Map<String, Object> item = itemWithMaterial(
+                "아세트아미노펜,,,밀리그램,USP,/슈도에페드린염산염,,,밀리그램,USP,");
+
+        // when
+        final MedicineCandidate candidate = MedicineCandidate.fromMfdsItem(item);
+
+        // then
+        assertThat(candidate.mainIngr()).isEqualTo("아세트아미노펜, 슈도에페드린염산염");
+    }
+
+    @Test
+    @DisplayName("복합 성분은 쉼표로 구분하고 소수점 뒤 0은 정리한다")
+    void formatMultipleIngredients() {
+        // given
+        final Map<String, Object> item = itemWithMaterial(
+                "로사르탄칼륨,1511.09,100.00,밀리그램,EP,/암로디핀캄실산염,1511.09,7.84,밀리그램,별첨규격(전과동),");
+
+        // when
+        final MedicineCandidate candidate = MedicineCandidate.fromMfdsItem(item);
+
+        // then
+        assertThat(candidate.mainIngr()).isEqualTo("로사르탄칼륨 100밀리그램, 암로디핀캄실산염 7.84밀리그램");
+    }
+
+    @Test
+    @DisplayName("규격만 다른 중복 성분은 한 번만 표시한다")
+    void deduplicatesIdenticalIngredients() {
+        // given
+        final Map<String, Object> item = itemWithMaterial(
+                "로사르탄칼륨,1335.29,50.00,밀리그램,EP,/로사르탄칼륨,1412.04,50.00,밀리그램,EP,");
+
+        // when
+        final MedicineCandidate candidate = MedicineCandidate.fromMfdsItem(item);
+
+        // then
+        assertThat(candidate.mainIngr()).isEqualTo("로사르탄칼륨 50밀리그램");
+    }
+
+    @Test
+    @DisplayName("MATERIAL_NAME 이 없으면 주성분은 null 이다")
+    void nullMaterialReturnsNull() {
+        // given
+        final Map<String, Object> item = itemWithMaterial(null);
+
+        // when
+        final MedicineCandidate candidate = MedicineCandidate.fromMfdsItem(item);
+
+        // then
+        assertThat(candidate.mainIngr()).isNull();
+    }
+}


### PR DESCRIPTION
## AS-IS
약물 검색/처방 추가 화면 하단의 `주성분`이 식약처 `MATERIAL_NAME` 원본을 그대로 노출.
- 분량이 비면 `,,,` 처럼 쉼표만 표시 (예: `아세트아미노펜,,,밀리그램,USP,/슈도에페드린염산염,,,밀리그램,USP,`)
- `USP`/`KP`/`EP`(규격), 총량 코드(`1511.09`) 등 의미 없는 값 노출

## TO-BE
`MedicineCandidate.fromMfdsItem()` 에서 `MATERIAL_NAME` 을 파싱해 `성분명 분량단위, ...` 형태로 정제.
- `아세트아미노펜,,500,밀리그램,USP,` → `아세트아미노펜 500밀리그램`
- `아세트아미노펜,,,밀리그램,USP,/슈도에페드린염산염,,,밀리그램,USP,` → `아세트아미노펜, 슈도에페드린염산염`
- `로사르탄칼륨,1511.09,100.00,밀리그램,EP,/...` → `로사르탄칼륨 100밀리그램, ...`
- 빈 칸·규격·총량코드 제거, 소수점 뒤 0 정리, 규격만 다른 중복 성분 합치기

프론트는 `mainIngr` 그대로 표시하므로 변경 불필요. API 엔드포인트 변경 없음(Notion 갱신 불요).

## 테스트
실제 MFDS 응답 5종 기반 단위 테스트 추가 (`MedicineCandidateTest`).

## AI 체크리스트
- [x] `./gradlew checkstyleMain spotlessCheck test` 통과
- [x] 신규 엔드포인트 없음 (기존 매핑 로직 수정)
- [x] 보호 영역 변경 없음
- [x] API 명세 변경 없음 (응답 값 정제만, 스키마 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **주요 기능**
  * 의약품의 주요 성분 정보가 더욱 명확하고 정돈되어 표시됩니다. 각 성분의 이름과 함량 정보가 표준화된 형식으로 표시되며, 불필요한 규격이나 부가 정보는 자동으로 제거되어 사용자에게 핵심 정보만 제공합니다.
  * 동일한 성분의 중복 표시가 제거되어 더욱 간결한 정보를 제공합니다.
  * 성분의 함량 수치가 정규화되어 소수점 처리 등이 일관되게 표시됩니다.

* **테스트**
  * 성분 정보 포맷팅이 정확하게 동작하는지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->