### PR TITLE
release: v0.18.0

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -54,22 +54,44 @@ jobs:
           password: ${{ secrets.REMOTE_PASSWORD }}
           port: 22
           script: |
-            docker login ${{ secrets.NCP_REGISTRY }} -u ${{ secrets.NCP_ACCESS_KEY }} -p ${{ secrets.NCP_SECRET_KEY }}
-            
-            echo "Stopping and removing old container..."
-            docker stop ppiyaki-server || true
-            docker rm ppiyaki-server || true
-            
+            set -e
+            # ── 무중단 blue-green 배포 ──
+            # 호스트 nginx 의 upstream(ppiyaki_backend) 대상 포트를 blue↔green 으로 전환한다.
+            # 사전 일회성 셋업 필요(운영 작업): /etc/nginx/conf.d/ppiyaki-upstream.conf 생성 +
+            #   default 의 proxy_pass 를 http://ppiyaki_backend 로 변경 + CD 유저 NOPASSWD sudo(tee/nginx/systemctl).
+            # 상세: docs/features/zero-downtime-deploy.md
+            REGISTRY='${{ secrets.NCP_REGISTRY }}'
+            IMAGE="$REGISTRY/ppiyaki-server:latest"
+            UPSTREAM_CONF=/etc/nginx/conf.d/ppiyaki-upstream.conf
+
+            docker login "$REGISTRY" -u '${{ secrets.NCP_ACCESS_KEY }}' -p '${{ secrets.NCP_SECRET_KEY }}'
+
             echo "Pulling latest image..."
-            docker pull ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
-            
-            echo "Starting new container..."
+            docker pull "$IMAGE"
+
+            # 활성 색 판별: upstream 이 green(8082) 을 가리키면 green 활성 → 다음은 blue, 아니면 그 반대
+            if grep -q '127.0.0.1:8082' "$UPSTREAM_CONF" 2>/dev/null; then
+              ACTIVE=green; NEW=blue;  NEW_APP=8080; NEW_MGMT=18081
+            else
+              ACTIVE=blue;  NEW=green; NEW_APP=8082; NEW_MGMT=18082
+            fi
+            NEW_NAME="ppiyaki-server-$NEW"
+            OLD_NAME="ppiyaki-server-$ACTIVE"
+            echo "Active=$ACTIVE → deploying NEW=$NEW ($NEW_NAME, app=$NEW_APP, mgmt=$NEW_MGMT)"
+
+            # 이전 실패로 남아있을 수 있는 동일 색 컨테이너 정리
+            docker rm -f "$NEW_NAME" 2>/dev/null || true
+
+            echo "Starting $NEW_NAME ..."
             docker run -d \
-              --name ppiyaki-server \
+              --name "$NEW_NAME" \
               --network ppiyaki-monitoring \
-              -p 8080:8080 \
+              -p 127.0.0.1:$NEW_APP:8080 \
+              -p 127.0.0.1:$NEW_MGMT:8081 \
+              --memory=768m \
               --restart always \
               -e TZ='Asia/Seoul' \
+              -e JAVA_TOOL_OPTIONS='-XX:MaxRAMPercentage=65' \
               -e SPRING_PROFILES_ACTIVE=prod \
               -e DB_URL='${{ secrets.DB_URL }}' \
               -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \
@@ -93,8 +115,32 @@ jobs:
               -e REDIS_HOST='ppiyaki-redis' \
               -e REDIS_PORT='6379' \
               -e REDIS_PASSWORD='${{ secrets.REDIS_PASSWORD }}' \
