### PR TITLE
fix(medication): COUNT_MISMATCH 시 복약 완료 오확정 방지

### DIFF
--- a/docs/features/medication-log-phase2.md
+++ b/docs/features/medication-log-phase2.md
@@ -101,23 +101,32 @@ public enum LogAiStatus {
 ```text
 [PUT /api/v1/medication-logs]
   ├─ status != TAKEN || photoObjectKey == null → AI 검증 스킵, ai_status=null
+  │    (status != TAKEN이면 takenAt=null로 저장 — status 무관 takenAt 세팅 금지, issue #462)
   └─ photoObjectKey 있음 + status == TAKEN
        ↓
        1. NCP S3에서 사진 fetch (byte[])
        2. 동일 (seniorId, targetDate, mealSlot) 의 모든 active schedule 조회
-       3. 각 schedule.dosage를 DosageParser.parsePillCount() 적용 → 정수 합산
-          ├─ 하나라도 파싱 실패 → ai_status = COUNT_UNKNOWN, Vision 호출 스킵
+       3. 각 schedule.dosage를 정수 합산
+          ├─ 하나라도 파싱 실패 / 스케줄 없음 → ai_status = COUNT_UNKNOWN, Vision 호출 스킵
           └─ 모두 성공 → expectedCount 산출 → 다음 단계
        4. OpenAiClient.countPills(imageBytes) → Optional<Integer>
           ├─ empty (Vision 실패) → ai_status = COUNT_FAILED
-          └─ present → 비교
-              ├─ actualCount == expectedCount → COUNT_MATCH
-              └─ != → COUNT_MISMATCH
-       5. medication_log.ai_status 갱신 후 저장
+          └─ present → actualCount == expectedCount ? COUNT_MATCH : COUNT_MISMATCH
+       ※ 1~4 검증은 DB 저장 "전"에 수행한다 (issue #462). 저장 후 검증하면
+         COUNT_MISMATCH여도 takenAt을 되돌릴 수 없어 복약 완료로 오확정된다.
+       5. 검증 결과에 따라 저장:
+          ├─ COUNT_MISMATCH → 복약 완료로 확정하지 않음:
+          │    takenAt=null, status=PENDING(요청이 TAKEN이어도 강등), ai_status=COUNT_MISMATCH 저장.
+          │    잔여분 차감 / 포인트 이벤트 / 알림 완료(markReminderTaken) / 슬롯 전파 모두 skip.
+          │    FE는 ai_status로 "약 개수 불일치 → 재인증 필요" 안내.
+          └─ COUNT_MATCH / COUNT_FAILED / COUNT_UNKNOWN → 복약 완료로 인정:
+               takenAt 세팅, status=TAKEN, ai_status 저장.
+               (검증 불가한 FAILED·UNKNOWN은 사용자 책임이 아니므로 관대 처리)
        6. ai_status == COUNT_MATCH → 슬롯의 다른 active schedule들도 TAKEN 전파 (issue #343)
           - 각 peer schedule에 medication_log upsert (이미 TAKEN이면 skip, 멱등)
           - 새로 TAKEN 전환되는 peer의 medicine.remainingAmount 차감
           - peer log의 ai_status = COUNT_MATCH (슬롯 전체가 검증된 상태이므로)
+          - COUNT_FAILED·COUNT_UNKNOWN은 검증되지 않았으므로 전파하지 않음
        7. 응답 200 + aiStatus 포함 (PUT 응답 시간: 평소 + 5~10s)
 ```
 

--- a/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
+++ b/src/main/java/com/ppiyaki/medication/service/MedicationLogService.java
@@ -115,7 +115,26 @@ public class MedicationLogService {
             validatePhotoObjectKey(request.photoObjectKey(), userId);
         }
 
-        final LocalDateTime takenAt = request.takenAt() != null ? request.takenAt() : LocalDateTime.now();
+        final boolean photoProvided = request.photoObjectKey() != null && !request.photoObjectKey().isBlank();
+
+        // 사진 + status=TAKEN이면 DB 저장 전에 약 개수 AI 검증 (issue #462).
+        // 저장 후 검증하면 COUNT_MISMATCH여도 takenAt을 되돌릴 수 없어 복약 완료로 오확정된다.
+        LogPillCountStatus pillCountStatus = null;
+        if (request.status() == LogStatus.TAKEN && photoProvided) {
+            pillCountStatus = verifyPillCount(seniorId, schedule, request);
+            meterRegistry.counter("ppiyaki.medication.pill_count.total",
+                    "result", pillCountStatus.name()).increment();
+        }
+
+        // COUNT_MISMATCH면 복약 완료로 확정하지 않는다: takenAt 미설정 + status는 PENDING으로 강등.
+        // 그 외(COUNT_MATCH / 사진 없는 수동 인증 / 검증 불가 COUNT_FAILED·COUNT_UNKNOWN)는 인증으로 인정.
+        final boolean confirmedTaken = request.status() == LogStatus.TAKEN
+                && pillCountStatus != LogPillCountStatus.COUNT_MISMATCH;
+        final LogStatus effectiveStatus = request.status() == LogStatus.TAKEN && !confirmedTaken
+                ? LogStatus.PENDING : request.status();
+        final LocalDateTime takenAt = confirmedTaken
+                ? (request.takenAt() != null ? request.takenAt() : LocalDateTime.now())
+                : null;
 
         final Optional<MedicationLog> existing = medicationLogRepository
                 .findByScheduleIdAndTargetDate(request.scheduleId(), request.targetDate());
@@ -125,12 +144,12 @@ public class MedicationLogService {
         try {
             log = existing
                     .map(found -> {
-                        found.updateRecord(takenAt, request.status(), request.photoObjectKey(), isProxy, userId);
+                        found.updateRecord(takenAt, effectiveStatus, request.photoObjectKey(), isProxy, userId);
                         return found;
                     })
                     .orElseGet(() -> medicationLogRepository.saveAndFlush(new MedicationLog(
                             seniorId, request.scheduleId(), request.targetDate(),
-                            takenAt, request.status(), request.photoObjectKey(), isProxy, userId)));
+                            takenAt, effectiveStatus, request.photoObjectKey(), isProxy, userId)));
         } catch (final DataIntegrityViolationException e) {
             // 동시 INSERT 경합 발생: UNIQUE(schedule_id, target_date)에 의해 두 번째가 충돌.
             // 현재 트랜잭션은 rollback-only 상태이므로 같은 트랜잭션 내 재조회 불가.
@@ -139,10 +158,14 @@ public class MedicationLogService {
                     "Concurrent upsert conflict on (scheduleId, targetDate); please retry");
         }
 
