### PR TITLE
fix(chat): SSE 비동기 디스패치 인증 컨텍스트 유실로 인한 가짜 401 수정

### DIFF
--- a/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ppiyaki/common/auth/JwtAuthenticationFilter.java
@@ -67,6 +67,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
     }
 
+    // SSE 등 비동기 응답은 스트림 종료/에러 시 컨테이너로 ASYNC/ERROR 디스패치가 한 번 더 일어난다.
+    // OncePerRequestFilter는 기본적으로 두 디스패치를 건너뛰어 SecurityContext가 비는데,
+    // Spring Security 6의 AuthorizationFilter는 모든 디스패치 타입에서 동작하므로 익명으로 간주돼 401(AUTH_001)이 난다.
+    // 첫 이벤트 전송 전에 스트림이 실패하면 이 401이 클라이언트에 그대로 노출된다(REST는 재디스패치가 없어 무관).
+    // 따라서 이 디스패치들에서도 필터가 토큰을 다시 읽어 컨텍스트를 복원하도록 한다.
+    @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return false;
+    }
+
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return false;
+    }
+
     private String extractToken(final HttpServletRequest request) {
         final String header = request.getHeader(AUTHORIZATION_HEADER);
         if (header != null && header.startsWith(BEARER_PREFIX)) {

--- a/src/test/java/com/ppiyaki/chat/SseAsyncDispatchAuthTest.java
+++ b/src/test/java/com/ppiyaki/chat/SseAsyncDispatchAuthTest.java
@@ -1,0 +1,117 @@
+package com.ppiyaki.chat;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.not;
+
+import com.ppiyaki.common.auth.JwtProvider;
+import io.restassured.RestAssured;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * SSE 비동기 응답의 인증 회귀 가드.
+ *
+ * <p>SseEmitter는 스트림 종료/에러 시 컨테이너로 ASYNC/ERROR 디스패치가 한 번 더 일어난다.
+ * JwtAuthenticationFilter(OncePerRequestFilter)는 기본적으로 이 두 디스패치를 건너뛰지만,
+ * Spring Security 6의 AuthorizationFilter는 모든 디스패치 타입에서 동작한다.
+ * 따라서 첫 이벤트 전송 전에 스트림이 실패하면 SecurityContext가 비어 익명으로 간주돼
+ * 유효한 토큰임에도 가짜 401(AUTH_001)이 클라이언트에 노출됐다.
+ *
+ * <p>JwtAuthenticationFilter가 ASYNC/ERROR 디스패치에서도 컨텍스트를 복원하도록 고친 뒤,
+ * 첫 send 전 실패가 더 이상 401로 둔갑하지 않음을 검증한다. 실제 SecurityConfig /
+ * JwtAuthenticationFilter / RestAuthenticationEntryPoint / chatStreamExecutor 빈을 그대로 사용한다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = "spring.ai.openai.api-key=test-dummy-key")
+@Import(SseAsyncDispatchAuthTest.TestSseController.class)
+class SseAsyncDispatchAuthTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        accessToken = jwtProvider.createAccessToken(1L, "SENIOR");
+    }
+
+    @Test
+    @DisplayName("첫 이벤트 전송에 성공하면 200을 반환한다 (대조군)")
+    void successPath_returns200() {
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .post("/api/v1/chat/sessions/1/sse-test-success")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @DisplayName("첫 이벤트 전송 전에 스트림이 실패해도 인증은 유지되어 가짜 401을 반환하지 않는다")
+    void errorBeforeFirstSend_doesNotReturnSpurious401() {
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .post("/api/v1/chat/sessions/1/sse-test-error-before-send")
+                .then()
+                .statusCode(not(401));
+    }
+
+    @TestConfiguration
+    @RestController
+    @RequestMapping("/api/v1/chat/sessions")
+    static class TestSseController {
+
+        private final Executor chatStreamExecutor;
+
+        TestSseController(@Qualifier("chatStreamExecutor") final Executor chatStreamExecutor) {
+            this.chatStreamExecutor = chatStreamExecutor;
+        }
+
+        @PostMapping("/{id}/sse-test-success")
+        public SseEmitter sseSuccess(
+                @AuthenticationPrincipal final Long userId,
+                @PathVariable final Long id) {
+            final SseEmitter emitter = new SseEmitter();
+            chatStreamExecutor.execute(() -> {
+                try {
+                    emitter.send(SseEmitter.event().data("hello userId=" + userId));
+                    emitter.complete();
+                } catch (final Exception e) {
+                    emitter.completeWithError(e);
+                }
+            });
+            return emitter;
+        }
+
+        @PostMapping("/{id}/sse-test-error-before-send")
+        public SseEmitter sseErrorBeforeSend(
+                @AuthenticationPrincipal final Long userId,
+                @PathVariable final Long id) {
+            final SseEmitter emitter = new SseEmitter();
+            chatStreamExecutor.execute(() -> emitter.completeWithError(new RuntimeException(
+                    "stream failed before first event")));
+            return emitter;
+        }
+    }
+}


