### PR TITLE
fix(user): 알림 문구의 '어르신' 표현을 '님'으로 통일

### DIFF
--- a/src/main/java/com/ppiyaki/notification/service/DurWarningDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/DurWarningDispatcher.java
@@ -66,7 +66,7 @@ public class DurWarningDispatcher {
 
         final String title = "처방전 안전 경고";
         final String body = String.format(
-                "%s 어르신의 처방전에 %s 주의 약물이 포함되어 있습니다.",
+                "%s님의 처방전에 %s 주의 약물이 포함되어 있습니다.",
                 senior.getNickname() == null ? "" : senior.getNickname(),
                 level == DurWarningLevel.BLOCK ? "복용 금기" : "주의 필요");
 

--- a/src/main/java/com/ppiyaki/notification/service/FamilySafetyDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/FamilySafetyDispatcher.java
@@ -102,7 +102,7 @@ public class FamilySafetyDispatcher {
 
             final String title = "가족 안전망 알림";
             final String body = String.format(
-                    "%s 어르신이 %d시간 이상 앱에 접속하지 않았습니다.",
+                    "%s님이 %d시간 이상 앱에 접속하지 않았습니다.",
                     senior.getNickname() == null ? "" : senior.getNickname(), thresholdHours);
             final Notification saved = notificationRepository.save(
                     Notification.createForFamilySafety(caregiverId, senior.getId(), title, body, today));

--- a/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
@@ -158,7 +158,7 @@ public class MedicationDelayDispatcher {
         final String seniorName = senior.getNickname() == null ? "" : senior.getNickname();
         final StringBuilder bodyBuilder = new StringBuilder();
         bodyBuilder.append(String.format(
-                "%s 어르신이 %s에 약 %d개를 아직 복용하지 않았어요. (%d분 경과)",
+                "%s님이 %s에 약 %d개를 아직 복용하지 않았어요. (%d분 경과)",
                 seniorName, slotLabel, schedules.size(), thresholdMinutes));
         for (final MedicationSchedule schedule : schedules) {
             bodyBuilder.append("\n• ").append(resolveMedicineLabel(schedule));

--- a/src/main/java/com/ppiyaki/notification/service/PrescriptionReviewRequestDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/PrescriptionReviewRequestDispatcher.java
@@ -32,7 +32,7 @@ public class PrescriptionReviewRequestDispatcher {
 
     private static final Logger log = LoggerFactory.getLogger(PrescriptionReviewRequestDispatcher.class);
     private static final String PUSH_TITLE = "처방전 검토 요청";
-    private static final String PUSH_BODY_FORMAT = "%s 어르신의 새 처방전이 도착했어요. 검토해 주세요.";
+    private static final String PUSH_BODY_FORMAT = "%s님의 새 처방전이 도착했어요. 검토해 주세요.";
 
     private final UserRepository userRepository;
     private final CareRelationRepository careRelationRepository;

--- a/src/main/java/com/ppiyaki/notification/service/WellbeingPingService.java
+++ b/src/main/java/com/ppiyaki/notification/service/WellbeingPingService.java
@@ -24,7 +24,7 @@ public class WellbeingPingService {
 
     private static final Logger log = LoggerFactory.getLogger(WellbeingPingService.class);
     private static final String PUSH_TITLE = "안부 알림";
-    private static final String PUSH_BODY_FORMAT = "%s 어르신이 안부를 전했어요.";
+    private static final String PUSH_BODY_FORMAT = "%s님이 안부를 전했어요.";
 
     private final UserRepository userRepository;
     private final CareRelationRepository careRelationRepository;

--- a/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
@@ -105,7 +105,7 @@ class MedicationDelayDispatcherTest {
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository, times(1)).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정 1정");
+                .isEqualTo("김철수님이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정 1정");
     }
 
     @Test
@@ -127,7 +127,7 @@ class MedicationDelayDispatcherTest {
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 약 2캡슐");
+                .isEqualTo("김철수님이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 약 2캡슐");
     }
 
     @Test
@@ -149,7 +149,7 @@ class MedicationDelayDispatcherTest {
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정");
+                .isEqualTo("김철수님이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정");
     }
 
     @Test
@@ -179,7 +179,7 @@ class MedicationDelayDispatcherTest {
         final ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository, times(1)).save(notificationCaptor.capture());
         assertThat(notificationCaptor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 3개를 아직 복용하지 않았어요. (60분 경과)"
+                .isEqualTo("김철수님이 아침에 약 3개를 아직 복용하지 않았어요. (60분 경과)"
                         + "\n• 타이레놀500mg 1정"
                         + "\n• 비타민C 2캡슐"
                         + "\n• 위장약");
@@ -215,7 +215,7 @@ class MedicationDelayDispatcherTest {
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 비타민C 2캡슐");
+                .isEqualTo("김철수님이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 비타민C 2캡슐");
     }
 
     @Test


### PR DESCRIPTION
## AS-IS
푸시 알림 본문이 `~ 어르신이/의` 로 표기됨 (예: `홍길동 어르신이 안부를 전했어요.`).

## TO-BE
`~님이/님의` 로 통일 (기존 복약완료 알림이 이미 `~님이` 형태라 톤 일치).

| 알림 | 변경 후 |
|------|--------|
| 안부(WellbeingPing) | `%s님이 안부를 전했어요.` |
| 가족 안전망(FamilySafety) | `%s님이 %d시간 이상 앱에 접속하지 않았습니다.` |
| DUR 경고(DurWarning) | `%s님의 처방전에 …` |
| 처방전 검토(PrescriptionReviewRequest) | `%s님의 새 처방전이 …` |
| 복약 지연(MedicationDelay) | `%s님이 %s에 약 %d개를 …` |

## 테스트
`MedicationDelayDispatcherTest` 단언 5건을 새 문구로 갱신. API 엔드포인트 변경 없음(Notion 갱신 불요).

## AI 체크리스트
- [x] `./gradlew checkstyleMain spotlessCheck test` 통과
- [x] 신규 엔드포인트 없음 (문구 상수만 변경)
- [x] 보호 영역 변경 없음
- [x] API 명세 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)