### PR TITLE
chore(user): JWT 인증 실패 사유 로깅 추가

### DIFF
--- a/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
@@ -6,6 +6,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
@@ -17,6 +19,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String ROLE_PREFIX = "ROLE_";
@@ -36,6 +39,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         final String token = extractToken(request);
         final boolean userIdSet = token != null && jwtProvider.isValid(token);
+
+        // 토큰이 실렸는데 거부된 경우만 경로와 함께 기록 (사유는 JwtProvider 로그, requestId로 상관).
+        // 토큰 미첨부(로그인 등 permitAll)는 정상이라 로깅하지 않음 — 노이즈 회피.
+        if (token != null && !userIdSet) {
+            log.warn("JWT 인증 실패 — {} {}", request.getMethod(), request.getRequestURI());
+        }
 
         if (userIdSet) {
             final Long userId = jwtProvider.extractUserId(token);

--- a/src/main/java/com/ppiyaki/common/auth/JwtProvider.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtProvider.java
@@ -7,10 +7,14 @@ import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import javax.crypto.SecretKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class JwtProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtProvider.class);
 
     private final SecretKey secretKey;
     private final long accessTokenExpiry;
@@ -50,6 +54,8 @@ public class JwtProvider {
             parseClaims(token);
             return true;
         } catch (final JwtException | IllegalArgumentException e) {
+            // 토큰 값은 절대 남기지 않고 실패 사유(예외 클래스)만 기록 — 만료/서명불일치/형식오류 판별용.
+            log.warn("JWT 검증 실패: {}", e.getClass().getSimpleName());
             return false;
         }
     }


### PR DESCRIPTION
## 배경
채팅 SSE refresh-토큰 401 버그(fe-백로그 'Refresh로 토큰 재발급') 진단 중, 현재 백엔드는 401 발생 시 사유를 전혀 안 남겨 "FE 미전송 / 만료 / 서명불일치 / 깨진 토큰"을 구분할 수 없었다. (`JwtProvider.isValid`가 예외를 조용히 삼킴)

## 변경
- `JwtProvider.isValid`: 검증 실패 시 **예외 클래스명만** warn 로깅 (`ExpiredJwtException`/`SignatureException`/`MalformedJwtException` 등). **토큰 값은 절대 미노출.**
- `JwtAuthenticationFilter`: **토큰이 실렸는데 거부된 경우에만** `method path` warn 로깅. 토큰 미첨부(로그인 등 permitAll)는 정상이라 로깅 안 함(노이즈 회피). requestId(MDC)로 두 로그 상관.

## 목적 / 검증
배포 후 FE가 재현하면 prod 로그(Loki)에서 `POST /api/v1/chat/messages` 옆에 실제 사유가 찍혀 "서버냐 FE냐"를 추측 없이 확정.
- 참고 진단: 서버는 정상 발급/refresh 토큰을 채팅 SSE에서 200 처리함(실측 2회). FE 계측은 refresh 토큰으로도 401 → 충돌. 이 로깅으로 사유 확정 예정.

## AI 체크리스트
- [x] `./gradlew checkstyleMain spotlessCheck test` 통과 (전체)
- [x] 신규 엔드포인트 없음 (로깅만 추가)
- [x] 보호 영역 변경 없음
- [x] 민감정보(토큰 값) 미로깅 — 예외 클래스명·경로만
- [x] API/스키마 변경 없음 (Notion 갱신 불요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * JWT 인증 실패 시 요청 메서드와 경로를 포함한 상세 로그 기록이 추가되었습니다.
  * JWT 검증 예외 발생 시 실패 원인이 로그에 기록됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->