### PR DESCRIPTION
## AS-IS
유효한 JWT(로그인/refresh 무관)로도 채팅 SSE 엔드포인트(`/chat/sessions/{id}/messages`, `voice-messages` 등)만 `401 AUTH_001`이 발생. 동일 토큰으로 일반 REST(`/users/me` 등)는 정상 200. 프론트의 refresh→retry로도 매번 새 토큰이 모두 401.

## TO-BE
첫 이벤트 전송 전에 스트림이 실패해도 인증 컨텍스트가 유지되어, 가짜 401 대신 실제 처리 결과(정상 또는 실제 에러)가 반환된다.

## 원인 (재현으로 확정)
- 필터 체인은 단일. `JwtAuthenticationFilter`는 엔드포인트 구분 없이 토큰만 검증 → 첫(REQUEST) 디스패치는 REST/채팅 동일 통과.
- 채팅은 `SseEmitter` 비동기. **첫 이벤트 전송 전 스트림 실패**(`completeWithError`) 시 Spring MVC가 ASYNC/ERROR 디스패치를 한 번 더 수행.
- `JwtAuthenticationFilter`(`OncePerRequestFilter`)는 ASYNC/ERROR 디스패치를 기본 스킵하지만 Spring Security 6의 `AuthorizationFilter`는 모든 디스패치 타입에서 동작 → SecurityContext가 비어 익명 거부 → `RestAuthenticationEntryPoint` → 401.
- REST는 재디스패치가 없어 무관 → '같은 토큰, REST 200, 채팅 401, 토큰 무관' 증상 일치.

## 변경
- `JwtAuthenticationFilter`: `shouldNotFilterAsyncDispatch()`/`shouldNotFilterErrorDispatch()` → `false` 오버라이드 (ASYNC/ERROR 디스패치에서도 토큰 재검증·컨텍스트 복원).
- `SseAsyncDispatchAuthTest` 추가: 실제 SecurityConfig/필터/EntryPoint/executor 빈을 그대로 태워 (1) 정상 송신→200, (2) 첫 send 전 실패→401 아님 검증.

## 검증
- 재현: 수정 전 '첫 send 전 실패' → `401 AUTH_001`, 수정 후 → `500`(실제 에러 노출).
- `./gradlew checkstyleMain spotlessCheck test` 통과.

## ⚠️ 후속 (별개 이슈)
이 PR은 **가짜 401 제거**가 목적. 채팅 스트림이 prod에서 첫 토큰 전에 실패하는 **근본 원인**(OpenAI 호출/툴/저장 실패 등)은 별개이며, 본 수정 배포 후 실제 500+예외가 prod 로그에 드러나면 그때 추적.

## AI 체크리스트
- [x] type/scope 라벨 부여
- [x] 신규 엔드포인트 없음 → API 명세(Notion) 변경 불필요
- [x] 엔티티/도메인 모델 변경 없음
- [x] 보안 인증 필터 변경 → `needs-human-review`

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 스트림 전송(예: 실시간 업데이트) 중 발생하는 인증 오류 노출 문제 개선
  * 비정상 스트림 종료 시 부적절한 인증 오류 응답 방지

* **Tests**
  * 스트림 환경에서 인증 컨텍스트 유지 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->