### PR TITLE
chore(infra): CD 무중단 blue-green 배포 전환

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -54,22 +54,44 @@ jobs:
           password: ${{ secrets.REMOTE_PASSWORD }}
           port: 22
           script: |
-            docker login ${{ secrets.NCP_REGISTRY }} -u ${{ secrets.NCP_ACCESS_KEY }} -p ${{ secrets.NCP_SECRET_KEY }}
-            
-            echo "Stopping and removing old container..."
-            docker stop ppiyaki-server || true
-            docker rm ppiyaki-server || true
-            
+            set -e
+            # ── 무중단 blue-green 배포 ──
+            # 호스트 nginx 의 upstream(ppiyaki_backend) 대상 포트를 blue↔green 으로 전환한다.
+            # 사전 일회성 셋업 필요(운영 작업): /etc/nginx/conf.d/ppiyaki-upstream.conf 생성 +
+            #   default 의 proxy_pass 를 http://ppiyaki_backend 로 변경 + CD 유저 NOPASSWD sudo(tee/nginx/systemctl).
+            # 상세: docs/features/zero-downtime-deploy.md
+            REGISTRY='${{ secrets.NCP_REGISTRY }}'
+            IMAGE="$REGISTRY/ppiyaki-server:latest"
+            UPSTREAM_CONF=/etc/nginx/conf.d/ppiyaki-upstream.conf
+
+            docker login "$REGISTRY" -u '${{ secrets.NCP_ACCESS_KEY }}' -p '${{ secrets.NCP_SECRET_KEY }}'
+
             echo "Pulling latest image..."
-            docker pull ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
-            
-            echo "Starting new container..."
+            docker pull "$IMAGE"
+
+            # 활성 색 판별: upstream 이 green(8082) 을 가리키면 green 활성 → 다음은 blue, 아니면 그 반대
+            if grep -q '127.0.0.1:8082' "$UPSTREAM_CONF" 2>/dev/null; then
+              ACTIVE=green; NEW=blue;  NEW_APP=8080; NEW_MGMT=18081
+            else
+              ACTIVE=blue;  NEW=green; NEW_APP=8082; NEW_MGMT=18082
+            fi
+            NEW_NAME="ppiyaki-server-$NEW"
+            OLD_NAME="ppiyaki-server-$ACTIVE"
+            echo "Active=$ACTIVE → deploying NEW=$NEW ($NEW_NAME, app=$NEW_APP, mgmt=$NEW_MGMT)"
+
+            # 이전 실패로 남아있을 수 있는 동일 색 컨테이너 정리
+            docker rm -f "$NEW_NAME" 2>/dev/null || true
+
+            echo "Starting $NEW_NAME ..."
             docker run -d \
-              --name ppiyaki-server \
+              --name "$NEW_NAME" \
               --network ppiyaki-monitoring \
-              -p 8080:8080 \
+              -p 127.0.0.1:$NEW_APP:8080 \
+              -p 127.0.0.1:$NEW_MGMT:8081 \
+              --memory=768m \
               --restart always \
               -e TZ='Asia/Seoul' \
+              -e JAVA_TOOL_OPTIONS='-XX:MaxRAMPercentage=65' \
               -e SPRING_PROFILES_ACTIVE=prod \
               -e DB_URL='${{ secrets.DB_URL }}' \
               -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \
@@ -93,8 +115,32 @@ jobs:
               -e REDIS_HOST='ppiyaki-redis' \
               -e REDIS_PORT='6379' \
               -e REDIS_PASSWORD='${{ secrets.REDIS_PASSWORD }}' \
-              ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
-            
+              "$IMAGE"
+
+            echo "Health checking $NEW_NAME (2s × 최대 60s)..."
+            OK=0
+            for i in $(seq 1 30); do
+              if curl -fsS "http://127.0.0.1:$NEW_MGMT/actuator/health" 2>/dev/null | grep -q '"status":"UP"'; then
+                OK=1; break
+              fi
+              sleep 2
+            done
+            if [ "$OK" != "1" ]; then
+              echo "Health check FAILED — nginx 전환 없이 롤백 (활성 $ACTIVE 유지). 새 컨테이너 로그:"
+              docker logs --tail 80 "$NEW_NAME" || true
+              docker rm -f "$NEW_NAME" || true
+              exit 1
+            fi
+            echo "Health OK → nginx upstream 을 127.0.0.1:$NEW_APP 로 전환"
+
+            echo "upstream ppiyaki_backend { server 127.0.0.1:$NEW_APP; }" | sudo tee "$UPSTREAM_CONF" >/dev/null
+            sudo nginx -t
+            sudo systemctl reload nginx
+
+            echo "구 컨테이너 $OLD_NAME drain & 종료..."
+            docker stop -t 30 "$OLD_NAME" 2>/dev/null || true
+            docker rm "$OLD_NAME" 2>/dev/null || true
+
             echo "Cleaning up old images..."
             docker image prune -f
 


### PR DESCRIPTION
## 개요
릴리즈 시 다운타임(stop→run 사이 수십 초~1분)을 없애기 위해 CD를 **호스트 nginx upstream 전환 blue-green**으로 변경.
참고: `docs/features/zero-downtime-deploy.md` (status=approved, #452)

## 변경
- `backend-cd.yml`의 SSH 배포 스크립트를 blue-green으로 교체 (build/push·Discord 알림 단계는 유지)
- 새 색 컨테이너(blue=8080/green=8082, mgmt 18081/18082, 127.0.0.1 바인딩)를 먼저 기동
- `/actuator/health` 2s×최대60s 폴링 → 통과 시에만 `nginx -t` 후 `systemctl reload`로 전환
- 전환 후 구 색 graceful stop(`-t 30`)
- **헬스 실패 시 nginx 미전환 + 구 색 유지(자동 롤백)** + 실패 컨테이너 제거 후 배포 실패 종료
- 각 앱 `--memory=768m` + `JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=65`

## ⚠️ 선행 운영 작업 (이 PR 머지만으로는 동작 안 함)
다음 release 전에 운영 서버에 일회성 셋업 필요 (Q1: ssh 수동 1회):
1. 호스트 swap 2GB 추가 (현재 swap 0)
2. `/etc/nginx/conf.d/ppiyaki-upstream.conf` 생성(`upstream ppiyaki_backend { server 127.0.0.1:8080; }`) + `default`의 `proxy_pass`를 `http://ppiyaki_backend`로 변경 → `nginx -t` → reload (무중단)
3. 기존 `ppiyaki-server` 컨테이너를 `ppiyaki-server-blue`로 rename (재시작 없음)
4. CD remote 유저에 NOPASSWD sudo (tee 해당 conf / `nginx -t` / `systemctl reload nginx`) 부여
5. 리허설 배포 1회로 무중단 실측

## 가정 / 검증 포인트 (리뷰 요망)
- CD remote 유저가 위 nginx 명령에 대해 sudo 가능해야 함 (선행 작업 4)
- 호스트에 `curl` 존재 가정 (헬스체크). 리허설에서 확인
- 본 PR은 develop 대상이라 머지해도 prod 자동 배포되지 않음 (CD는 main push 트리거)

## AI 체크리스트
- [x] YAML 유효성 확인
- [ ] 보호 영역(`.github/workflows/**`) 변경 → 사람 리뷰 필요
- [x] API/스키마 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 배포 방식을 무중단 배포로 전환하여 서비스 가용성 향상
  * 자동 헬스 체크 및 실패 시 자동 롤백 기능 추가로 배포 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->