-              ${{ secrets.NCP_REGISTRY }}/ppiyaki-server:latest
-            
+              "$IMAGE"
+
+            echo "Health checking $NEW_NAME (2s × 최대 60s)..."
+            OK=0
+            for i in $(seq 1 30); do
+              if curl -fsS "http://127.0.0.1:$NEW_MGMT/actuator/health" 2>/dev/null | grep -q '"status":"UP"'; then
+                OK=1; break
+              fi
+              sleep 2
+            done
+            if [ "$OK" != "1" ]; then
+              echo "Health check FAILED — nginx 전환 없이 롤백 (활성 $ACTIVE 유지). 새 컨테이너 로그:"
+              docker logs --tail 80 "$NEW_NAME" || true
+              docker rm -f "$NEW_NAME" || true
+              exit 1
+            fi
+            echo "Health OK → nginx upstream 을 127.0.0.1:$NEW_APP 로 전환"
+
+            echo "upstream ppiyaki_backend { server 127.0.0.1:$NEW_APP; }" | sudo tee "$UPSTREAM_CONF" >/dev/null
+            sudo nginx -t
+            sudo systemctl reload nginx
+
+            echo "구 컨테이너 $OLD_NAME drain & 종료..."
+            docker stop -t 30 "$OLD_NAME" 2>/dev/null || true
+            docker rm "$OLD_NAME" 2>/dev/null || true
+
             echo "Cleaning up old images..."
             docker image prune -f
 

