### PR TITLE
fix(medication): 복약 알림 응답에 mealSlot 노출

### DIFF
--- a/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
@@ -11,6 +11,7 @@ public record NotificationItemResponse(
         String title,
         String body,
         String payload,
+        String mealSlot,
         LocalDateTime readAt,
         LocalDateTime takenAt,
         LocalDateTime createdAt
@@ -24,6 +25,7 @@ public record NotificationItemResponse(
                 notification.getTitle(),
                 notification.getBody(),
                 notification.getPayload(),
+                notification.getMealSlot(),
                 notification.getReadAt(),
                 notification.getTakenAt(),
                 notification.getCreatedAt()

--- a/src/test/java/com/ppiyaki/notification/controller/NotificationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/NotificationControllerE2ETest.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.notification.controller;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 
 import io.restassured.RestAssured;
@@ -45,8 +46,9 @@ class NotificationControllerE2ETest {
 
         // owner 알림 2건 + other 알림 1건 INSERT
         jdbcTemplate.update("INSERT INTO notifications "
-                + "(user_id, category, title, body, created_at) "
-                + "VALUES (?, 'MEDICATION_REMINDER', '아침 약 복용', '아침 약 드세요', NOW(6))", ownerId);
+                + "(user_id, category, title, body, meal_slot, target_date, created_at) "
+                + "VALUES (?, 'MEDICATION_REMINDER', '아침 약 복용', '아침 약 드세요', 'BREAKFAST', CURDATE(), NOW(6))",
+                ownerId);
         jdbcTemplate.update("INSERT INTO notifications "
                 + "(user_id, category, title, body, created_at) "
                 + "VALUES (?, 'MEDICATION_REMINDER', '저녁 약 복용', '저녁 약 드세요', NOW(6))", ownerId);
@@ -68,6 +70,7 @@ class NotificationControllerE2ETest {
                 .then()
                 .statusCode(200)
                 .body("responses.size()", greaterThanOrEqualTo(2))
+                .body("responses.mealSlot", hasItem("BREAKFAST"))
                 .body("hasNext", is(false));
 
         // 단건 읽음


### PR DESCRIPTION
## AS-IS
`GET /api/v1/notifications` 의 MEDICATION_REMINDER 항목이 `payload: null` 로 내려옴 → 프론트가 현재 시각으로 슬롯을 추론하다 **아침 알림 탭이 저녁 슬롯으로 인증되는 버그**.

## 원인
슬롯은 이미 엔티티 `meal_slot` 컬럼에 저장되고 FCM 푸시 data 에도 mealSlot 이 들어가지만, 목록 응답 DTO `NotificationItemResponse` 가 노출하지 않음. (`payload` 컬럼은 모든 알림에서 미사용·항상 null)

## TO-BE
`NotificationItemResponse` 에 `mealSlot` 추가 — 값: `BREAKFAST` / `LUNCH` / `DINNER` (복약 외 알림은 null).
- 기존 `meal_slot` 컬럼을 그대로 노출 → **DB 마이그레이션·백필 불필요**
- 추가 필드라 하위호환
- `targetDate` 는 미추가: 복약 인증은 항상 오늘분이라 프론트가 today 사용 (요청 본문 `MedicationLogUpsertRequest.targetDate` 와 별개), 응답의 `createdAt` 으로도 파생 가능

## 테스트
`NotificationControllerE2ETest` 에 reminder INSERT(meal_slot=BREAKFAST) 후 `GET /api/v1/notifications` 응답에 `mealSlot=BREAKFAST` 가 내려오는지 검증 추가.

## 비고
- API 응답 스키마 변경(필드 추가) → Notion API 명세 갱신 동반
- scope: notification 패키지 변경이나 복약 인증 흐름 수정이라 `scope:medication` 부여

## AI 체크리스트
- [x] `./gradlew checkstyleMain spotlessCheck test` 통과
- [x] 신규 엔드포인트 없음 (기존 응답 필드 추가)
- [x] 보호 영역 변경 없음
- [ ] Notion API 명세 갱신 (응답 필드 mealSlot 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)