-        // 새로 TAKEN으로 전환되는 케이스에만 잔여분 차감 (멱등성: 이미 TAKEN이던 row 재호출 시 중복 차감 방지).
+        if (pillCountStatus != null) {
+            log.updatePillCountStatus(pillCountStatus);
+        }
+
+        // 새로 TAKEN으로 확정되는 케이스에만 잔여분 차감 (멱등성: 이미 TAKEN이던 row 재호출 시 중복 차감 방지).
         // 차감 단위 = schedule.dosageQuantity (BigDecimal). null이면 차감 skip
         // (옛 schedule이거나 PRN 같은 정의 안 된 케이스. spec dosage-quantity-unit-split.md Q7 결정).
-        if (request.status() == LogStatus.TAKEN && previousStatus != LogStatus.TAKEN) {
+        if (confirmedTaken && previousStatus != LogStatus.TAKEN) {
             final BigDecimal dosageQuantity = schedule.getDosageQuantity();
             if (dosageQuantity != null) {
                 final int dosageCount = dosageQuantity.setScale(0, java.math.RoundingMode.CEILING).intValueExact();
@@ -152,8 +175,8 @@ public class MedicationLogService {
             }
         }
 
-        // 복약 성공 처리
-        if (request.status() == LogStatus.TAKEN) {
+        // 복약 성공 처리: 인증으로 확정된 경우에만 (COUNT_MISMATCH는 제외)
+        if (confirmedTaken) {
             // 이벤트는 처음 TAKEN 전환 시에만 발행 (중복 포인트/뱃지 방지)
             if (previousStatus != LogStatus.TAKEN) {
                 eventPublisher.publishEvent(new MedicationTakenEvent(seniorId, request.targetDate()));
@@ -162,22 +185,10 @@ public class MedicationLogService {
             // 시니어 본인 인증/보호자 대리 인증 모두 시니어의 알림이 대상 (userId=seniorId).
             notificationRepository.markReminderTaken(
                     seniorId, request.targetDate(), schedule.getMealSlot().name(), takenAt);
-        }
 
-        // Phase 2: 사진 + status=TAKEN일 때 약 개수 AI 검증 (spec medication-log-phase2 §5-4)
-        if (request.status() == LogStatus.TAKEN) {
-            if (request.photoObjectKey() != null && !request.photoObjectKey().isBlank()) {
-                final LogPillCountStatus pillCountStatus = verifyPillCount(seniorId, schedule, request);
-                log.updatePillCountStatus(pillCountStatus);
-                meterRegistry.counter("ppiyaki.medication.pill_count.total",
-                        "result", pillCountStatus.name()).increment();
-                // COUNT_MATCH일 때 슬롯의 다른 active schedule도 TAKEN 전파 (issue #343).
-                // 시니어가 슬롯 전체 약을 사진 한 장에 담아 인증한 경우 == 슬롯 전체 인증으로 인정.
-                if (pillCountStatus == LogPillCountStatus.COUNT_MATCH) {
-                    propagateTakenToSlotSchedules(seniorId, schedule, request, takenAt, isProxy, userId);
-                }
-            } else {
-                // 사진 없이 매뉴얼 인증한 경우에도 슬롯 전체 인증으로 인정하여 전파
+            // 슬롯 전체 전파: 사진 한 장에 슬롯 전체 약을 담아 인증한 COUNT_MATCH, 또는 사진 없는 수동 인증일 때만.
+            // (issue #343) COUNT_FAILED·COUNT_UNKNOWN은 검증되지 않았으므로 전파하지 않는다.
+            if (!photoProvided || pillCountStatus == LogPillCountStatus.COUNT_MATCH) {
                 propagateTakenToSlotSchedules(seniorId, schedule, request, takenAt, isProxy, userId);
             }
         }

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServicePhase2Test.java
@@ -291,6 +291,67 @@ class MedicationLogServicePhase2Test {
         verify(openAiClient).countPills(any(), eq("image/png"));
     }
 
+    @Test
+    @DisplayName("COUNT_MISMATCH면 복약 미확정: status=PENDING, takenAt=null, 잔여분·알림 완료 처리 안 함 (issue #462)")
+    void count_mismatch_not_confirmed() throws Exception {
+        final MedicationSchedule schedule = buildSchedule(SCHEDULE_ID, "1정");
+        when(medicationScheduleRepository.findById(SCHEDULE_ID)).thenReturn(Optional.of(schedule));
+        final Medicine medicine = new Medicine(SENIOR_ID, null, "테스트약", 30, 30, "ITEM-1", null);
+        setField(medicine, "id", MEDICINE_ID);
+        when(medicineRepository.findById(MEDICINE_ID)).thenReturn(Optional.of(medicine));
+        givenAutonomousSenior();
+        givenUpsertSucceeds();
+        givenSiblingSchedules(List.of(buildSchedule(SCHEDULE_ID, "1정"), buildSchedule(2L, "1정")));
+        givenS3Returns(new byte[]{1});
+        when(openAiClient.countPills(any(), any())).thenReturn(Optional.of(1));
+
+        final var saved = captureSavedLog();
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        final MedicationLog log = saved.get();
+        assertThat(log.getStatus()).isEqualTo(LogStatus.PENDING);
+        assertThat(log.getTakenAt()).isNull();
+        assertThat(log.getPillCountStatus()).isEqualTo(LogPillCountStatus.COUNT_MISMATCH);
+        assertThat(medicine.getRemainingAmount()).isEqualTo(30);
+        verify(notificationRepository, never()).markReminderTaken(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("COUNT_FAILED(검증 불가)면 관대 처리: status=TAKEN, takenAt 세팅")
+    void count_failed_lenient_confirm() throws Exception {
+        givenScheduleAndMedicine();
+        givenUpsertSucceeds();
+        givenSiblingSchedules(List.of(buildSchedule(SCHEDULE_ID, "1정")));
+        givenS3Returns(new byte[]{1});
+        when(openAiClient.countPills(any(), any())).thenReturn(Optional.empty());
+
+        final var saved = captureSavedLog();
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.TAKEN, VALID_OBJECT_KEY));
+
+        final MedicationLog log = saved.get();
+        assertThat(log.getStatus()).isEqualTo(LogStatus.TAKEN);
+        assertThat(log.getTakenAt()).isNotNull();
+        assertThat(log.getPillCountStatus()).isEqualTo(LogPillCountStatus.COUNT_FAILED);
+    }
+
+    @Test
+    @DisplayName("status=PENDING 요청이면 takenAt=null로 저장 (status 무관 takenAt 세팅 버그 수정)")
+    void pending_request_clears_taken_at() throws Exception {
+        givenScheduleAndMedicine();
+        givenUpsertSucceeds();
+
+        final var saved = captureSavedLog();
+        service.upsert(SENIOR_ID, new MedicationLogUpsertRequest(
+                SCHEDULE_ID, TARGET_DATE, null, LogStatus.PENDING, null));
+
+        final MedicationLog log = saved.get();
+        assertThat(log.getStatus()).isEqualTo(LogStatus.PENDING);
+        assertThat(log.getTakenAt()).isNull();
+        verify(openAiClient, never()).countPills(any(), any());
+    }
+
     // --- fixtures -----------------------------------------------------------
 
     private void givenScheduleAndMedicine() throws Exception {

--- a/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
+++ b/src/test/java/com/ppiyaki/medication/service/MedicationLogServiceTest.java
@@ -169,7 +169,8 @@ class MedicationLogServiceTest {
         // then
         verify(medicationLogRepository, never()).saveAndFlush(any()); // update via dirty checking
         assertThat(existing.getStatus()).isEqualTo(LogStatus.MISSED);
-        assertThat(existing.getTakenAt()).isEqualTo(LocalDateTime.of(2026, 4, 18, 10, 0));
+        // status != TAKEN이면 요청에 takenAt이 있어도 null로 정리한다 (issue #462: status 무관 takenAt 세팅 금지)
+        assertThat(existing.getTakenAt()).isNull();
         verify(eventPublisher, never()).publishEvent(any(MedicationTakenEvent.class));
     }
 

--- a/src/test/java/com/ppiyaki/notification/controller/MedicationCompleteNotificationE2ETest.java
+++ b/src/test/java/com/ppiyaki/notification/controller/MedicationCompleteNotificationE2ETest.java
@@ -92,8 +92,10 @@ class MedicationCompleteNotificationE2ETest {
     }
 
     @Test
-    @DisplayName("끼니에 schedule이 2개인데 1개만 인증되면 완료 알림이 발송되지 않는다")
-    void slotPartiallyTaken_noNotification() {
+    @DisplayName("끼니에 schedule이 2개여도 (약별이 아닌 끼니 단위 인증) 사진 없는 인증 1건으로 슬롯 전체가 완료되어 알림이 발송된다")
+    void slotSingleManualAuth_completesWholeSlot() {
+        // 약별로 인증 사진을 따로 찍지 않고 끼니 단위로 인증하는 구조이므로, 사진 없는 수동 인증 1건은
+        // 같은 끼니의 다른 schedule들로 TAKEN이 전파된다 (b6fd662). 따라서 끼니 전체가 완료 처리된다.
         final Long seniorId = seedSenior();
         final Long caregiverId = seedCaregiver();
         seedRelation(seniorId, caregiverId);
@@ -103,11 +105,13 @@ class MedicationCompleteNotificationE2ETest {
         seedSchedule(medicineId, MealSlot.BREAKFAST);
         final LocalDate today = LocalDate.now();
 
-        // when — BREAKFAST 2정 중 1정만 인증
+        // when — BREAKFAST 2개 schedule 중 1건만 (사진 없이) 인증
         certifyTaken(seniorToken, scheduleA, today);
 
-        // then — 아침 끼니가 아직 완료되지 않았으므로 알림 없음
-        Assertions.assertThat(findCompleteNotifications(caregiverId)).isEmpty();
+        // then — 끼니 전체로 전파되어 완료 알림 1건 발송
+        Assertions.assertThat(findCompleteNotifications(caregiverId))
+                .extracting(Notification::getMealSlot)
+                .containsExactly(MealSlot.BREAKFAST.name());
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
Closes #462

## AS-IS
- 복약 사진 인증에서 Vision 결과가 `COUNT_MISMATCH`(약 개수 불일치)인데도, `MedicationLogService.upsert()`가 **검증보다 먼저** `takenAt`+`status=TAKEN`을 DB에 저장 → 뒤로가기로 나가도 복약 완료로 오확정됨.
- 알림(`markReminderTaken`)의 `takenAt`도 세팅됨.
- `status` 무관하게 `takenAt=now()`를 채워, PENDING/MISSED 갱신 시에도 `takenAt`이 안 지워짐.

## TO-BE
약 개수 검증을 **DB 저장 전**으로 옮기고 결과별로 분기:
| 결과 | takenAt | status | 잔여차감·이벤트·알림완료·슬롯전파 |
|---|---|---|---|
| COUNT_MATCH | 세팅 | TAKEN | 수행 |
| **COUNT_MISMATCH** | **null** | **PENDING 강등** | **모두 skip** (pillCountStatus만 저장) |
| COUNT_FAILED·UNKNOWN(검증 불가) | 세팅 | TAKEN | 수행(전파 제외) |
| 사진 없는 수동 인증 | 세팅 | TAKEN | 수행 |
- `status != TAKEN`이면 `takenAt=null`로 정리.

## 변경
- `MedicationLogService.upsert()` 리팩터링 (검증 선행 + 결과별 분기)
- `MedicationLogServicePhase2Test` 신규 3건(MISMATCH 미확정 / FAILED 관대 / PENDING takenAt 정리), `멱등_업서트` 단언 갱신
- `docs/features/medication-log-phase2.md §5-4` 데이터 흐름 갱신

## ⚠️ 함께 수정 (사전 존재 develop redness)
- `b6fd662`(6/9, 무사진 수동 인증 시 끼니 peer로 TAKEN 전파)가 6/4 추가된 `MedicationCompleteNotificationE2ETest.slotPartiallyTaken_noNotification`을 깨뜨려 **develop이 6/9부터 빨간 상태**였음.
- 약별이 아닌 **끼니 단위 인증** 구조상 전파는 의도된 동작 → 해당 E2E를 새 동작(끼니 전체 완료 알림 발송)에 맞게 갱신해 게이트 green 복구.

## 검증
- `./gradlew checkstyleMain spotlessCheck test` ✅ (398+ tests, 실패 0)

## AI 체크리스트
- [x] AI 보조 작성 (`ai-generated`)
- [x] 엔드포인트 시그니처 불변 → Notion API 명세 변경 없음 (동작만 변경)
- [x] 엔티티 변경 없음 → 도메인 문서/ERD 변경 없음
- [x] 보호 영역(워크플로/마이그레이션/yml/gradle) 변경 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 복약 인증 시 AI 기반 약 개수 검증 기능 추가
  * 검증 결과(불일치/성공/실패)에 따른 차등 복약 확정 처리 로직 구현

* **Bug Fixes**
  * 미확정 복약 상태의 타임스탬프 저장 오류 수정
  * 수동 인증 요청 시 불필요한 AI 검증 호출 제거

* **Tests**
  * AI 검증 결과별 복약 확정 처리 검증 케이스 추가
  * 슬롯 단위 완료 조건 및 알림 발송 로직 검증 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->