--- a/docs/features/zero-downtime-deploy.md
+++ b/docs/features/zero-downtime-deploy.md
@@ -1,0 +1,136 @@
+---
+feature: 무중단 배포 (nginx blue-green)
+slug: zero-downtime-deploy
+status: approved
+owner: @goohong
+scope: infra
+related_issues: [452]
+related_prs: []
+last_reviewed: 2026-06-06
+---
+
+# 무중단 배포 (nginx blue-green)
+
+## 1) 개요 (What / Why)
+현재 CD는 `docker stop ppiyaki-server` → `docker rm` → `docker pull` → `docker run` 순서라,
+기존 컨테이너를 먼저 내린 뒤 새 컨테이너를 띄운다. 그 사이 + 새 컨테이너의 Spring Boot 부팅 완료까지
+**수십 초~1분가량 API가 끊긴다(connection refused).** 릴리즈마다 짧은 다운타임이 발생한다.
+
+이 스펙은 **다운타임 없이** 새 버전을 배포하기 위해, 이미 운영 중인 호스트 nginx를 활용한
+**blue-green 배포**로 CD를 전환하는 것을 다룬다. 대상 액터는 운영자(배포)와 최종 사용자(무중단 경험)다.
+
+## 2) 사용자 시나리오
+- (운영자) `develop → main` 릴리즈가 머지되면 CD가 새 색(color) 컨테이너를 띄우고, 헬스체크 통과 후
+  nginx를 graceful reload 하여 트래픽을 전환한다. **기존 컨테이너는 전환 전까지 계속 서빙**한다.
+- (사용자) 배포 중에도 앱 요청이 끊기지 않는다.
+- (운영자) 새 컨테이너가 헬스체크에 실패하면 nginx를 전환하지 않고 기존 컨테이너를 그대로 유지한다
+  (= 실패한 배포가 트래픽을 받지 않음, 무중단 보장).
+
+## 3) 요구사항
+### 기능 요구사항
+- [ ] 배포 시 기존 컨테이너를 내리지 않고 **새 색 컨테이너를 다른 포트에 먼저 기동**한다.
+- [ ] 새 컨테이너의 `/actuator/health`(관리 포트 8081)가 `UP` 이 될 때까지 폴링한다(타임아웃 有).
+- [ ] 헬스 통과 시에만 nginx upstream을 새 색으로 바꾸고 **`nginx -t` 검증 후 graceful reload**한다.
+- [ ] 전환 후 구 색 컨테이너를 graceful 종료(in-flight 요청 드레인)한다.
+- [ ] 헬스 실패/타임아웃 시: nginx 전환하지 않고, 새(실패) 컨테이너만 제거하고 배포를 실패로 종료한다.
+- [ ] 활성 색 판별이 재실행에도 안전하도록 **멱등**하게 동작한다.
+
+### 비기능 요구사항
+- **무중단**: nginx graceful reload(`SIGHUP`)로 기존 연결 유지. reload 전 `nginx -t` 필수.
+- **자원**: 전환 순간 앱 JVM 2개가 잠깐 공존한다. 서버 RAM 3.8GB에 MySQL + 모니터링 5종이 공존하므로
+  **각 앱 컨테이너에 heap/메모리 상한**을 두어 OOM을 방지한다 (§8 Q4).
+- **보안**: 앱 포트·관리 포트는 모두 `127.0.0.1` 바인딩(외부 미노출). 공개 진입점은 nginx 443만 유지.
+- **관측성**: 배포 결과 Discord 알림 유지. 전환/롤백 로그를 배포 로그에 남긴다.
+- **무회귀**: SSE 스트리밍(`/chat` 등), 업로드 등 기존 nginx proxy 동작(헤더·타임아웃)을 그대로 보존한다.
+
+## 4) 범위 / 비범위 (중요)
+### 포함
+- `.github/workflows/backend-cd.yml`의 SSH 배포 스크립트를 blue-green으로 교체
+- 호스트 nginx의 upstream 간접화(`proxy_pass` → `upstream` 참조) 및 활성 색 전환 메커니즘
+- 색깔별 컨테이너 포트/관리포트 규약, 헬스체크 폴링, 자동 롤백
+- 일회성 서버 셋업 절차 문서화(현재 8080 컨테이너를 첫 blue로 재사용, 무중단 셋업)
+
+### 제외 (Out of Scope)
+- **다중 서버 / 오토스케일 / 오케스트레이터(K8s, Swarm) 도입** — 단일 호스트 유지
+- **DB 스키마 마이그레이션의 무중단화** — release 직전 ALTER 절차는 기존 방식 유지([[2026-05-12-release-prod-ai]] 참조)
+- **nginx의 컨테이너화** — 현재 시스템 패키지 nginx(1.18.0) 유지
+- **TLS/도메인 변경** — 기존 Let's Encrypt(`ppiyaki.store`) 그대로
+- **carbon copy 트래픽/카나리 비율 분배** — 100% 일괄 전환만(blue↔green)
+
+## 5) 설계
+
+### 5-1) 도메인 모델
+인프라 변경이며 도메인 엔티티/컨텍스트는 건드리지 않는다.
+
+### 5-2) API 엔드포인트
+변경 없음. (`/actuator/health`는 기존 actuator 그대로 활용)
+
+### 5-3) 외부 연동 / 운영 구조 (현황)
+조사로 확인한 prod 진입 구조:
+```text
+[모바일 앱] → ppiyaki.store :443 (호스트 시스템 nginx 1.18.0, Let's Encrypt TLS 종료)
+                   └ location / { proxy_pass http://localhost:8080; }  → ppiyaki-server (127.0.0.1:8080)
+```
+- 호스트 nginx가 이미 앞단에 존재 → **새 프록시 도입 불필요**. upstream 대상만 전환하면 됨.
+- 관리 포트 8081은 현재 미publish → 색깔별로 `127.0.0.1`에 publish해 헬스체크에 사용.
+- MySQL(`127.0.0.1:13306`)·Redis·모니터링(grafana 3000 등)은 별개 컨테이너로 영향 없음.
+
+### 5-4) 데이터 흐름 / 시퀀스
+```text
+배포 트리거(main push)
+  1. 활성 색 판별 (예: blue=8080 활성)
+  2. 새 이미지 pull
+  3. 비활성 색(green) 컨테이너 기동  (127.0.0.1:8082 app / 127.0.0.1:18082 mgmt)
+  4. green /actuator/health 폴링 → UP 까지 (timeout 내)
+       ├─ 실패 → green 제거, 배포 실패 종료 (nginx 그대로 = 무중단, blue 유지)
+       └─ 성공 → 다음 단계
+  5. nginx upstream 파일을 green 포트로 재작성 → `nginx -t` → `systemctl reload nginx` (graceful)
+  6. 구 색(blue) graceful stop & rm (in-flight 드레인)
+  7. 이미지 prune
+```
+
+nginx 간접화:
+```nginx
+# /etc/nginx/conf.d/ppiyaki-upstream.conf  (배포 스크립트가 재작성)
+upstream ppiyaki_backend { server 127.0.0.1:8080; }   # ← 활성 색 포트
+
+# /etc/nginx/sites-available/default (1회 변경)
+location / { proxy_pass http://ppiyaki_backend; ... 기존 헤더/타임아웃 유지 ... }
+```
+
+### 5-5) DB 마이그레이션
+없음.
+
+### 5-6) 확정 파라미터 (합의 2026-06-06)
+- **색/포트**: blue = app `127.0.0.1:8080` · mgmt `127.0.0.1:18081`, green = app `127.0.0.1:8082` · mgmt `127.0.0.1:18082`.
+  현재 8080 컨테이너를 **첫 blue로 재사용**(재시작 없음).
+- **헬스체크**: `http://127.0.0.1:<mgmt>/actuator/health` 를 **2초 간격·최대 60초** 폴링. 미통과 시 nginx 미전환 + 구 색 유지(자동 롤백) + 새 컨테이너 제거 후 배포 실패 종료.
+- **메모리**: 각 앱 컨테이너 `--memory=768m` + `JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=65`. 전환 직후 구 색 즉시 graceful stop. 추가로 **호스트 swap 2GB** 안전망 구성(현재 swap 0).
+- **nginx 일회성 셋업**: 운영자/AI가 ssh로 1회 적용(`/etc/nginx/conf.d/ppiyaki-upstream.conf` 생성 + `default` proxy_pass를 `http://ppiyaki_backend` 로 변경 → `nginx -t` → reload). 이후 CD는 upstream 파일 재작성 + reload만 수행.
+- **첫 적용**: 정규 release 전에 **리허설 배포 1회**로 무중단 실측(별도 터미널 1초 간격 헬스 폴링이 연속 200인지 확인).
+
+## 6) 작업 분할 (예상 PR 리스트)
+- [ ] PR 1 (`docs(infra)`): 본 Feature Spec 초안 — 합의용
+- [ ] PR 2 (`chore(infra)`): `backend-cd.yml` blue-green 배포 스크립트 + (선택) 헬퍼 스크립트.
+      **보호 영역(`.github/workflows/**`) → `needs-human-review` 라벨 필수**
+- [ ] 서버 일회성 셋업: nginx upstream 간접화 + 활성 색 파일 생성 (무중단 reload). PR 아님 / 운영 작업으로 기록
+
+## 7) 테스트 전략
+- 배포 스크립트는 CI 단위 테스트 대상이 아니므로, **스테이징 성격의 검증**을 어떻게 할지 §8 Q5.
+- 최소 검증: 전환 직후 `curl https://ppiyaki.store/actuator/health` 200 확인, 배포 중 별도 터미널에서
+  1초 간격 헬스 폴링으로 무중단(연속 200) 실측.
+- 롤백 경로: 일부러 부팅 실패하는 이미지로 green 기동 → nginx 미전환 + blue 유지 확인.
+
+## 8) 오픈 질문
+모두 해소됨 → §9 결정 로그로 이동.
+
+## 9) 결정 로그
+- 2026-06-06: 초안 작성 (status=draft)
+- 2026-06-06: 방식 = **호스트 nginx upstream 전환 blue-green** 확정. 사용자 선택(권장안). 이유: 호스트 nginx가 이미 TLS 종료 + 프록시 앞단으로 존재하여 추가 프록시 도입 없이 무중단 reload로 전환 가능.
+- 2026-06-06: 진행 절차 = **Feature Spec 선합의 후 구현**(사용자 선택 B). 보호 영역 변경이라 권장 절차.
+- 2026-06-06: Q1 → (a) **AI가 ssh로 nginx 일회성 셋업 수동 1회**. 위험한 첫 변경을 검증하며 진행, CD는 이후 전환만.
+- 2026-06-06: Q2 → blue=8080/green=8082(app), 18081/18082(mgmt) 확정.
+- 2026-06-06: Q3 → 헬스체크 2초 간격·최대 60초, 실패 시 자동 롤백(전환 안 함).
+- 2026-06-06: Q4 → **heap 상한(`--memory=768m`+`MaxRAMPercentage=65`) + 호스트 swap 2GB**. 서버 3.8GB·가용 1.8GB·swap 0 실측 근거.
+- 2026-06-06: Q5 → 정규 release 전 **리허설 배포 1회**로 무중단 실측.
+- 2026-06-06: 오픈 질문 전부 해소 → status=**approved**. 구현 PR(`backend-cd.yml`) 착수 가능.

--- a/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
@@ -6,6 +6,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
@@ -17,6 +19,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String ROLE_PREFIX = "ROLE_";
@@ -36,6 +39,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         final String token = extractToken(request);
         final boolean userIdSet = token != null && jwtProvider.isValid(token);
+
+        // 토큰이 실렸는데 거부된 경우만 경로와 함께 기록 (사유는 JwtProvider 로그, requestId로 상관).
+        // 토큰 미첨부(로그인 등 permitAll)는 정상이라 로깅하지 않음 — 노이즈 회피.
+        if (token != null && !userIdSet) {
+            log.warn("JWT 인증 실패 — {} {}", request.getMethod(), request.getRequestURI());
+        }
 
         if (userIdSet) {
             final Long userId = jwtProvider.extractUserId(token);

--- a/src/main/java/com/ppiyaki/common/auth/JwtProvider.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtProvider.java
@@ -7,10 +7,14 @@ import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import javax.crypto.SecretKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class JwtProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtProvider.class);
 
     private final SecretKey secretKey;
     private final long accessTokenExpiry;
@@ -50,6 +54,8 @@ public class JwtProvider {
             parseClaims(token);
             return true;
         } catch (final JwtException | IllegalArgumentException e) {
+            // 토큰 값은 절대 남기지 않고 실패 사유(예외 클래스)만 기록 — 만료/서명불일치/형식오류 판별용.
+            log.warn("JWT 검증 실패: {}", e.getClass().getSimpleName());
             return false;
         }
     }

--- a/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineCandidate.java
+++ b/src/main/java/com/ppiyaki/medicine/controller/dto/MedicineCandidate.java
@@ -1,6 +1,8 @@
 package com.ppiyaki.medicine.controller.dto;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 public record MedicineCandidate(
         String itemSeq,
@@ -17,11 +19,42 @@ public record MedicineCandidate(
                 getString(item, "ITEM_SEQ"),
                 getString(item, "ITEM_NAME"),
                 getString(item, "ENTP_NAME"),
-                getString(item, "MATERIAL_NAME"),
+                formatMainIngredient(getString(item, "MATERIAL_NAME")),
                 getString(item, "CHART"),
                 getString(item, "ETC_OTC_CODE"),
                 getString(item, "CLASS_NO")
         );
+    }
+
+    /**
+     * 식약처 MATERIAL_NAME 원본을 사람이 읽을 수 있는 주성분 문구로 변환한다.
+     * 원본 형식: 성분마다 {@code /} 로 구분, 각 성분은 {@code 성분명,총량,분량,단위,규격,비고} 를
+     * 쉼표로 나열한다. 분량 등이 비면 {@code ,,,} 가 그대로 노출되고 규격(USP·KP)·총량 코드처럼
+     * 사용자에게 의미 없는 값이 섞이므로, 성분명과 분량·단위만 추려 {@code "성분명 분량단위, ..."} 로 만든다.
+     */
+    private static String formatMainIngredient(final String materialName) {
+        if (materialName == null || materialName.isBlank()) {
+            return null;
+        }
+        final Set<String> ingredients = new LinkedHashSet<>();
+        for (final String segment : materialName.split("/")) {
+            final String[] fields = segment.split(",", -1);
+            final String ingredientName = fields[0].strip();
+            if (ingredientName.isEmpty()) {
+                continue;
+            }
+            final String amount = fields.length > 2 ? normalizeAmount(fields[2].strip()) : "";
+            final String unit = fields.length > 3 ? fields[3].strip() : "";
+            ingredients.add(amount.isEmpty() ? ingredientName : ingredientName + " " + amount + unit);
+        }
+        return ingredients.isEmpty() ? null : String.join(", ", ingredients);
+    }
+
+    private static String normalizeAmount(final String amount) {
+        if (!amount.contains(".")) {
+            return amount;
+        }
+        return amount.replaceAll("0+$", "").replaceAll("\\.$", "");
     }
 
     private static String getString(final Map<String, Object> item, final String key) {

--- a/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
+++ b/src/main/java/com/ppiyaki/notification/controller/dto/NotificationItemResponse.java
@@ -11,6 +11,7 @@ public record NotificationItemResponse(
         String title,
         String body,
         String payload,
+        String mealSlot,
         LocalDateTime readAt,
         LocalDateTime takenAt,
         LocalDateTime createdAt
@@ -24,6 +25,7 @@ public record NotificationItemResponse(
                 notification.getTitle(),
                 notification.getBody(),
                 notification.getPayload(),
+                notification.getMealSlot(),
                 notification.getReadAt(),
                 notification.getTakenAt(),
                 notification.getCreatedAt()

--- a/src/main/java/com/ppiyaki/notification/service/DurWarningDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/DurWarningDispatcher.java
@@ -66,7 +66,7 @@ public class DurWarningDispatcher {
 
         final String title = "처방전 안전 경고";
         final String body = String.format(
-                "%s 어르신의 처방전에 %s 주의 약물이 포함되어 있습니다.",
+                "%s님의 처방전에 %s 주의 약물이 포함되어 있습니다.",
                 senior.getNickname() == null ? "" : senior.getNickname(),
                 level == DurWarningLevel.BLOCK ? "복용 금기" : "주의 필요");
 

--- a/src/main/java/com/ppiyaki/notification/service/FamilySafetyDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/FamilySafetyDispatcher.java
@@ -102,7 +102,7 @@ public class FamilySafetyDispatcher {
 
             final String title = "가족 안전망 알림";
             final String body = String.format(
-                    "%s 어르신이 %d시간 이상 앱에 접속하지 않았습니다.",
+                    "%s님이 %d시간 이상 앱에 접속하지 않았습니다.",
                     senior.getNickname() == null ? "" : senior.getNickname(), thresholdHours);
             final Notification saved = notificationRepository.save(
                     Notification.createForFamilySafety(caregiverId, senior.getId(), title, body, today));

--- a/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/MedicationDelayDispatcher.java
@@ -158,7 +158,7 @@ public class MedicationDelayDispatcher {
         final String seniorName = senior.getNickname() == null ? "" : senior.getNickname();
         final StringBuilder bodyBuilder = new StringBuilder();
         bodyBuilder.append(String.format(
-                "%s 어르신이 %s에 약 %d개를 아직 복용하지 않았어요. (%d분 경과)",
+                "%s님이 %s에 약 %d개를 아직 복용하지 않았어요. (%d분 경과)",
                 seniorName, slotLabel, schedules.size(), thresholdMinutes));
         for (final MedicationSchedule schedule : schedules) {
             bodyBuilder.append("\n• ").append(resolveMedicineLabel(schedule));

--- a/src/main/java/com/ppiyaki/notification/service/PrescriptionReviewRequestDispatcher.java
+++ b/src/main/java/com/ppiyaki/notification/service/PrescriptionReviewRequestDispatcher.java
@@ -32,7 +32,7 @@ public class PrescriptionReviewRequestDispatcher {
 
     private static final Logger log = LoggerFactory.getLogger(PrescriptionReviewRequestDispatcher.class);
     private static final String PUSH_TITLE = "처방전 검토 요청";
-    private static final String PUSH_BODY_FORMAT = "%s 어르신의 새 처방전이 도착했어요. 검토해 주세요.";
+    private static final String PUSH_BODY_FORMAT = "%s님의 새 처방전이 도착했어요. 검토해 주세요.";
 
     private final UserRepository userRepository;
     private final CareRelationRepository careRelationRepository;

--- a/src/main/java/com/ppiyaki/notification/service/WellbeingPingService.java
+++ b/src/main/java/com/ppiyaki/notification/service/WellbeingPingService.java
@@ -24,7 +24,7 @@ public class WellbeingPingService {
 
     private static final Logger log = LoggerFactory.getLogger(WellbeingPingService.class);
     private static final String PUSH_TITLE = "안부 알림";
-    private static final String PUSH_BODY_FORMAT = "%s 어르신이 안부를 전했어요.";
+    private static final String PUSH_BODY_FORMAT = "%s님이 안부를 전했어요.";
 
     private final UserRepository userRepository;
     private final CareRelationRepository careRelationRepository;

--- a/src/test/java/com/ppiyaki/medicine/controller/dto/MedicineCandidateTest.java
+++ b/src/test/java/com/ppiyaki/medicine/controller/dto/MedicineCandidateTest.java
@@ -1,0 +1,87 @@
+package com.ppiyaki.medicine.controller.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MedicineCandidateTest {
+
+    private static Map<String, Object> itemWithMaterial(final String materialName) {
+        final Map<String, Object> item = new HashMap<>();
+        item.put("ITEM_SEQ", "1");
+        item.put("ITEM_NAME", "테스트정");
+        item.put("MATERIAL_NAME", materialName);
+        return item;
+    }
+
+    @Test
+    @DisplayName("단일 성분은 성분명과 분량·단위만 남긴다 (규격·빈 칸 제거)")
+    void formatSingleIngredient() {
+        // given
+        final Map<String, Object> item = itemWithMaterial("아세트아미노펜,,500,밀리그램,USP,");
+
+        // when
+        final MedicineCandidate candidate = MedicineCandidate.fromMfdsItem(item);
+
+        // then
+        assertThat(candidate.mainIngr()).isEqualTo("아세트아미노펜 500밀리그램");
+    }
+
+    @Test
+    @DisplayName("분량이 비어 있으면 성분명만 남기고 연속 쉼표(,,,)를 만들지 않는다")
+    void formatIngredientWithoutAmount() {
+        // given
+        final Map<String, Object> item = itemWithMaterial(
+                "아세트아미노펜,,,밀리그램,USP,/슈도에페드린염산염,,,밀리그램,USP,");
+
+        // when
+        final MedicineCandidate candidate = MedicineCandidate.fromMfdsItem(item);
+
+        // then
+        assertThat(candidate.mainIngr()).isEqualTo("아세트아미노펜, 슈도에페드린염산염");
+    }
+
+    @Test
+    @DisplayName("복합 성분은 쉼표로 구분하고 소수점 뒤 0은 정리한다")
+    void formatMultipleIngredients() {
+        // given
+        final Map<String, Object> item = itemWithMaterial(
+                "로사르탄칼륨,1511.09,100.00,밀리그램,EP,/암로디핀캄실산염,1511.09,7.84,밀리그램,별첨규격(전과동),");
+
+        // when
+        final MedicineCandidate candidate = MedicineCandidate.fromMfdsItem(item);
+
+        // then
+        assertThat(candidate.mainIngr()).isEqualTo("로사르탄칼륨 100밀리그램, 암로디핀캄실산염 7.84밀리그램");
+    }
+
+    @Test
+    @DisplayName("규격만 다른 중복 성분은 한 번만 표시한다")
+    void deduplicatesIdenticalIngredients() {
+        // given
+        final Map<String, Object> item = itemWithMaterial(
+                "로사르탄칼륨,1335.29,50.00,밀리그램,EP,/로사르탄칼륨,1412.04,50.00,밀리그램,EP,");
+
+        // when
+        final MedicineCandidate candidate = MedicineCandidate.fromMfdsItem(item);
+
+        // then
+        assertThat(candidate.mainIngr()).isEqualTo("로사르탄칼륨 50밀리그램");
+    }
+
+    @Test
+    @DisplayName("MATERIAL_NAME 이 없으면 주성분은 null 이다")
+    void nullMaterialReturnsNull() {
+        // given
+        final Map<String, Object> item = itemWithMaterial(null);
+
+        // when
+        final MedicineCandidate candidate = MedicineCandidate.fromMfdsItem(item);
+
+        // then
+        assertThat(candidate.mainIngr()).isNull();
+    }
+}

--- a/src/test/java/com/ppiyaki/notification/controller/NotificationControllerE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/NotificationControllerE2ETest.java
@@ -1,6 +1,7 @@
 package com.ppiyaki.notification.controller;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 
 import io.restassured.RestAssured;
@@ -45,8 +46,9 @@ class NotificationControllerE2ETest {
 
         // owner 알림 2건 + other 알림 1건 INSERT
         jdbcTemplate.update("INSERT INTO notifications "
-                + "(user_id, category, title, body, created_at) "
-                + "VALUES (?, 'MEDICATION_REMINDER', '아침 약 복용', '아침 약 드세요', NOW(6))", ownerId);
+                + "(user_id, category, title, body, meal_slot, target_date, created_at) "
+                + "VALUES (?, 'MEDICATION_REMINDER', '아침 약 복용', '아침 약 드세요', 'BREAKFAST', CURDATE(), NOW(6))",
+                ownerId);
         jdbcTemplate.update("INSERT INTO notifications "
                 + "(user_id, category, title, body, created_at) "
                 + "VALUES (?, 'MEDICATION_REMINDER', '저녁 약 복용', '저녁 약 드세요', NOW(6))", ownerId);
@@ -68,6 +70,7 @@ class NotificationControllerE2ETest {
                 .then()
                 .statusCode(200)
                 .body("responses.size()", greaterThanOrEqualTo(2))
+                .body("responses.mealSlot", hasItem("BREAKFAST"))
                 .body("hasNext", is(false));
 
         // 단건 읽음

--- a/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
+++ b/src/test/java/com/ppiyaki/notification/service/MedicationDelayDispatcherTest.java
@@ -105,7 +105,7 @@ class MedicationDelayDispatcherTest {
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository, times(1)).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정 1정");
+                .isEqualTo("김철수님이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정 1정");
     }
 
     @Test
@@ -127,7 +127,7 @@ class MedicationDelayDispatcherTest {
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 약 2캡슐");
+                .isEqualTo("김철수님이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 약 2캡슐");
     }
 
     @Test
@@ -149,7 +149,7 @@ class MedicationDelayDispatcherTest {
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정");
+                .isEqualTo("김철수님이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 록스펜씨알정");
     }
 
     @Test
@@ -179,7 +179,7 @@ class MedicationDelayDispatcherTest {
         final ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository, times(1)).save(notificationCaptor.capture());
         assertThat(notificationCaptor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 3개를 아직 복용하지 않았어요. (60분 경과)"
+                .isEqualTo("김철수님이 아침에 약 3개를 아직 복용하지 않았어요. (60분 경과)"
                         + "\n• 타이레놀500mg 1정"
                         + "\n• 비타민C 2캡슐"
                         + "\n• 위장약");
@@ -215,7 +215,7 @@ class MedicationDelayDispatcherTest {
         final ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
         assertThat(captor.getValue().getBody())
-                .isEqualTo("김철수 어르신이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 비타민C 2캡슐");
+                .isEqualTo("김철수님이 아침에 약 1개를 아직 복용하지 않았어요. (60분 경과)\n• 비타민C 2캡슐");
     }
 
     @Test


### PR DESCRIPTION
## v0.18.0 — 무중단 배포 전환 + 알림/약물 응답 개선

이 릴리즈가 **새 blue-green CD 워크플로우로 동작하는 첫 배포**입니다 (무중단). schema 변경 없음 → prod 마이그레이션 불필요.

### chore (infra)
- CD를 nginx upstream 전환 **blue-green 무중단 배포**로 변경 (#454, 스펙 #452)
- JWT 인증 실패 사유 로깅 추가 — 채팅 SSE 401 진단용 (#458)

### fix
- 복약 알림 응답에 `mealSlot` 노출 — 아침/저녁 슬롯 오인증 버그 (#456)
- 알림 문구의 '어르신' → '님' 통일 (#451)
- 약물 검색 주성분(`mainIngr`) 표시값 정제 — `,,,`·규격코드 제거 (#450)

### docs
- 무중단 배포 Feature Spec (#453)

### ⚠️ 배포 운영 메모
- 사전 서버 셋업 완료: swap 2GB, nginx upstream 간접화(8080).
- 첫 blue-green 실행은 green(8082)으로 전환되며, 레거시 `ppiyaki-server` 컨테이너가 8080에 고아로 남음 → **배포 직후 1회 `docker rm -f ppiyaki-server` 정리 필요** (다음 배포 포트충돌 방지). 운영자/AI가 배포 직후 수행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)